### PR TITLE
chore: 모니터링 환경 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,7 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create-drop
+    open-in-view: false
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,3 +34,9 @@ logging:
 app:
   scheduling:
     enabled: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, health


### PR DESCRIPTION
## 작업 내용

모니터링 환경을 구축했어요. 어떤 툴을 사용할지 고민했고, 우선순위는 비용(돈)과 비용(시간)이에요. 
가장 빨리 할 수 있는 것은 많이 다뤄본 프로메테우스, 그라파나 조합이에요. 
돈이 덜 드는 것은 AWS CloudWatch를 사용하는 것이에요. 
저는 전자를 택했는데, 이유는 프로메테우스, 그라파나를 띄울 서버 용량이 남기 때문이에요. 
가장 빨리 작업할 수 있는 방법을 택했어요. 

해당 PR에는 actuator와 Prometheus 설정만을 담고 있어요. 바로 머지해도 될 것 같아요. 