### PR TITLE
refactor: 여석 엔티티에 불필요한 필드 삭제

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/seat/Seat.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/Seat.java
@@ -25,72 +25,11 @@ public class Seat {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private LocalDate createdDate;
-
     @ManyToOne
     @JoinColumn(name = "subject_id")
     private Subject subject;
 
-    private String smtCd;
-    private Integer remainTotRcnt;
-    private Integer totLimitRcnt1;
-    private Integer outLimitRcnt;
-    private String classCode;
-    private Integer totLimitRcnt4;
-    private Integer totLimitRcnt3;
-    private Integer totLimitRcnt2;
-    private String year;
-    private Integer outLimitRcnt2;
-    private Integer outLimitRcnt1;
-    private Integer totRcnt;
-    private String curiNo;
-    private Integer outLimitRcnt4;
-    private Integer outLimitRcnt3;
-    private Integer totLimitRcnt;
-    private Integer remainOtherRcnt;
-    private Integer totOutRcnt;
-    private Integer remainOutRcnt;
-    private String deptCd;
-    private String studentDivNm;
-    private String orgnClsfCd;
-    private String studentDiv;
+    private Integer seatNumber;
 
-    public Seat(LocalDate createdDate, Subject subject, String smtCd, Integer remainTotRcnt, Integer totLimitRcnt1,
-        Integer outLimitRcnt,
-        String classCode, Integer totLimitRcnt4, Integer totLimitRcnt3, Integer totLimitRcnt2, String year,
-        Integer outLimitRcnt2, Integer outLimitRcnt1, Integer totRcnt, String curiNo, Integer outLimitRcnt4,
-        Integer outLimitRcnt3, Integer totLimitRcnt, Integer remainOtherRcnt, Integer totOutRcnt, Integer remainOutRcnt,
-        String deptCd, String studentDivNm, String orgnClsfCd, String studentDiv) {
-        this.createdDate = createdDate;
-        this.subject = subject;
-        this.smtCd = smtCd;
-        this.remainTotRcnt = remainTotRcnt;
-        this.totLimitRcnt1 = totLimitRcnt1;
-        this.outLimitRcnt = outLimitRcnt;
-        this.classCode = classCode;
-        this.totLimitRcnt4 = totLimitRcnt4;
-        this.totLimitRcnt3 = totLimitRcnt3;
-        this.totLimitRcnt2 = totLimitRcnt2;
-        this.year = year;
-        this.outLimitRcnt2 = outLimitRcnt2;
-        this.outLimitRcnt1 = outLimitRcnt1;
-        this.totRcnt = totRcnt;
-        this.curiNo = curiNo;
-        this.outLimitRcnt4 = outLimitRcnt4;
-        this.outLimitRcnt3 = outLimitRcnt3;
-        this.totLimitRcnt = totLimitRcnt;
-        this.remainOtherRcnt = remainOtherRcnt;
-        this.totOutRcnt = totOutRcnt;
-        this.remainOutRcnt = remainOutRcnt;
-        this.deptCd = deptCd;
-        this.studentDivNm = studentDivNm;
-        this.orgnClsfCd = orgnClsfCd;
-        this.studentDiv = studentDiv;
-    }
-
-    public void merge(Seat seat) {
-        id = seat.id;
-        createdDate = seat.createdDate;
-        subject = seat.subject;
-    }
+    private LocalDate createdDate;
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/dto/PreSeatResponse.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/dto/PreSeatResponse.java
@@ -8,6 +8,6 @@ public record PreSeatResponse(
 ) {
 
     public static PreSeatResponse from(Seat seat) {
-        return new PreSeatResponse(seat.getSubject().getId(), Math.max(seat.getTotLimitRcnt() - seat.getTotRcnt(), 0));
+        return new PreSeatResponse(seat.getSubject().getId(), seat.getSeatNumber());
     }
 }


### PR DESCRIPTION
## 작업 내용

### 문제 상황

Seat 테이블에 Subject 테이블의 컬럼이 많이 포함되어 있습니다. 아래 이미지는 Seat 테이블에 존재하는 Subject 테이블의 컬럼입니다. Seat 테이블에는 Subject.id가 이미 존재하는데 아래 컬럼이 존재하는 것이 이상했습니다. 

<img width="563" alt="스크린샷 2025-03-27 오후 8 06 43" src="https://github.com/user-attachments/assets/0ab81b31-64c7-4262-8121-a8fcad6a9444" />

왜 이런 테이블이 만들어졌을까 고민해 보았고, 여석 API의 응답을 그대로 테이블로 만들었다는 사실을 알았습니다. 아래는 여석 API 응답의 일부입니다. 

```json
{
  "SMT_CD": "21",
  "REMAIN_TOT_RCNT": 123,
  "TOT_LIMIT_RCNT_1": 0,
  "OUT_LIMIT_RCNT": 0,
  "CLASS": "001",
  "TOT_LIMIT_RCNT_4": 0,
  "TOT_LIMIT_RCNT_3": 0,
  "TOT_LIMIT_RCNT_2": 0,
  "RCNT": 1,
  "YEAR": "2024",
  "OUT_LIMIT_RCNT_2": 0,
  "OUT_LIMIT_RCNT_1": 0,
  "TOT_RCNT": 77,
  "STUDENT_DIV_NM": "본교생",
  "STUDENT_DEPT_CD_NM": "교육학과",
  "CURI_NO": "011183",
  "OUT_LIMIT_RCNT_4": 0,
  "OUT_LIMIT_RCNT_3": 0,
  "TOT_LIMIT_RCNT": 200,
  "REMAIN_OTHER_RCNT": 123,
  "TOT_OUT_RCNT": 76,
  "REMAIN_OUT_RCNT": 0,
  "DEPT_CD": "9005",
  "STUDENT_DEPT_CD": "2114",
  "ORGN_CLSF_CD": "20",
  "STUDENT_DIV": "10"
}
```

### 고민 

Subject 테이블와 중복된 컬럼은 모두 삭제했습니다. 이로 인한 영향이 외부로 전파되지 않아서 삭제해도 문제 없습니다. 
다음은 여석과 관련된 필드들인데요. 아래 친구들을 어떻게 할지 고민했습니다. 백엔드 서버 코드에 노출할지 말지에 대해 수민님과 오프라인으로 논의했고, 해당 필드는 크롤러 서버에서 관리하기로 합의했습니다. 대신에 seatNumber 필드를 추가하여 여석 숫자 컬럼을 포함했습니다. 

```java
private Integer totLimitRcnt4;
private Integer totLimitRcnt3;
private Integer totLimitRcnt2;
private Integer totLimitRcnt1;
private Integer totLimitRcnt;
private Integer outLimitRcnt4;
private Integer outLimitRcnt3;
private Integer outLimitRcnt2;
private Integer outLimitRcnt1;
private Integer outLimitRcnt;
private Integer totOutRcnt;
private Integer totRcnt;
private Integer remainOtherRcnt;
private Integer remainTotRcnt;
private Integer remainOutRcnt;
```

오프라인 논의 사항을 기록차 좀더 남겨보자면, 위 필드는 크롤러 서버 코드에 남기기로 했습니다. 위 필드를 Seat과 별도의 필드로 분리하기로 했습니다. 
Seat의 seatNumber 필드는 조회한 날짜에 여석 데이터를 의미하는데, 이것은 특정 로직에 결정됩니다. 이 로직도 크롤러 서버에서 관리하기로 했습니다. 