### PR TITLE
feat: 어드민 기능 구현

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/AdminApi.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminApi.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class AdminController {
+public class AdminApi {
 
     private final AdminService adminService;
 

--- a/src/main/java/kr/allcll/backend/admin/AdminController.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminController.java
@@ -22,4 +22,10 @@ public class AdminController {
         adminService.sseDisconnect();
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/admin/send-non-major")
+    public ResponseEntity<Void> startToSendNonMajor() {
+        adminService.startToSendNonMajor();
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/kr/allcll/backend/admin/AdminController.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminController.java
@@ -1,0 +1,19 @@
+package kr.allcll.backend.admin;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PostMapping("/admin/set-sse-connection-open")
+    public ResponseEntity<Void> sseConnect() {
+        adminService.sseConnect();
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/kr/allcll/backend/admin/AdminController.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminController.java
@@ -11,7 +11,7 @@ public class AdminController {
 
     private final AdminService adminService;
 
-    @PostMapping("/admin/set-sse-connection-open")
+    @PostMapping("/admin/sse-connect")
     public ResponseEntity<Void> sseConnect() {
         adminService.sseConnect();
         return ResponseEntity.ok().build();

--- a/src/main/java/kr/allcll/backend/admin/AdminController.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminController.java
@@ -16,4 +16,10 @@ public class AdminController {
         adminService.sseConnect();
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/admin/sse-disconnect")
+    public ResponseEntity<Void> sseDisconnect() {
+        adminService.sseDisconnect();
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/kr/allcll/backend/admin/AdminService.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminService.java
@@ -1,0 +1,22 @@
+package kr.allcll.backend.admin;
+
+import kr.allcll.backend.config.AdminConfigStorage;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final AdminConfigStorage adminConfigStorage;
+
+    public void sseConnect() {
+        if (adminConfigStorage.sseAccessible()) {
+            throw new AllcllException(AllcllErrorCode.SSE_CONNECTION_ALREADY_OPEN);
+        }
+        adminConfigStorage.connectionOpen();
+    }
+
+}

--- a/src/main/java/kr/allcll/backend/admin/AdminService.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminService.java
@@ -1,6 +1,7 @@
 package kr.allcll.backend.admin;
 
 import kr.allcll.backend.config.AdminConfigStorage;
+import kr.allcll.backend.domain.seat.SeatService;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
 import kr.allcll.backend.support.exception.AllcllException;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 public class AdminService {
 
     private final AdminConfigStorage adminConfigStorage;
+    private final SeatService seatService;
 
     public void sseConnect() {
         if (adminConfigStorage.sseAccessible()) {
@@ -24,5 +26,12 @@ public class AdminService {
             throw new AllcllException(AllcllErrorCode.SSE_CONNECTION_ALREADY_CLOSED);
         }
         adminConfigStorage.connectionClose();
+    }
+
+    public void startToSendNonMajor() {
+        if (adminConfigStorage.sseNotAccessible()) {
+            throw new AllcllException(AllcllErrorCode.SSE_CONNECTION_DENIED);
+        }
+        seatService.sendNonMajorSeats();
     }
 }

--- a/src/main/java/kr/allcll/backend/admin/AdminService.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminService.java
@@ -19,4 +19,10 @@ public class AdminService {
         adminConfigStorage.connectionOpen();
     }
 
+    public void sseDisconnect() {
+        if (adminConfigStorage.sseNotAccessible()) {
+            throw new AllcllException(AllcllErrorCode.SSE_CONNECTION_ALREADY_CLOSED);
+        }
+        adminConfigStorage.connectionClose();
+    }
 }

--- a/src/main/java/kr/allcll/backend/config/AdminConfigStorage.java
+++ b/src/main/java/kr/allcll/backend/config/AdminConfigStorage.java
@@ -1,7 +1,7 @@
 package kr.allcll.backend.config;
 
 import kr.allcll.backend.support.exception.AllcllErrorCode;
-import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.backend.support.exception.AllcllSseException;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,9 +21,9 @@ public class AdminConfigStorage {
         return !sseAccessible();
     }
 
-    public void validateSseConnection(){
-        if (sseNotAccessible()){
-            throw new AllcllException(AllcllErrorCode.SSE_CONNECTION_DENIED);
+    public void validateSseConnection() {
+        if (sseNotAccessible()) {
+            throw new AllcllSseException(AllcllErrorCode.SSE_CONNECTION_DENIED);
         }
     }
 

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
@@ -12,7 +12,7 @@ import kr.allcll.backend.domain.seat.pin.Pin;
 import kr.allcll.backend.domain.seat.pin.PinRepository;
 import kr.allcll.backend.domain.seat.pin.dto.PinSeatsResponse;
 import kr.allcll.backend.domain.subject.Subject;
-import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.backend.support.exception.AllcllSseException;
 import kr.allcll.backend.support.schedule.ScheduleStorage;
 import kr.allcll.backend.support.sse.SseService;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +43,7 @@ public class SeatService {
             List<SeatDto> nonMajorSeatDtos = seatStorage.getNonMajorSeats(NON_MAJOR_SUBJECT_QUERY_LIMIT);
             try {
                 sseService.propagate(NON_MAJOR_SEATS_EVENT_NAME, SeatsResponse.from(nonMajorSeatDtos));
-            } catch (AllcllException e) {
+            } catch (AllcllSseException e) {
                 scheduleStorage.cancelNonMajorSchedule();
             }
         };

--- a/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
@@ -20,6 +20,7 @@ public enum AllcllErrorCode {
 
     SSE_EMITTER_NOT_FOUND("존재하지 않는 SSE 연결입니다"),
     SSE_CONNECTION_DENIED("현재 SSE 연결을 할 수 없습니다."),
+    SSE_CONNECTION_ALREADY_OPEN("SSE가 이미 연결되어 있습니다."),
     ;
 
     private String message;

--- a/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
@@ -21,6 +21,7 @@ public enum AllcllErrorCode {
     SSE_EMITTER_NOT_FOUND("존재하지 않는 SSE 연결입니다"),
     SSE_CONNECTION_DENIED("현재 SSE 연결을 할 수 없습니다."),
     SSE_CONNECTION_ALREADY_OPEN("SSE가 이미 연결되어 있습니다."),
+    SSE_CONNECTION_ALREADY_CLOSED("SSE가 이미 연결 해제 되어있습니다.")
     ;
 
     private String message;

--- a/src/main/java/kr/allcll/backend/support/exception/AllcllSseException.java
+++ b/src/main/java/kr/allcll/backend/support/exception/AllcllSseException.java
@@ -1,0 +1,14 @@
+package kr.allcll.backend.support.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AllcllSseException extends AllcllException {
+
+    private final String errorCode;
+
+    public AllcllSseException(AllcllErrorCode errorCode, Object... args) {
+        super(errorCode, args);
+        this.errorCode = errorCode.name();
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/schedule/ScheduleStorage.java
+++ b/src/main/java/kr/allcll/backend/support/schedule/ScheduleStorage.java
@@ -3,22 +3,29 @@ package kr.allcll.backend.support.schedule;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
+import lombok.Setter;
 import org.springframework.stereotype.Component;
 
+@Setter
 @Component
 public class ScheduleStorage {
 
     private final Map<String, ScheduledFuture<?>> scheduledPinTasks = new ConcurrentHashMap<>();
+    private ScheduledFuture<?> nonMajorSchedule;
 
-    public boolean isAlreadyScheduled(String token) {
+    public void cancelNonMajorSchedule() {
+        nonMajorSchedule.cancel(true);
+    }
+
+    public boolean isAlreadyScheduledPin(String token) {
         return scheduledPinTasks.containsKey(token);
     }
 
-    public void deleteSchedule(String token) {
+    public void deletePinSchedule(String token) {
         scheduledPinTasks.remove(token);
     }
 
-    public void addSchedule(String token, ScheduledFuture<?> scheduledFuture) {
+    public void addPinSchedule(String token, ScheduledFuture<?> scheduledFuture) {
         scheduledPinTasks.put(token, scheduledFuture);
     }
 }

--- a/src/main/java/kr/allcll/backend/support/sse/SseService.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseService.java
@@ -2,8 +2,6 @@ package kr.allcll.backend.support.sse;
 
 import java.io.IOException;
 import kr.allcll.backend.config.AdminConfigStorage;
-import kr.allcll.backend.support.exception.AllcllErrorCode;
-import kr.allcll.backend.support.exception.AllcllException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/test/java/kr/allcll/backend/admin/AdminServiceTest.java
+++ b/src/test/java/kr/allcll/backend/admin/AdminServiceTest.java
@@ -107,13 +107,13 @@ class AdminServiceTest {
             adminConfigStorage.connectionOpen();
             sseService.connect("token");
             AtomicInteger executeCount = new AtomicInteger(0);
-            AtomicInteger countBeforeDisconnect = new AtomicInteger(0);
+            AtomicInteger countAtCancel = new AtomicInteger(0);
             Runnable task = () -> {
                 try {
                     sseService.propagate("message", "Is SSE there?");
                     executeCount.incrementAndGet();
                 } catch (AllcllException e) {
-                    countBeforeDisconnect.set(executeCount.get());
+                    countAtCancel.set(executeCount.get());
                     scheduledFuture.cancel(true);
                 }
             };
@@ -125,8 +125,8 @@ class AdminServiceTest {
 
             // then
             Thread.sleep(taskDuration * 2);
-            int countAfterDisconnect = executeCount.get();
-            assertThat(countBeforeDisconnect.get()).isEqualTo(countAfterDisconnect);
+            int countAfterDuration = executeCount.get();
+            assertThat(countAtCancel.get()).isEqualTo(countAfterDuration);
         }
     }
 }

--- a/src/test/java/kr/allcll/backend/admin/AdminServiceTest.java
+++ b/src/test/java/kr/allcll/backend/admin/AdminServiceTest.java
@@ -1,0 +1,57 @@
+package kr.allcll.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import kr.allcll.backend.config.AdminConfigStorage;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class AdminServiceTest {
+
+    @Autowired
+    private AdminService adminService;
+
+    @Autowired
+    private AdminConfigStorage adminConfigStorage;
+
+    @AfterEach
+    void setUp() {
+        adminConfigStorage.connectionClose();
+    }
+
+    @Nested
+    @DisplayName("SSE 연결 가능 상태로 변경한다.")
+    class sseConnectTest {
+
+        @Test
+        @DisplayName("연결 불가능 상태였을 경우 변경을 성공한다.")
+        void sseConnect() {
+            // when
+            adminService.sseConnect();
+
+            // then
+            assertThat(adminConfigStorage.sseAccessible()).isTrue();
+        }
+
+        @Test
+        @DisplayName("이미 연결 가능 상태였을 경우 예외가 발생한다.")
+        void sseConnectException() {
+            // given
+            adminConfigStorage.connectionOpen();
+
+            // when && then
+            assertThatThrownBy(() -> adminService.sseConnect())
+                .isInstanceOf(AllcllException.class)
+                .hasMessage(AllcllErrorCode.SSE_CONNECTION_ALREADY_OPEN.getMessage());
+        }
+    }
+}

--- a/src/test/java/kr/allcll/backend/admin/AdminServiceTest.java
+++ b/src/test/java/kr/allcll/backend/admin/AdminServiceTest.java
@@ -94,7 +94,7 @@ class AdminServiceTest {
     }
 
     @Nested
-    @DisplayName("비전공 과목 전송 시나리오 테스트")
+    @DisplayName("비전공 과목 전송 관련 sse 연결 테스트")
     class nonMajorWithSse {
 
         private ScheduledFuture<?> scheduledFuture;

--- a/src/test/java/kr/allcll/backend/admin/AdminServiceTest.java
+++ b/src/test/java/kr/allcll/backend/admin/AdminServiceTest.java
@@ -54,4 +54,31 @@ class AdminServiceTest {
                 .hasMessage(AllcllErrorCode.SSE_CONNECTION_ALREADY_OPEN.getMessage());
         }
     }
+
+    @Nested
+    @DisplayName("SSE 연결 불가능 상태로 변경한다.")
+    class sseDisconnectTest {
+
+        @Test
+        @DisplayName("연결 가능 상태였을 경우 변경을 성공한다.")
+        void sseDisconnect() {
+            // given
+            adminConfigStorage.connectionOpen();
+
+            // when
+            adminService.sseDisconnect();
+
+            // then
+            assertThat(adminConfigStorage.sseNotAccessible()).isTrue();
+        }
+
+        @Test
+        @DisplayName("이미 연결 불가능 상태였을 경우 예외가 발생한다.")
+        void sseDisconnectException() {
+            // when && then
+            assertThatThrownBy(() -> adminService.sseDisconnect())
+                .isInstanceOf(AllcllException.class)
+                .hasMessage(AllcllErrorCode.SSE_CONNECTION_ALREADY_CLOSED.getMessage());
+        }
+    }
 }

--- a/src/test/java/kr/allcll/backend/admin/AdminServiceTest.java
+++ b/src/test/java/kr/allcll/backend/admin/AdminServiceTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import kr.allcll.backend.config.AdminConfigStorage;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
 import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.backend.support.exception.AllcllSseException;
 import kr.allcll.backend.support.sse.SseService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -112,7 +113,7 @@ class AdminServiceTest {
                 try {
                     sseService.propagate("message", "Is SSE there?");
                     executeCount.incrementAndGet();
-                } catch (AllcllException e) {
+                } catch (AllcllSseException e) {
                     countAtCancel.set(executeCount.get());
                     scheduledFuture.cancel(true);
                 }


### PR DESCRIPTION
## 작업 내용
멀티 모듈의 사용은 추후 도입하기로 결정 후, 현재 프로젝트에서 어드민 기능을 구현했습니다.

그리고, 아직 학기 정보 세팅에 관한 pr이 머지가 안되어서 해당 기능은 구현하지 않았습니다. 머지 이후 따로 pr을 파도 좋을 것 같아요.

### SSE 연결 가능 상태/불가능 상태로 변경하는 기능
저희가 SSE 연결을 통제하기 위해 `AdminConfigStorage`를 사용하는데요, 여기의 sseAccessible의 상태값이 `false` 일 경우 sse의 connect, propagate가 전부 예외를 발생합니다. 이 상태를 관리하는 api를 두개로 갈라서 만들었어용.
이때 이미 상태가 바꾸려는 상태와 동일하다면 예외를 던져줍니다.

### 교양 과목 전송 시작하는 기능
핀 고정 과목은 클라이언트에서 요청이 오면 그 때 sse 응답을 시작하는데요, 이와 달리 교양과목은 별도의 클라이언트 요청 없이 응답을 계속 전송합니다. 이전엔 `@Scheduled` 어노테이션을 사용했었으나 sse 연결 관리의 불편함때문에 taskScheduler로 변경해주었어요. 따라서 어드민 페이지에서 요청을 직접 관리하는 방향으로 구현을 했습니다.

### sse 연결 불가 시 스케줄러 테스트
sse 연결을 불가능하도록 세팅했을 때, 기존에 이미 일정 주기로 돌아가던 스케줄러는 계속 돌아갑니다. 따라서 Runnable에서 예외를 catch 후 스케줄을 취소하는 로직으로 수정했습니다. 이 로직이 정상 작동하는지 메서드 콜로 테스트하는게 아닌 **직접 테스트 코드 내부에서 Runnable을 작성**하여 테스트를 해보았습니다. 테스트의 검증 방법에 대해 부연 설명을 하자면 다음과 같아요.
Runnable의 task에서 AtomicInteger가 증가하고, 예외를 catch 했을 때 수가 얼마나 증가했는지 알아두어요.(`countAtCancel`) 그리고 스케줄을 취소합니다.  이후 스케줄러가 돌아가던 **주기 이상의 시간 간격**을 적절히 두고 다시 AtomicInteger의 count를 알아두어요(`countAfterDuration`). 이때 `countAfterDuration`가 `countAtCancel`보다 크다면, 즉 count가 증가했다면 스케줄이 한번 더 돈거니까 잘못된 로직일 것이고, 둘이 같으면 스케줄이 돌지 않았을 것이니까 의도한 로직이겠지요.

## 고민 지점과 리뷰 포인트
교양 과목 전송을 시작하는 기능을 구현할 때 고민한 지점이 있습니다. sse 연결 가능상태에서 교양 과목 전송을 시작을합니다. 그러면 scheduleAtFixedRate로 주기적으로 sse 응답이 propagate되잖아요? 이때 sse 커넥션을 어드민에서 닫았을 경우가 문제였어요. 이제 저희가 다 관리를 하니, `seatService.sendNonMajorSeats();`를 직접 호출하는거 까진 인정인데, sse 연결 여부도 저희가 관리하잖아요? `seatService.sendNonMajorSeats();`를 호출해서 한참 sse 응답이 나가고 있는데 중간에 sse 연결을 불가능하게 상태변경을 해버리면, sse 응답을 주는 과정에서 계속 예외가 터지게 되어요. 막아두었으니까요... 그래서 SeatService의 `sendNonMajorSeats` 메서드의 로직을 변경해주었습니다. 스케줄러에 넣는 Runnable task 내부에 try catch를 두었어요. 그리고 저희가 발생시키는 예외(sse 연결 불가능 상태로 propagate하려고 하면 예외 터지게 설정했음)가 catch 되면 스케줄을 취소 시키도록 했습니다.
그리고 admin의 교양 과목 전송 시작하는 기능은 단순 seatService의 sendNonMajorSeats를 호출하는 것이고, 이 메서드의 테스트는 이미 있잖아요? 
그래서 메서드 콜로 인한 테스트가 아닌, 테스트 내부에서 똑같이 Runnable을 만들고 커넥션을 끊었을 때에 취소가 잘 되는지를 확인해보았습니다. 피드백주세요!!

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->