### PR TITLE
refactor: SeatStorage 클래스 가독성을 개선

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class SeatStorage {
 
-    private final Map<Long, SeatDto> seats;
+    private final Map<Subject, SeatDto> seats;
 
     public SeatStorage() {
         this.seats = new ConcurrentHashMap<>();
@@ -43,12 +43,10 @@ public class SeatStorage {
     }
 
     public void add(SeatDto seatDto) {
-        seats.put(seatDto.getSubject().getId(), seatDto);
+        seats.put(seatDto.getSubject(), seatDto);
     }
 
     public void addAll(List<SeatDto> seatDtos) {
-        for (SeatDto seatDto : seatDtos) {
-            this.seats.put(seatDto.getSubject().getId(), seatDto);
-        }
+        seatDtos.forEach(this::add);
     }
 }

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
@@ -108,7 +108,7 @@ class SeatStorageTest {
     }
 
     @Test
-    @DisplayName("특정 과목의 여석을 반환한다.")
+    @DisplayName("요청한 과목들의 여석을 반환한다.")
     void getSeatsTest() {
         // given
         Subject subject0 = createSubject("정보보호개론", "003278", "001", "유재석");

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
@@ -1,0 +1,155 @@
+package kr.allcll.backend.domain.seat;
+
+import static kr.allcll.backend.fixture.SubjectFixture.createNonMajorSubject;
+import static kr.allcll.backend.fixture.SubjectFixture.createSubject;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import kr.allcll.backend.domain.seat.dto.SeatDto;
+import kr.allcll.backend.domain.subject.Subject;
+import kr.allcll.backend.domain.subject.SubjectRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class SeatStorageTest {
+
+    @Autowired
+    private SeatStorage seatStorage;
+
+    @Autowired
+    private SubjectRepository subjectRepository;
+
+    @AfterEach
+    void tearDown() {
+        seatStorage.clear();
+        subjectRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("동일한 과목의 여석을 저장하면 최근 여석으로 갱신된다.")
+    @Test
+    void addDuplicateSeatTest() {
+        // given
+        Subject subject = createSubject("컴퓨터구조", "003278", "001", "유재석");
+        subjectRepository.save(subject);
+
+        // when
+        SeatDto seatDto = new SeatDto(subject, 10, LocalDateTime.now());
+        seatStorage.add(seatDto);
+        SeatDto updatedSeatDto = new SeatDto(subject, 5, LocalDateTime.now());
+        seatStorage.add(updatedSeatDto);
+
+        // then
+        List<SeatDto> seats = seatStorage.getSeats(List.of(subject));
+        SeatDto seatDto1 = seats.getFirst();
+
+        assertThat(seatDto1.getSeatCount()).isEqualTo(5);
+    }
+
+    /*
+        - 비전공 과목만 조회한다.
+        - limit 개수만큼 조회한다.
+        - 여석이 0인 것은 조회 안된다.
+        - 여석이 적은 것부터 조회한다.
+     */
+    @DisplayName("비전공 과목 여석이 규칙에 맞게 반환된다.")
+    @Test
+    void getNonMajorSeatsTest() {
+        // given
+        Subject subject0 = createSubject("정보보호개론", "003278", "001", "유재석");
+        Subject subject1 = createSubject("컴퓨터구조", "003278", "001", "유재석");
+        Subject subject2 = createSubject("운영체제", "003279", "001", "노홍철");
+        Subject subject3 = createSubject("자료구조", "003280", "001", "하하");
+        Subject subject4 = createSubject("알고리즘", "003281", "001", "길");
+        Subject subject5 = createNonMajorSubject("수요집현강좌", "003278", "002", "정형돈");
+        Subject subject6 = createNonMajorSubject("서양고전강독1", "003279", "002", "나영석");
+        Subject subject7 = createNonMajorSubject("동양고전강독1", "003280", "003", "박명수");
+        Subject subject8 = createNonMajorSubject("채플4", "003281", "004", "전진");
+        Subject subject9 = createNonMajorSubject("일반물리학", "003281", "004", "전진");
+        Subject subject10 = createNonMajorSubject("인공지능컨텐츠", "003281", "004", "전진");
+        subjectRepository.saveAll(
+            List.of(subject0, subject1, subject2, subject3, subject4, subject5, subject6, subject7, subject8, subject9,
+                subject10));
+        SeatDto seatDto1 = new SeatDto(subject0, 8, LocalDateTime.now());
+        SeatDto seatDto2 = new SeatDto(subject1, 7, LocalDateTime.now());
+        SeatDto seatDto3 = new SeatDto(subject2, 6, LocalDateTime.now());
+        SeatDto seatDto4 = new SeatDto(subject3, 5, LocalDateTime.now());
+        SeatDto seatDto5 = new SeatDto(subject4, 4, LocalDateTime.now());
+        SeatDto seatDto6 = new SeatDto(subject5, 3, LocalDateTime.now());
+        SeatDto seatDto7 = new SeatDto(subject6, 2, LocalDateTime.now());
+        SeatDto seatDto8 = new SeatDto(subject7, 1, LocalDateTime.now());
+        SeatDto seatDto9 = new SeatDto(subject8, 0, LocalDateTime.now());
+        SeatDto seatDto10 = new SeatDto(subject9, 2, LocalDateTime.now());
+        SeatDto seatDto11 = new SeatDto(subject10, 1, LocalDateTime.now());
+        seatStorage.addAll(
+            List.of(seatDto1, seatDto2, seatDto3, seatDto4, seatDto5, seatDto6, seatDto7, seatDto8, seatDto9, seatDto10,
+                seatDto11));
+
+        // when
+        int queryLimit = 5;
+        List<SeatDto> seats = seatStorage.getNonMajorSeats(queryLimit);
+
+        // then
+        assertThat(seats).hasSize(queryLimit)
+            .extracting(SeatDto::getSubject, SeatDto::getSeatCount)
+            .containsExactly(
+                tuple(subject7, 1),
+                tuple(subject10, 1),
+                tuple(subject6, 2),
+                tuple(subject9, 2),
+                tuple(subject5, 3)
+            );
+    }
+
+    @DisplayName("특정 과목의 여석을 반환한다.")
+    @Test
+    void getSeatsTest() {
+        // given
+        Subject subject0 = createSubject("정보보호개론", "003278", "001", "유재석");
+        Subject subject1 = createSubject("컴퓨터구조", "003278", "001", "유재석");
+        Subject subject2 = createSubject("운영체제", "003279", "001", "노홍철");
+        Subject subject3 = createSubject("자료구조", "003280", "001", "하하");
+        Subject subject4 = createSubject("알고리즘", "003281", "001", "길");
+        Subject subject5 = createNonMajorSubject("수요집현강좌", "003278", "002", "정형돈");
+        Subject subject6 = createNonMajorSubject("서양고전강독1", "003279", "002", "나영석");
+        Subject subject7 = createNonMajorSubject("동양고전강독1", "003280", "003", "박명수");
+        Subject subject8 = createNonMajorSubject("채플4", "003281", "004", "전진");
+        Subject subject9 = createNonMajorSubject("일반물리학", "003281", "004", "전진");
+        Subject subject10 = createNonMajorSubject("인공지능컨텐츠", "003281", "004", "전진");
+        subjectRepository.saveAll(
+            List.of(subject0, subject1, subject2, subject3, subject4, subject5, subject6, subject7, subject8, subject9,
+                subject10));
+        SeatDto seatDto1 = new SeatDto(subject0, 8, LocalDateTime.now());
+        SeatDto seatDto2 = new SeatDto(subject1, 7, LocalDateTime.now());
+        SeatDto seatDto3 = new SeatDto(subject2, 6, LocalDateTime.now());
+        SeatDto seatDto4 = new SeatDto(subject3, 5, LocalDateTime.now());
+        SeatDto seatDto5 = new SeatDto(subject4, 4, LocalDateTime.now());
+        SeatDto seatDto6 = new SeatDto(subject5, 3, LocalDateTime.now());
+        SeatDto seatDto7 = new SeatDto(subject6, 2, LocalDateTime.now());
+        SeatDto seatDto8 = new SeatDto(subject7, 1, LocalDateTime.now());
+        SeatDto seatDto9 = new SeatDto(subject8, 0, LocalDateTime.now());
+        SeatDto seatDto10 = new SeatDto(subject9, 2, LocalDateTime.now());
+        SeatDto seatDto11 = new SeatDto(subject10, 1, LocalDateTime.now());
+        seatStorage.addAll(
+            List.of(seatDto1, seatDto2, seatDto3, seatDto4, seatDto5, seatDto6, seatDto7, seatDto8, seatDto9, seatDto10,
+                seatDto11));
+
+        // when
+        List<SeatDto> seats = seatStorage.getSeats(List.of(subject0, subject5, subject7));
+
+        // then
+        assertThat(seats).hasSize(3)
+            .extracting(SeatDto::getSubject, SeatDto::getSeatCount)
+            .containsExactly(
+                tuple(subject0, 8),
+                tuple(subject5, 3),
+                tuple(subject7, 1)
+            );
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
@@ -40,16 +40,16 @@ class SeatStorageTest {
         subjectRepository.save(subject);
 
         // when
-        SeatDto seatDto = new SeatDto(subject, 10, LocalDateTime.now());
-        seatStorage.add(seatDto);
+        SeatDto previousSeatDto = new SeatDto(subject, 10, LocalDateTime.now());
+        seatStorage.add(previousSeatDto);
         SeatDto updatedSeatDto = new SeatDto(subject, 5, LocalDateTime.now());
         seatStorage.add(updatedSeatDto);
 
         // then
         List<SeatDto> seats = seatStorage.getSeats(List.of(subject));
-        SeatDto seatDto1 = seats.getFirst();
+        SeatDto resultSeatDto = seats.getFirst();
 
-        assertThat(seatDto1.getSeatCount()).isEqualTo(5);
+        assertThat(resultSeatDto.getSeatCount()).isEqualTo(updatedSeatDto.getSeatCount());
     }
 
     /*

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
@@ -32,8 +32,8 @@ class SeatStorageTest {
         subjectRepository.deleteAllInBatch();
     }
 
-    @DisplayName("동일한 과목의 여석을 저장하면 최근 여석으로 갱신된다.")
     @Test
+    @DisplayName("동일한 과목의 여석을 저장하면 최근 여석으로 갱신된다.")
     void addDuplicateSeatTest() {
         // given
         Subject subject = createSubject("컴퓨터구조", "003278", "001", "유재석");
@@ -58,8 +58,8 @@ class SeatStorageTest {
         - 여석이 0인 것은 조회 안된다.
         - 여석이 적은 것부터 조회한다.
      */
-    @DisplayName("비전공 과목 여석이 규칙에 맞게 반환된다.")
     @Test
+    @DisplayName("비전공 과목 여석이 규칙에 맞게 반환된다.")
     void getNonMajorSeatsTest() {
         // given
         Subject subject0 = createSubject("정보보호개론", "003278", "001", "유재석");
@@ -107,8 +107,8 @@ class SeatStorageTest {
             );
     }
 
-    @DisplayName("특정 과목의 여석을 반환한다.")
     @Test
+    @DisplayName("특정 과목의 여석을 반환한다.")
     void getSeatsTest() {
         // given
         Subject subject0 = createSubject("정보보호개론", "003278", "001", "유재석");

--- a/src/test/java/kr/allcll/backend/fixture/SubjectFixture.java
+++ b/src/test/java/kr/allcll/backend/fixture/SubjectFixture.java
@@ -19,6 +19,21 @@ public class SubjectFixture {
             "", "", "", "", "");
     }
 
+    public static Subject createNonMajorSubject(
+        String subjectName,
+        String subjectCode,
+        String classCode,
+        String professorName
+    ) {
+        return new Subject("", "", "", "",
+            subjectCode, subjectName,
+            "", "", "", "", "", "", "", "",
+            professorName, "", "", "", "", "",
+            "", "대양휴머니티칼리지",
+            classCode, "", "", "", "", "",
+            "", "", "", "", "");
+    }
+
     public static Subject createSubjectWithDepartmentCode(
         String subjectName,
         String subjectCode,


### PR DESCRIPTION
## 작업 내용

SeatStorage 클래스 가독성을 개선합니다. 기존에 없던 테스트도 추가합니다. 

### Map의 key 변경

SeatStorage는 여석을 관리하는 저장소입니다. 내부에 Map<Long, SeatDto> 자료구조를 관리하고 있습니다. 
key로 과목 ID을 사용하고 있는데, Long이라는 자료구조는 과목 ID라는 점을 명시적으로 표현하지 않습니다. 

과목 ID라는 value object를 만들까 고민하던 찰나, key를 Subject.class로 두어도 된다는 사실을 알았습니다. 이 변경으로 인해 외부에 어떠한 전파도 없습니다. 
Subject.class를 key로 쓴다면 주의할 점은 equals와 hashcode인데요. Subject.class는 id값으로 동등성을 비교하기 때문에 문제 없습니다. 

### 존재하지 않는 여석을 조회하는 경우 로깅

getSeats 메서드는 특정 과목의 여석 정보를 조회하는 기능입니다. 만약 SeatStorage가 관리하지 않는 과목의 여석 정보를 요청한다면 어떻게 되어야 할까요? 

예외를 발생할 수 있을 것 같습니다. 하지만 이는 적절하지 않다고 판단했는데요. 10개의 과목 여석을 요청했는데, 1개 과목의 여석 정보가 없는 상황에서 예외를 터뜨리는 게 좋을까요? 우리가 의도한 상황이 아님은 분명하지만 예외를 터뜨린다면, 9개 과목의 여석 정보는 전달하지 못합니다. 예외를 터뜨리진 않은 채로, warn 레벨 로깅 정도만 남기게 했습니다. 모니터링 중에 이 로그가 보인다면 조치가 필요할 것 같아요. 

## 고민 지점과 리뷰 포인트

제안입니다! 로깅 남길 때, 클래스 정보를 포함해서 남기면 어떨까요? 다음과 같이요! 그럼 로그가 어떤 코드 지점에서 발생했는지 파악하기 용이할 것 같습니다. 아래 로그는 스택 트레이스 남기지 않기 때문에 메시지만으로 파악하기 어려울 것 같습니다. 

```java
log.warn("[SeatStorage] 여석 정보가 존재하지 않습니다. subjectId={}, subjectName={}", subject.getId(), subject.getCuriNm());
```