### PR TITLE
feat: 현재 학기의 서비스 기간 조회 API 구현

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/util/SemesterCode.java
+++ b/src/main/java/kr/allcll/backend/domain/util/SemesterCode.java
@@ -1,0 +1,34 @@
+package kr.allcll.backend.domain.util;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import lombok.Getter;
+
+@Getter
+public enum SemesterCode {
+    SPRING_25("2025-1", LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 31)),
+    SUMMER_25("2025-여름", LocalDate.of(2025, 6, 1), LocalDate.of(2025, 6, 30)),
+    FALL_25("2025-2", LocalDate.of(2025, 8, 1), LocalDate.of(2025, 9, 30)),
+    WINTER_25("2025-겨울", LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 31)),
+    ;
+
+    private final String value;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+
+    SemesterCode(String value, LocalDate startDate, LocalDate endDate) {
+        this.value = value;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public static SemesterCode getCode(LocalDate date) {
+        return Arrays.stream(values())
+            .filter(semesterCode -> !semesterCode.startDate.isAfter(date))
+            .filter(semesterCode -> !semesterCode.endDate.isBefore(date))
+            .findFirst()
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.SEMESTER_NOT_FOUND));
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/util/UtilApi.java
+++ b/src/main/java/kr/allcll/backend/domain/util/UtilApi.java
@@ -1,0 +1,20 @@
+package kr.allcll.backend.domain.util;
+
+import kr.allcll.backend.domain.util.dto.SemesterResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UtilApi {
+
+    private final UtilService utilService;
+
+    @GetMapping("/api/service/semester")
+    public ResponseEntity<SemesterResponse> getSemester() {
+        SemesterResponse semesterResponse = utilService.getSemester();
+        return ResponseEntity.ok(semesterResponse);
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/util/UtilService.java
+++ b/src/main/java/kr/allcll/backend/domain/util/UtilService.java
@@ -1,0 +1,18 @@
+package kr.allcll.backend.domain.util;
+
+import java.time.LocalDate;
+import kr.allcll.backend.domain.util.dto.SemesterResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UtilService {
+
+    public SemesterResponse getSemester() {
+        LocalDate now = LocalDate.now();
+        SemesterCode currentSemesterCode = SemesterCode.getCode(now);
+        return SemesterResponse.from(currentSemesterCode);
+    }
+
+}

--- a/src/main/java/kr/allcll/backend/domain/util/dto/SemesterResponse.java
+++ b/src/main/java/kr/allcll/backend/domain/util/dto/SemesterResponse.java
@@ -1,0 +1,24 @@
+package kr.allcll.backend.domain.util.dto;
+
+import java.time.LocalDate;
+import kr.allcll.backend.domain.util.SemesterCode;
+
+public record SemesterResponse(
+    String semester,
+    Period period
+) {
+
+    public static SemesterResponse from(SemesterCode semesterCode) {
+        return new SemesterResponse(
+            semesterCode.getValue(),
+            new Period(semesterCode.getStartDate(), semesterCode.getEndDate())
+        );
+    }
+
+    public record Period(
+        LocalDate startDate,
+        LocalDate endDate
+    ) {
+
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
@@ -12,6 +12,8 @@ public enum AllcllErrorCode {
     DUPLICATE_STAR("%s은(는) 이미 핀 등록된 과목입니다."),
     STAR_SUBJECT_MISMATCH("즐겨찾기에 등록된 과목이 아닙니다."),
 
+    SEMESTER_NOT_FOUND("현재 학기 정보가 없습니다. 관리자에게 문의해주세요."),
+
     TOKEN_NOT_FOUND("쿠키에 토큰이 존재하지 않습니다."),
 
     BASKET_NOT_FOUND("관심과목 정보가 존재하지 않습니다."),

--- a/src/test/java/kr/allcll/backend/domain/util/SemesterCodeTest.java
+++ b/src/test/java/kr/allcll/backend/domain/util/SemesterCodeTest.java
@@ -1,0 +1,117 @@
+package kr.allcll.backend.domain.util;
+
+import java.time.LocalDate;
+import kr.allcll.backend.support.exception.AllcllException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SemesterCodeTest {
+
+    @Test
+    @DisplayName("학기 시작일에 해당하는 코드가 반환되어야 한다.")
+    void shouldReturnCorrectSemesterCodeOnStartDate() {
+        LocalDate springStart = LocalDate.of(2025, 2, 1);
+        LocalDate summerStart = LocalDate.of(2025, 6, 1);
+        LocalDate fallStart = LocalDate.of(2025, 8, 1);
+        LocalDate winterStart = LocalDate.of(2025, 12, 1);
+
+        assertAll(
+            () -> assertThat(SemesterCode.getCode(springStart)).isEqualTo(SemesterCode.SPRING_25),
+            () -> assertThat(SemesterCode.getCode(summerStart)).isEqualTo(SemesterCode.SUMMER_25),
+            () -> assertThat(SemesterCode.getCode(fallStart)).isEqualTo(SemesterCode.FALL_25),
+            () -> assertThat(SemesterCode.getCode(winterStart)).isEqualTo(SemesterCode.WINTER_25)
+        );
+    }
+
+    @Test
+    @DisplayName("학기 종료일에 해당하는 코드가 반환되어야 한다.")
+    void shouldReturnCorrectSemesterCodeOnEndDate() {
+        LocalDate springEnd = LocalDate.of(2025, 3, 31);
+        LocalDate summerEnd = LocalDate.of(2025, 6, 30);
+        LocalDate fallEnd = LocalDate.of(2025, 9, 30);
+        LocalDate winterEnd = LocalDate.of(2025, 12, 31);
+
+        assertAll(
+            () -> assertThat(SemesterCode.getCode(springEnd)).isEqualTo(SemesterCode.SPRING_25),
+            () -> assertThat(SemesterCode.getCode(summerEnd)).isEqualTo(SemesterCode.SUMMER_25),
+            () -> assertThat(SemesterCode.getCode(fallEnd)).isEqualTo(SemesterCode.FALL_25),
+            () -> assertThat(SemesterCode.getCode(winterEnd)).isEqualTo(SemesterCode.WINTER_25)
+        );
+    }
+
+    @Test
+    @DisplayName("학기 기간 내 날짜에 대해 올바른 학기 코드가 반환되어야 한다.")
+    void shouldReturnCorrectSemesterCodeWithinPeriod() {
+        LocalDate springMiddle = LocalDate.of(2025, 2, 15);
+        LocalDate summerMiddle = LocalDate.of(2025, 6, 15);
+        LocalDate fallMiddle = LocalDate.of(2025, 8, 15);
+        LocalDate winterMiddle = LocalDate.of(2025, 12, 15);
+
+        assertAll(
+            () -> assertThat(SemesterCode.getCode(springMiddle)).isEqualTo(SemesterCode.SPRING_25),
+            () -> assertThat(SemesterCode.getCode(summerMiddle)).isEqualTo(SemesterCode.SUMMER_25),
+            () -> assertThat(SemesterCode.getCode(fallMiddle)).isEqualTo(SemesterCode.FALL_25),
+            () -> assertThat(SemesterCode.getCode(winterMiddle)).isEqualTo(SemesterCode.WINTER_25)
+        );
+    }
+
+    @Test
+    @DisplayName("학기 시작일 하루 전 날짜는 예외를 발생시켜야 한다.")
+    void shouldThrowExceptionWhenBeforeStartDate() {
+        LocalDate beforeSpring = LocalDate.of(2025, 1, 31);
+        LocalDate beforeSummer = LocalDate.of(2025, 5, 31);
+        LocalDate beforeFall = LocalDate.of(2025, 7, 31);
+        LocalDate beforeWinter = LocalDate.of(2025, 11, 30);
+
+        assertAll(
+            () -> assertThatThrownBy(() -> SemesterCode.getCode(beforeSpring))
+                .isInstanceOf(AllcllException.class),
+            () -> assertThatThrownBy(() -> SemesterCode.getCode(beforeSummer))
+                .isInstanceOf(AllcllException.class),
+            () -> assertThatThrownBy(() -> SemesterCode.getCode(beforeFall))
+                .isInstanceOf(AllcllException.class),
+            () -> assertThatThrownBy(() -> SemesterCode.getCode(beforeWinter))
+                .isInstanceOf(AllcllException.class)
+        );
+    }
+
+    @Test
+    @DisplayName("학기 종료일 하루 후 날짜는 예외를 발생시켜야 한다.")
+    void shouldThrowExceptionWhenAfterEndDate() {
+        LocalDate afterSpring = LocalDate.of(2025, 4, 1);
+        LocalDate afterSummer = LocalDate.of(2025, 7, 1);
+        LocalDate afterFall = LocalDate.of(2025, 10, 1);
+        LocalDate afterWinter = LocalDate.of(2026, 1, 1);
+
+        assertAll(
+            () -> assertThatThrownBy(() -> SemesterCode.getCode(afterSpring))
+                .isInstanceOf(AllcllException.class),
+            () -> assertThatThrownBy(() -> SemesterCode.getCode(afterSummer))
+                .isInstanceOf(AllcllException.class),
+            () -> assertThatThrownBy(() -> SemesterCode.getCode(afterFall))
+                .isInstanceOf(AllcllException.class),
+            () -> assertThatThrownBy(() -> SemesterCode.getCode(afterWinter))
+                .isInstanceOf(AllcllException.class)
+        );
+    }
+
+    @Test
+    @DisplayName("학기와 학기 사이의 날짜는 예외를 발생시켜야 한다.")
+    void shouldThrowExceptionWhenBetweenSemesters() {
+        LocalDate betweenSpringAndSummer = LocalDate.of(2025, 4, 15);
+        LocalDate betweenSummerAndFall = LocalDate.of(2025, 7, 15);
+        LocalDate betweenFallAndWinter = LocalDate.of(2025, 10, 15);
+
+        assertAll(
+            () -> assertThatThrownBy(() -> SemesterCode.getCode(betweenSpringAndSummer))
+                .isInstanceOf(AllcllException.class),
+            () -> assertThatThrownBy(() -> SemesterCode.getCode(betweenSummerAndFall))
+                .isInstanceOf(AllcllException.class),
+            () -> assertThatThrownBy(() -> SemesterCode.getCode(betweenFallAndWinter))
+                .isInstanceOf(AllcllException.class)
+        );
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/util/UtilApiTest.java
+++ b/src/test/java/kr/allcll/backend/domain/util/UtilApiTest.java
@@ -1,0 +1,51 @@
+package kr.allcll.backend.domain.util;
+
+import java.time.LocalDate;
+import kr.allcll.backend.domain.util.dto.SemesterResponse;
+import kr.allcll.backend.domain.util.dto.SemesterResponse.Period;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.when;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UtilApi.class)
+class UtilApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UtilService utilService;
+
+    @Test
+    @DisplayName("학기 정보를 조회한다.")
+    void getSemesterTest() throws Exception {
+        // given
+        String expected = """
+            {
+                "semester": "2025-1",
+                "period": {
+                    "startDate": "2025-02-01",
+                    "endDate": "2025-03-31"
+                }
+            }
+            """;
+
+        when(utilService.getSemester())
+            .thenReturn(new SemesterResponse(
+                "2025-1",
+                new Period(LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 31)))
+            );
+
+        // when, then
+        mockMvc.perform(get("/api/service/semester"))
+            .andExpect(status().isOk())
+            .andExpect(content().json(expected));
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/util/UtilServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/util/UtilServiceTest.java
@@ -1,0 +1,32 @@
+package kr.allcll.backend.domain.util;
+
+import java.time.LocalDate;
+import kr.allcll.backend.domain.util.dto.SemesterResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class UtilServiceTest {
+
+    @Autowired
+    private UtilService utilService;
+
+    @Test
+    @DisplayName("현재 학기 정보를 조회한다.")
+    void getSemesterTest() {
+        // when
+        SemesterResponse semesterResponse = utilService.getSemester();
+
+        // then
+        assertAll(
+            () -> assertThat(semesterResponse.semester()).isEqualTo("2025-1"),
+            () -> assertThat(semesterResponse.period().startDate()).isEqualTo(LocalDate.of(2025, 2, 1)),
+            () -> assertThat(semesterResponse.period().endDate()).isEqualTo(LocalDate.of(2025, 3, 31))
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용

### 개요
현재 학기의 서비스 기간을 조회하는 API를 구현했어요. 이 API는 현재 학기(2025년 1학기)에 올클의 서비스 기간을 조회하는 API에요. 
아래 응답을 기반으로 25년 1학기 서비스 기간이 `2월 1일부터 3월 31일까지`라는 사실을 클라이언트가 알 수 있어요. 
이 데이터로 해당 학기 서비스 종료 여부를 사용자에게 표시해 줄 수 있겠죠! 

응답은 다음과 같아요. 

**`Request: GET /api/semester`**

```json
{
    "semester": "2025-1",
    "period": {
        "start": "2025-02-01",
        "end": "2025-03-31"
    }
}
```

### 참고 사항
api의 응답 데이터인 학기와 기간은 mysql에서 관리하는 데이터에요. 관리자가 매 학기마다 데이터를 저장해야 해요. 
자동화한 부분도 있는데요. 코드 레벨에서 1-6월은 1학기, 7-12월은 2학기로 설정해 두었어요! 
6월에 api를 호출하면 시간을 기반으로 25년1학기 데이터를 조회하고, 7월에는 25년 2학기 데이터를 조회해요. 

## 고민 지점과 리뷰 포인트

추후 변경이 필요한 지점이에요. 작성한 테스트는 현재 시간을 기반으로 두고 있는데요. 7월이 되면 실패하는 테스트가 돼요. 이것은 테스트용 클락을 빈으로 등록하면 해결할 수 있어요. 이 내용은 추후 다른 pr에서 적용하는 게 어떨까해서 구현하지 않았어요! 

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->