### PR TITLE
feat: Subject 엔티티에 soft delete 적용

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface BasketRepository extends JpaRepository<Basket, Long> {
 
     @Query("select b from Basket b "
-        + "join b.subject s "
+        + "join fetch b.subject s "
         + "where s.id = :id "
         + "and s.isDeleted = false")
     List<Basket> findBySubjectId(Long id);

--- a/src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java
@@ -2,8 +2,14 @@ package kr.allcll.backend.domain.basket;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BasketRepository extends JpaRepository<Basket, Long> {
 
+    @Query("select b from Basket b "
+        + "join fetch b.subject s "
+        + "where s.id = :id "
+        + "and s.deletedAt is null "
+        + "and s.isDeleted = false")
     List<Basket> findBySubjectId(Long id);
 }

--- a/src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface BasketRepository extends JpaRepository<Basket, Long> {
 
     @Query("select b from Basket b "
-        + "join fetch b.subject s "
+        + "join b.subject s "
         + "where s.id = :id "
         + "and s.isDeleted = false")
     List<Basket> findBySubjectId(Long id);

--- a/src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java
@@ -9,7 +9,6 @@ public interface BasketRepository extends JpaRepository<Basket, Long> {
     @Query("select b from Basket b "
         + "join fetch b.subject s "
         + "where s.id = :id "
-        + "and s.deletedAt is null "
         + "and s.isDeleted = false")
     List<Basket> findBySubjectId(Long id);
 }

--- a/src/main/java/kr/allcll/backend/domain/basket/star/StarRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/star/StarRepository.java
@@ -3,13 +3,31 @@ package kr.allcll.backend.domain.basket.star;
 import java.util.List;
 import kr.allcll.backend.domain.subject.Subject;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface StarRepository extends JpaRepository<Star, Long> {
 
+    @Query("select case when count(s) > 0 then true else false end "
+        + "from Star s "
+        + "join s.subject sub "
+        + "where s.subject = :subject "
+        + "and s.token = :token "
+        + "and sub.deletedAt is null "
+        + "and sub.isDeleted = false")
     boolean existsBySubjectAndToken(Subject subject, String token);
 
+    @Query("select s from Star s "
+        + "join fetch s.subject sub "
+        + "where s.token = :token "
+        + "and sub.deletedAt is null "
+        + "and sub.isDeleted = false")
     List<Star> findAllByToken(String token);
 
+    @Query("select count(s) from Star s "
+        + "join s.subject sub "
+        + "where s.token = :token "
+        + "and sub.deletedAt is null "
+        + "and sub.isDeleted = false")
     Long countAllByToken(String token);
 
     void deleteStarBySubjectIdAndToken(Long subjectId, String token);

--- a/src/main/java/kr/allcll/backend/domain/basket/star/StarRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/star/StarRepository.java
@@ -12,21 +12,18 @@ public interface StarRepository extends JpaRepository<Star, Long> {
         + "join s.subject sub "
         + "where s.subject = :subject "
         + "and s.token = :token "
-        + "and sub.deletedAt is null "
         + "and sub.isDeleted = false")
     boolean existsBySubjectAndToken(Subject subject, String token);
 
     @Query("select s from Star s "
         + "join fetch s.subject sub "
         + "where s.token = :token "
-        + "and sub.deletedAt is null "
         + "and sub.isDeleted = false")
     List<Star> findAllByToken(String token);
 
     @Query("select count(s) from Star s "
         + "join s.subject sub "
         + "where s.token = :token "
-        + "and sub.deletedAt is null "
         + "and sub.isDeleted = false")
     Long countAllByToken(String token);
 

--- a/src/main/java/kr/allcll/backend/domain/basket/star/StarRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/star/StarRepository.java
@@ -16,7 +16,7 @@ public interface StarRepository extends JpaRepository<Star, Long> {
     boolean existsBySubjectAndToken(Subject subject, String token);
 
     @Query("select s from Star s "
-        + "join fetch s.subject sub "
+        + "join s.subject sub "
         + "where s.token = :token "
         + "and sub.isDeleted = false")
     List<Star> findAllByToken(String token);

--- a/src/main/java/kr/allcll/backend/domain/basket/star/StarRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/star/StarRepository.java
@@ -16,7 +16,7 @@ public interface StarRepository extends JpaRepository<Star, Long> {
     boolean existsBySubjectAndToken(Subject subject, String token);
 
     @Query("select s from Star s "
-        + "join s.subject sub "
+        + "join fetch s.subject sub "
         + "where s.token = :token "
         + "and sub.isDeleted = false")
     List<Star> findAllByToken(String token);

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatRepository.java
@@ -14,14 +14,12 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     @Query("select s from Seat s join s.subject sub "
         + "where s.subject = :subject "
         + "and s.createdDate = :today "
-        + "and sub.deletedAt is null "
         + "and sub.isDeleted = false")
     Optional<Seat> findBySubjectAndCreatedDate(Subject subject, LocalDate today);
 
     @Query("select s from Seat s "
         + "join s.subject sub "
         + "where s.createdDate = :createdDate "
-        + "and sub.deletedAt is null "
         + "and sub.isDeleted = false")
     List<Seat> findAllByCreatedDate(LocalDate createdDate);
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatRepository.java
@@ -5,12 +5,23 @@ import java.util.List;
 import java.util.Optional;
 import kr.allcll.backend.domain.subject.Subject;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
+    @Query("select s from Seat s join s.subject sub "
+        + "where s.subject = :subject "
+        + "and s.createdDate = :today "
+        + "and sub.deletedAt is null "
+        + "and sub.isDeleted = false")
     Optional<Seat> findBySubjectAndCreatedDate(Subject subject, LocalDate today);
 
+    @Query("select s from Seat s "
+        + "join s.subject sub "
+        + "where s.createdDate = :createdDate "
+        + "and sub.deletedAt is null "
+        + "and sub.isDeleted = false")
     List<Seat> findAllByCreatedDate(LocalDate createdDate);
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatRepository.java
@@ -11,7 +11,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
-    @Query("select s from Seat s join s.subject sub "
+    @Query("select s from Seat s "
+        + "join s.subject sub "
         + "where s.subject = :subject "
         + "and s.createdDate = :today "
         + "and sub.isDeleted = false")

--- a/src/main/java/kr/allcll/backend/domain/seat/pin/PinRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/pin/PinRepository.java
@@ -10,7 +10,6 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
 
     @Query("select p from Pin p join fetch p.subject s "
         + "where p.token = :tokenId "
-        + "and s.deletedAt is null "
         + "and s.isDeleted = false")
     List<Pin> findAllByToken(String tokenId);
 
@@ -22,13 +21,11 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
     @Query("select case when COUNT(p) > 0 then true else false end from Pin p join p.subject s "
         + "where p.subject = :subject "
         + "and p.token = :token "
-        + "and s.deletedAt is null "
         + "and s.isDeleted = false")
     boolean existsBySubjectAndToken(Subject subject, String token);
 
     @Query("select count(p) from Pin p join p.subject s "
         + "where p.token = :token "
-        + "and s.isDeleted = false "
-        + "and s.deletedAt is null")
+        + "and s.isDeleted = false ")
     Long countAllByToken(String token);
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/pin/PinRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/pin/PinRepository.java
@@ -8,7 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface PinRepository extends JpaRepository<Pin, Long> {
 
-    @Query("select p from Pin p join fetch p.subject s "
+    @Query("select p from Pin p "
+        + "join p.subject s "
         + "where p.token = :tokenId "
         + "and s.isDeleted = false")
     List<Pin> findAllByToken(String tokenId);
@@ -18,13 +19,15 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
         + "and p.token = :token")
     Optional<Pin> findBySubjectAndTokenToDelete(Subject subject, String token);
 
-    @Query("select case when COUNT(p) > 0 then true else false end from Pin p join p.subject s "
+    @Query("select case when COUNT(p) > 0 then true else false end from Pin p "
+        + "join p.subject s "
         + "where p.subject = :subject "
         + "and p.token = :token "
         + "and s.isDeleted = false")
     boolean existsBySubjectAndToken(Subject subject, String token);
 
-    @Query("select count(p) from Pin p join p.subject s "
+    @Query("select count(p) from Pin p "
+        + "join p.subject s "
         + "where p.token = :token "
         + "and s.isDeleted = false ")
     Long countAllByToken(String token);

--- a/src/main/java/kr/allcll/backend/domain/seat/pin/PinRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/pin/PinRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface PinRepository extends JpaRepository<Pin, Long> {
 
     @Query("select p from Pin p "
-        + "join p.subject s "
+        + "join fetch p.subject s "
         + "where p.token = :tokenId "
         + "and s.isDeleted = false")
     List<Pin> findAllByToken(String tokenId);

--- a/src/main/java/kr/allcll/backend/domain/seat/pin/PinRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/pin/PinRepository.java
@@ -8,12 +8,27 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface PinRepository extends JpaRepository<Pin, Long> {
 
-    @Query("select p from Pin p join fetch p.subject where p.token = :tokenId")
+    @Query("select p from Pin p join fetch p.subject s "
+        + "where p.token = :tokenId "
+        + "and s.deletedAt is null "
+        + "and s.isDeleted = false")
     List<Pin> findAllByToken(String tokenId);
 
-    Optional<Pin> findBySubjectAndToken(Subject subject, String token);
+    @Query("select p from Pin p "
+        + "where p.subject = :subject "
+        + "and p.token = :token")
+    Optional<Pin> findBySubjectAndTokenToDelete(Subject subject, String token);
 
+    @Query("select case when COUNT(p) > 0 then true else false end from Pin p join p.subject s "
+        + "where p.subject = :subject "
+        + "and p.token = :token "
+        + "and s.deletedAt is null "
+        + "and s.isDeleted = false")
     boolean existsBySubjectAndToken(Subject subject, String token);
 
+    @Query("select count(p) from Pin p join p.subject s "
+        + "where p.token = :token "
+        + "and s.isDeleted = false "
+        + "and s.deletedAt is null")
     Long countAllByToken(String token);
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/pin/PinService.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/pin/PinService.java
@@ -43,7 +43,7 @@ public class PinService {
     public void deletePinOnSubject(Long subjectId, String token) {
         Subject subject = subjectRepository.findById(subjectId)
             .orElseThrow(() -> new AllcllException(AllcllErrorCode.SUBJECT_NOT_FOUND));
-        Pin pin = pinRepository.findBySubjectAndToken(subject, token)
+        Pin pin = pinRepository.findBySubjectAndTokenToDelete(subject, token)
             .orElseThrow(() -> new AllcllException(AllcllErrorCode.PIN_SUBJECT_MISMATCH));
         pinRepository.deleteById(pin.getId());
     }

--- a/src/main/java/kr/allcll/backend/domain/subject/SubjectRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/SubjectRepository.java
@@ -10,13 +10,11 @@ public interface SubjectRepository extends JpaRepository<Subject, Long>, JpaSpec
 
     @Query("select s from Subject s "
         + "where s.deptCd = :deptCd "
-        + "and s.deletedAt is null "
         + "and s.isDeleted = false")
     List<Subject> findAllByDeptCd(String deptCd);
 
     @Query("select s from Subject s "
         + "where s.id = :id "
-        + "and s.deletedAt is null "
         + "and s.isDeleted = false")
     Optional<Subject> findById(Long id);
 }

--- a/src/main/java/kr/allcll/backend/domain/subject/SubjectRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/SubjectRepository.java
@@ -1,10 +1,22 @@
 package kr.allcll.backend.domain.subject;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SubjectRepository extends JpaRepository<Subject, Long>, JpaSpecificationExecutor<Subject> {
 
+    @Query("select s from Subject s "
+        + "where s.deptCd = :deptCd "
+        + "and s.deletedAt is null "
+        + "and s.isDeleted = false")
     List<Subject> findAllByDeptCd(String deptCd);
+
+    @Query("select s from Subject s "
+        + "where s.id = :id "
+        + "and s.deletedAt is null "
+        + "and s.isDeleted = false")
+    Optional<Subject> findById(Long id);
 }

--- a/src/main/java/kr/allcll/backend/support/entity/BaseEntity.java
+++ b/src/main/java/kr/allcll/backend/support/entity/BaseEntity.java
@@ -10,4 +10,6 @@ public abstract class BaseEntity {
 
     String semesterAt;
     LocalDateTime createdAt;
+    LocalDateTime deletedAt;
+    boolean isDeleted;
 }


### PR DESCRIPTION
## 작업 내용
Subject의 변경이 많은 것으로 파악되어 soft delete를 적용, 해당 설정을 포함하여 쿼리가 적용되었어야 했어요
쿼리들 작성한 pr 입니다.
그리고 과목을 고정해뒀던 pin과 star의 삭제와 같은경우엔 soft delete된(삭제된) 과목이더라도 제거가 되어야하므로 soft delete 설정과 상관없이 쿼리날리도록 해보았습니다.

## 고민 지점과 리뷰 포인트

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->