### PR TITLE
remove: 교양 탑20을 크롤러에 전송하는 기능 삭제

### DIFF
--- a/src/main/java/kr/allcll/backend/config/ExternalConfig.java
+++ b/src/main/java/kr/allcll/backend/config/ExternalConfig.java
@@ -19,7 +19,6 @@ public class ExternalConfig {
     public ApplicationRunner runAfterStartup() {
         return args -> {
             try {
-                externalPreInvoker.saveNonMajorSubjects();
                 externalPreInvoker.sendSseConnectionToExternal();
             } catch (Exception e) {
                 log.error("[서버] 초기 실행 중 오류 발생: {}", e.getMessage(), e);

--- a/src/main/java/kr/allcll/backend/config/ExternalPreInvoker.java
+++ b/src/main/java/kr/allcll/backend/config/ExternalPreInvoker.java
@@ -18,42 +18,16 @@ public class ExternalPreInvoker {
     private final SseClientService sseClientService;
 
     @Retryable(
-        retryFor = {Exception.class},
-        maxAttempts = 60 * 60 * 7,
-        backoff = @Backoff(delay = 100, multiplier = 1.5, maxDelay = 5000)
-    )
-    public void saveNonMajorSubjects() {
-        try {
-            externalService.saveNonMajorSubjects();
-        } catch (Exception e) {
-            log.error("[서버] 상위권 교양 저장 중 오류 발생", e);
-            throw e;
-        }
-        log.info("[서버] 상위권 교양 저장 완료");
-    }
-
-    @Retryable(
         maxAttempts = 12 * 60 * 7,
         backoff = @Backoff(delay = 100, multiplier = 1.5, maxDelay = 5000)
     )
     public void sendSseConnectionToExternal() {
-        sendNonMajorToExternal();
         try {
             keepSseConnection();
         } catch (Exception e) {
             log.error("[외부 서버 통신] {}", e.getMessage(), e);
             throw e;
         }
-    }
-
-    private void sendNonMajorToExternal() {
-        try {
-            externalService.sendNonMajorToExternal();
-        } catch (Exception e) {
-            log.error("[외부 서버 통신] 상위권 교양 전달 중 오류 발생", e);
-            throw e;
-        }
-        log.info("[외부 서버 통신] 상위권 교양 전달 완료");
     }
 
     private void keepSseConnection() {


### PR DESCRIPTION
## 작업 내용

요구사항 변경으로 교양 탑20을 크롤러에 전송하는 기능을 삭제합니다. 

**기존 요구사항**
백엔드 서버에서 교양 탑20을 선정하여 크롤러에게 요청을 보내는 형태였습니다. 

**새로운 요구사항**
전체 교양 과목의 여석 데이터를 받고, 백엔드 서버에서 교양 탑 20을 선정하는 방식으로 변경합니다. 

### 변경 사항에 대한 설명 
백엔드 서버와 크롤러 간에 여석 데이터는 SSE를 통해 전송됩니다. 
백엔드 서버에 어떤 데이터를 전달할 것인지 결정하는 주체는 크롤러 서버입니다. 
크롤러 코드를 수정하여 전체 교양의 여석 데이터를 전송하는 방식으로 수정해야 하므로, 이 pr에서는 코드를 제거하는 작업만 했습니다. 