### PR TITLE
chore: 리뷰어, 작업자 자동 구성 스크립트 추가

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,14 @@
+# Reviewer 자동 할당 설정
+addReviewers: true
+
+# Assignee를 Author로 설정
+addAssignees: author
+
+# Reviewer 추가할 사용자 목록
+reviewers:
+  - 3Juhwan
+  - boyekim
+
+# 추가할 리뷰어 수
+# 0으로 설정하면 그룹 내 모든 리뷰어를 추가합니다 (기본값: 0)
+numberOfReviewers: 0


### PR DESCRIPTION
## 작업 내용

이 스크립트를 추가하면 우측에 Assignees와 Reviewers를 자동으로 설정해 준다고 하네요! 
저도 안 써봐서 어떻게 동작할지 모르겠지만, 예상하는 동작은 아래와 같아요. 

- Assignees는 작성자로 자동 할당
- Reviewers는 작성자를 제외한 나머지 인원 자동 할당 