### PR TITLE
refactor: 에러 핸들링 개선

### DIFF
--- a/src/main/java/kr/allcll/seatfinder/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/seatfinder/exception/AllcllErrorCode.java
@@ -2,14 +2,18 @@ package kr.allcll.seatfinder.exception;
 
 public enum AllcllErrorCode {
 
+    SUBJECT_NOT_FOUND("존재하지 않는 과목 입니다."),
+
     PIN_LIMIT_EXCEEDED("이미 %d개의 핀을 등록했습니다."),
-    STAR_LIMIT_EXCEEDED("이미 %d개의 즐겨찾기를 등록했습니다."),
     DUPLICATE_PIN("%s은(는) 이미 핀 등록된 과목입니다."),
-    DUPLICATE_STAR("%s은(는) 이미 핀 등록된 과목입니다."),
     PIN_SUBJECT_MISMATCH("핀에 등록된 과목이 아닙니다."),
+
+    STAR_LIMIT_EXCEEDED("이미 %d개의 즐겨찾기를 등록했습니다."),
+    DUPLICATE_STAR("%s은(는) 이미 핀 등록된 과목입니다."),
     STAR_SUBJECT_MISMATCH("즐겨찾기에 등록된 과목이 아닙니다."),
+
     TOKEN_NOT_FOUND("쿠키에 토큰이 존재하지 않습니다."),
-    SUBJECT_NOT_FOUND("존재하지 않는 과목 입니다.");
+    ;
 
     private String message;
 

--- a/src/main/java/kr/allcll/seatfinder/exception/AllcllException.java
+++ b/src/main/java/kr/allcll/seatfinder/exception/AllcllException.java
@@ -7,16 +7,6 @@ public class AllcllException extends RuntimeException {
 
     private final String errorCode;
 
-    public AllcllException(AllcllErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode.name();
-    }
-
-    public AllcllException(String message, Throwable cause, AllcllErrorCode errorCode) {
-        super(message, cause);
-        this.errorCode = errorCode.name();
-    }
-
     public AllcllException(AllcllErrorCode errorCode, Object... args) {
         super(String.format(errorCode.getMessage(), args));
         this.errorCode = errorCode.name();

--- a/src/main/java/kr/allcll/seatfinder/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/allcll/seatfinder/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package kr.allcll.seatfinder.exception;
 
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -32,8 +33,14 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handleServletException(HttpServletRequest request, ServletException e) {
+        log.warn(LOG_FORMAT, request.getMethod(), request.getRequestURI(), getRequestBody(request), e.getMessage());
+        return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler
     public ResponseEntity<ErrorResponse> handleException(HttpServletRequest request, Exception e) {
-        log.error(LOG_FORMAT, request.getMethod(), request.getRequestURI(), getRequestBody(request), e.getMessage());
+        log.error(LOG_FORMAT, request.getMethod(), request.getRequestURI(), getRequestBody(request), e.getMessage(), e);
         return ResponseEntity.internalServerError()
             .body(new ErrorResponse("SERVER_ERROR",
                 "서버 에러가 발생하였습니다.",

--- a/src/main/java/kr/allcll/seatfinder/sse/SseErrorHandler.java
+++ b/src/main/java/kr/allcll/seatfinder/sse/SseErrorHandler.java
@@ -9,10 +9,9 @@ public class SseErrorHandler {
     public static void handle(IOException e) {
         if (isClientAbortException(e)) {
             log.info("클라이언트가 연결을 종료했습니다.");
-        } else {
-            log.error("SSE 연결 중 오류 발생: {}", e.getMessage());
-            throw new RuntimeException(e);
+            return;
         }
+        throw new RuntimeException(e);
     }
 
     private static boolean isClientAbortException(Throwable throwable) {


### PR DESCRIPTION
## 작업 내용

- 에러 코드를 리팩터링 했어요. 도메인 별로 구분 잘되게 모아두었어요. 
- ServletException을 발생하는 경우에 404 NOT FOUND가 발생하게 했어요. 
  - ServletException를 상속하는 클래스를 보면, 존재하지 않는 API에 요청을 보내는 경우, 잘못된 Http Method로 요청하는 경우, 파라미터를 설정하지 않은 경우 등, 웹 요청에서 발생하는 에러들이 모여 있어요. 
  - 이걸 한 번에 404 NOT FOUND도 묶어도 괜찮을까요? 
- 우리가 핸들링 할 수 있는 에러는 AllcllException으로 처리하고, 그 외에 어떤 에러가 나올지 모르는 부분은 RuntimeException을 발생하게 했어요. 그럼 Exception을 핸들링하는 코드에서 잡히게 되고 ERROR 레벨로 로깅이 돼요. 따라서 RuntimeException을 throw하는 코드에서는 별도의 로깅 로직을 넣지 않았어요. 
