### PR TITLE
feat: 관담 세부 조회에 에타 링크 추가

### DIFF
--- a/src/main/java/kr/allcll/seatfinder/basket/BasketService.java
+++ b/src/main/java/kr/allcll/seatfinder/basket/BasketService.java
@@ -57,7 +57,7 @@ public class BasketService {
         Subject subject = subjectRepository.findById(subjectId)
             .orElseThrow(() -> new AllcllException(AllcllErrorCode.SUBJECT_NOT_FOUND));
         List<Basket> baskets = getBaskets(subject);
-        return SubjectBasketsResponse.from(baskets);
+        return SubjectBasketsResponse.from(subject.getEverytimeLectureId(), baskets);
     }
 
     private List<Basket> getBaskets(Subject subject) {

--- a/src/main/java/kr/allcll/seatfinder/basket/dto/SubjectBasketsResponse.java
+++ b/src/main/java/kr/allcll/seatfinder/basket/dto/SubjectBasketsResponse.java
@@ -4,11 +4,12 @@ import java.util.List;
 import kr.allcll.seatfinder.basket.Basket;
 
 public record SubjectBasketsResponse(
+    Long everytimeLectureId,
     List<EachDepartmentBasket> eachDepartmentRegisters
 ) {
 
-    public static SubjectBasketsResponse from(List<Basket> baskets) {
+    public static SubjectBasketsResponse from(Long everytimeLectureId, List<Basket> baskets) {
         List<EachDepartmentBasket> result = EachDepartmentBasket.from(baskets);
-        return new SubjectBasketsResponse(result);
+        return new SubjectBasketsResponse(everytimeLectureId, result);
     }
 }

--- a/src/main/java/kr/allcll/seatfinder/subject/Subject.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/Subject.java
@@ -24,6 +24,10 @@ public class Subject extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "everytime_lecture_id")
+    private Long everytimeLectureId; // 에브리타임 강의 ID
+
     @Column(name = "smt_cd")
     private String smtCd; // 학기 코드
 
@@ -123,10 +127,6 @@ public class Subject extends BaseEntity {
     @Column(name = "prt_ord")
     private String prtOrd; // 정렬 순서
 
-    public boolean isNonMajor() {
-        return NON_MAJOR_DEPARTMENT_NAME.equals(manageDeptNm);
-    }
-
     public Subject(String smtCd, String smtCdNm, String year, String yearSmtNm, String curiNo, String curiNm,
         String curiTypeCd, String curiTypeCdNm, String cdt, String tmNum, String totTmNum, String studentYear,
         String lesnTime, String lesnRoom, String lesnEmp, String corsUnitGrpCd, String corsUnitGrpCdNm,
@@ -169,5 +169,9 @@ public class Subject extends BaseEntity {
         this.sltDomainCdNm = sltDomainCdNm;
         this.remark = remark;
         this.prtOrd = prtOrd;
+    }
+
+    public boolean isNonMajor() {
+        return NON_MAJOR_DEPARTMENT_NAME.equals(manageDeptNm);
     }
 }

--- a/src/test/java/kr/allcll/seatfinder/basket/BasketApiTest.java
+++ b/src/test/java/kr/allcll/seatfinder/basket/BasketApiTest.java
@@ -68,6 +68,7 @@ public class BasketApiTest {
         // given
         String expected = """
             {
+                "everytimeLectureId": 2864827,
                 "eachDepartmentRegisters": [
                     {
                         "studentBelong": "본교생",
@@ -80,9 +81,11 @@ public class BasketApiTest {
 
         // when
         when(basketService.getEachSubjectBaskets(1L)).thenReturn(
-            new SubjectBasketsResponse(List.of(
-                new EachDepartmentBasket("본교생", "컴퓨터공학과", 10)
-            ))
+            new SubjectBasketsResponse(
+                2864827L,
+                List.of(
+                    new EachDepartmentBasket("본교생", "컴퓨터공학과", 10)
+                ))
         );
         MvcResult result = mockMvc.perform(get("/api/baskets/1")).andExpect(status().isOk()).andReturn();
 
@@ -96,12 +99,17 @@ public class BasketApiTest {
         // given
         String expected = """
             {
+                "everytimeLectureId": 5412311,
                 "eachDepartmentRegisters": []
             }
             """;
 
         // when
-        when(basketService.getEachSubjectBaskets(1L)).thenReturn(new SubjectBasketsResponse(List.of()));
+        when(basketService.getEachSubjectBaskets(1L)).thenReturn(
+            new SubjectBasketsResponse(
+                5412311L,
+                List.of())
+        );
         MvcResult result = mockMvc.perform(get("/api/baskets/1")).andExpect(status().isOk()).andReturn();
 
         // then

--- a/src/test/java/kr/allcll/seatfinder/basket/BasketServiceTest.java
+++ b/src/test/java/kr/allcll/seatfinder/basket/BasketServiceTest.java
@@ -298,7 +298,7 @@ class BasketServiceTest {
 
     @Test
     @DisplayName("각 과목에 대한 관심과목 조회를 확인한다.")
-    public void getEachSubjectBasketsTest() {
+    void getEachSubjectBasketsTest() {
         // given
         Subject subjectA = createSubjectWithDepartmentCode("컴공 과목A", "001234", "001", "김보예", "3210");
         subjectRepository.save(subjectA);
@@ -326,7 +326,7 @@ class BasketServiceTest {
 
     @Test
     @DisplayName("각 과목에 대한 관심과목 조회의 응답값을 확인한다.")
-    public void getEachSubjectBasketResponse() {
+    void getEachSubjectBasketResponse() {
         // given
         Subject subjectA = createSubjectWithDepartmentCode("컴공 과목A", "001234", "001", "김보예", "3210");
         subjectRepository.save(subjectA);
@@ -349,7 +349,7 @@ class BasketServiceTest {
 
     @Test
     @DisplayName("과목에 대한 관심과목 담기한 인원이 없을 때는 빈 응답을 반환한다.")
-    public void emptyBasketResponse() {
+    void emptyBasketResponse() {
         // given
         Subject subjectA = createSubjectWithDepartmentCode("컴공 과목A", "001234", "001", "김보예", "3210");
         subjectRepository.save(subjectA);
@@ -365,7 +365,7 @@ class BasketServiceTest {
 
     @Test
     @DisplayName("관심과목 인원이 0명 일 때의 동작을 확인한다.")
-    public void emptyBasket() {
+    void emptyBasket() {
         // given
         Subject subjectA = createSubjectWithDepartmentCode("컴공 과목A", "001234", "001", "김보예", "3210");
         subjectRepository.save(subjectA);
@@ -380,7 +380,7 @@ class BasketServiceTest {
 
     @Test
     @DisplayName("관심과목 인원이 0명 일 때 과목 조회를 확인한다.")
-    public void emptyBasketSubject() {
+    void emptyBasketSubject() {
         // given
         Subject subjectA = createSubjectWithDepartmentCode("컴공 과목A", "001234", "001", "김보예", "3210");
         subjectRepository.save(subjectA);

--- a/src/test/java/kr/allcll/seatfinder/basket/BasketServiceTest.java
+++ b/src/test/java/kr/allcll/seatfinder/basket/BasketServiceTest.java
@@ -3,6 +3,7 @@ package kr.allcll.seatfinder.basket;
 import static kr.allcll.seatfinder.support.fixture.BasketFixture.createEmptyBasket;
 import static kr.allcll.seatfinder.support.fixture.SubjectFixture.createSubjectWithDepartmentCode;
 import static kr.allcll.seatfinder.support.fixture.SubjectFixture.createSubjectWithDepartmentInformation;
+import static kr.allcll.seatfinder.support.fixture.SubjectFixture.createSubjectWithEverytimeLectureId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -390,6 +391,22 @@ class BasketServiceTest {
 
         // then
         assertThat(eachSubjectBaskets.eachDepartmentRegisters().isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("관심과목 세부 조회에 에브리타임 강의 아이디를 확인한다.")
+    void everytimeLectureIdTest() {
+        // given
+        long everytimeLectureId = 1234567L;
+        Subject subjectA = createSubjectWithEverytimeLectureId(everytimeLectureId, "컴공 과목A", "001234", "001", "김보예",
+            "3210");
+        subjectRepository.save(subjectA);
+
+        // when
+        SubjectBasketsResponse eachSubjectBaskets = basketService.getEachSubjectBaskets(subjectA.getId());
+
+        // then
+        assertThat(eachSubjectBaskets.everytimeLectureId()).isEqualTo(1234567L);
     }
 
     private void saveSubjectsAndBaskets() {

--- a/src/test/java/kr/allcll/seatfinder/support/fixture/SubjectFixture.java
+++ b/src/test/java/kr/allcll/seatfinder/support/fixture/SubjectFixture.java
@@ -59,7 +59,7 @@ public class SubjectFixture {
         String classCode,
         String professorName
     ) {
-        return new Subject(subjectId,
+        return new Subject(subjectId, 0L,
             "", "", "", "",
             subjectCode, subjectName, "", "", "", "", "", "",
             "", "",
@@ -77,7 +77,7 @@ public class SubjectFixture {
         String classCode,
         String professorName
     ) {
-        return new Subject(subjectId,
+        return new Subject(subjectId, 0L,
             "", "", "", "",
             subjectCode, subjectName, "", "", "", "", "", "",
             "", "",
@@ -86,8 +86,5 @@ public class SubjectFixture {
             "컴퓨터공학과", classCode, "", "", "",
             "", "", "", "", "",
             "", "");
-//        return new Subject(subjectId, "소프트웨어융합대학", "컴퓨터공학과", subjectCode, classCode, subjectName, "", "", "", "", "",
-//            "", "", "", "",
-//            "", professorName, "", "", "", "", "", "", "", "3210");
     }
 }

--- a/src/test/java/kr/allcll/seatfinder/support/fixture/SubjectFixture.java
+++ b/src/test/java/kr/allcll/seatfinder/support/fixture/SubjectFixture.java
@@ -35,6 +35,23 @@ public class SubjectFixture {
             "", "", "", "", "");
     }
 
+    public static Subject createSubjectWithEverytimeLectureId(
+        Long everytimeLectureId,
+        String subjectName,
+        String subjectCode,
+        String classCode,
+        String professorName,
+        String departmentCode
+    ) {
+        return new Subject(null, everytimeLectureId, "", "", "", "",
+            subjectCode, subjectName,
+            "", "", "", "", "", "", "", "",
+            professorName, "", "", "", "", departmentCode,
+            "", "",
+            classCode, "", "", "", "", "",
+            "", "", "", "", "");
+    }
+
     public static Subject createSubjectWithDepartmentInformation(
         String subjectName, //과목명
         String departmentName, //개설학과


### PR DESCRIPTION
## 작업 내용

관담 세부 조회에 에타 링크 추가하는 작업을 했어요. 

### 변경된 API 명세 

- 작업한 URL: /api/baskets/{subjectId}
- 변경된 응답: 
```json
{
	"everytimeLectureId": 1234567,
	"eachDepartmentRegisters": [
		{
			"studentBelong": "본교생",
			"registerDepartment":"컴퓨터공학과",
			"eachCount": 10
		},
		{
			"studentBelong": "본교생",
			"registerDepartment":"전자정보통신공학과",
			"eachCount": 4
		}
	]
}
```

### 구현 방법

- Subject 테이블에 everytime_lecture_id 컬럼을 추가했어요. 
- 크롤링한 데이터를 prod 데이터베이스에 반영했어요. 
- Subject Entity에 everytimeLectureId 컬럼을 추가했어요. 
- Basket을 조회할 때 subject도 함께 조회하게 되는데, subject에서 에타 LectureId를 찾아서 Basket 응답에 넣어줬어요. 
- 클라이언트는 응답으로 온 LectureId 앞에 도메인을 붙여서 링크를 걸면 돼요. `https://everytime.kr/lecture/view/` + `1234567`

## 고민 지점과 리뷰 포인트

- 현재는 도메인과 엔티티 사이의 경계가 애매한데요, Subject 도메인에 에타 링크가 들어가는 게 굉장히 어색해요. 과목은 그 자체로 순수하게 보존되어야 하는데, 외부 서비스의 정책이 들어온 거니깐요. 기한이 급하기 때문에 일단은 Subject 도메인에 넣었는데, 추후 개선이 필요할 것 같아요. 