### PR TITLE
refactor: 스케줄링 4가지 개선(스레드풀 관리, 모니터링, 제어, 테스트에서 영향)

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/AdminApi.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminApi.java
@@ -17,7 +17,7 @@ public class AdminApi {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/api/admin/schedule/cancel")
+    @PostMapping("/api/admin/scheduler/cancel")
     public ResponseEntity<Void> cancelScheduling() {
         adminService.cancelScheduling();
         return ResponseEntity.ok().build();

--- a/src/main/java/kr/allcll/backend/admin/AdminApi.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminApi.java
@@ -1,0 +1,25 @@
+package kr.allcll.backend.admin;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminApi {
+
+    private final AdminService adminService;
+
+    @PostMapping("/api/admin/scheduler/start")
+    public ResponseEntity<Void> startScheduling() {
+        adminService.startScheduling();
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/api/admin/schedule/cancel")
+    public ResponseEntity<Void> cancelScheduling() {
+        adminService.cancelScheduling();
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/kr/allcll/backend/admin/AdminService.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminService.java
@@ -1,0 +1,20 @@
+package kr.allcll.backend.admin;
+
+import kr.allcll.backend.domain.seat.GeneralSeatSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final GeneralSeatSender generalSeatSender;
+
+    public void startScheduling() {
+        generalSeatSender.send();
+    }
+
+    public void cancelScheduling() {
+        generalSeatSender.cancel();
+    }
+}

--- a/src/main/java/kr/allcll/backend/config/ScheduleConfig.java
+++ b/src/main/java/kr/allcll/backend/config/ScheduleConfig.java
@@ -1,6 +1,8 @@
 package kr.allcll.backend.config;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import io.micrometer.core.instrument.MeterRegistry;
+import kr.allcll.backend.support.schedule.ScheduledTaskHandler;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -8,7 +10,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableScheduling
-@ConditionalOnProperty(name = "app.scheduling.enabled", havingValue = "true", matchIfMissing = true)
 public class ScheduleConfig {
 
     @Bean
@@ -21,5 +22,11 @@ public class ScheduleConfig {
         scheduler.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
         scheduler.initialize();
         return scheduler;
+    }
+
+    @Bean
+    @Qualifier("generalSeatTaskHandler")
+    public ScheduledTaskHandler generalSeatTaskHandler(MeterRegistry meterRegistry) {
+        return new ScheduledTaskHandler(2, "general-seat-sender", meterRegistry);
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
@@ -1,0 +1,52 @@
+package kr.allcll.backend.domain.seat;
+
+import java.time.Duration;
+import java.util.List;
+import kr.allcll.backend.domain.seat.dto.SeatDto;
+import kr.allcll.backend.domain.seat.dto.SeatsResponse;
+import kr.allcll.backend.support.schedule.ScheduledTaskHandler;
+import kr.allcll.backend.support.sse.SseService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class GeneralSeatSender {
+
+    private static final String NON_MAJOR_SEATS_EVENT_NAME = "nonMajorSeats";
+    private static final int NON_MAJOR_SUBJECT_QUERY_LIMIT = 20;
+    private static final Duration SENDING_PERIOD = Duration.ofSeconds(1);
+
+    private final SseService sseService;
+    private final SeatStorage seatStorage;
+    private final ScheduledTaskHandler scheduledTaskHandler;
+
+    public GeneralSeatSender(
+        SseService sseService,
+        SeatStorage seatStorage,
+        @Qualifier("generalSeatTaskHandler") ScheduledTaskHandler scheduledTaskHandler
+    ) {
+        this.sseService = sseService;
+        this.seatStorage = seatStorage;
+        this.scheduledTaskHandler = scheduledTaskHandler;
+    }
+
+    public void send() {
+        if (scheduledTaskHandler.getTaskCount() > 0) {
+            return;
+        }
+        scheduledTaskHandler.scheduleAtFixedRate(getNonMajorSeatTask(), SENDING_PERIOD);
+    }
+
+    public void cancel() {
+        scheduledTaskHandler.cancelAll();
+    }
+
+    private Runnable getNonMajorSeatTask() {
+        return () -> {
+            List<SeatDto> nonMajorSeats = seatStorage.getNonMajorSeats(NON_MAJOR_SUBJECT_QUERY_LIMIT);
+            sseService.propagate(NON_MAJOR_SEATS_EVENT_NAME, SeatsResponse.from(nonMajorSeats));
+        };
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
@@ -14,8 +14,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class GeneralSeatSender {
 
-    private static final String NON_MAJOR_SEATS_EVENT_NAME = "nonMajorSeats";
-    private static final int NON_MAJOR_SUBJECT_QUERY_LIMIT = 20;
+    private static final String EVENT_NAME = "nonMajorSeats";
+    private static final int QUERY_LIMIT = 20;
     private static final Duration SENDING_PERIOD = Duration.ofSeconds(1);
 
     private final SseService sseService;
@@ -36,17 +36,17 @@ public class GeneralSeatSender {
         if (scheduledTaskHandler.getTaskCount() > 0) {
             return;
         }
-        scheduledTaskHandler.scheduleAtFixedRate(getNonMajorSeatTask(), SENDING_PERIOD);
+        scheduledTaskHandler.scheduleAtFixedRate(getGeneralSeatTask(), SENDING_PERIOD);
     }
 
     public void cancel() {
         scheduledTaskHandler.cancelAll();
     }
 
-    private Runnable getNonMajorSeatTask() {
+    private Runnable getGeneralSeatTask() {
         return () -> {
-            List<SeatDto> nonMajorSeats = seatStorage.getNonMajorSeats(NON_MAJOR_SUBJECT_QUERY_LIMIT);
-            sseService.propagate(NON_MAJOR_SEATS_EVENT_NAME, SeatsResponse.from(nonMajorSeats));
+            List<SeatDto> generalSeats = seatStorage.getGeneralSeats(QUERY_LIMIT);
+            sseService.propagate(EVENT_NAME, SeatsResponse.from(generalSeats));
         };
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
@@ -9,7 +9,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import kr.allcll.backend.domain.seat.dto.PreSeatsResponse;
 import kr.allcll.backend.domain.seat.dto.SeatDto;
-import kr.allcll.backend.domain.seat.dto.SeatsResponse;
 import kr.allcll.backend.domain.seat.pin.Pin;
 import kr.allcll.backend.domain.seat.pin.PinRepository;
 import kr.allcll.backend.domain.seat.pin.dto.PinSeatsResponse;
@@ -17,7 +16,6 @@ import kr.allcll.backend.domain.subject.Subject;
 import kr.allcll.backend.support.sse.SseService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 
@@ -26,9 +24,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SeatService {
 
-    private static final String NON_MAJOR_SEATS_EVENT_NAME = "nonMajorSeats";
     private static final String PIN_EVENT_NAME = "pinSeats";
-    private static final int NON_MAJOR_SUBJECT_QUERY_LIMIT = 20;
     private static final int TASK_DURATION = 1000;
     private static final int TASK_PERIOD = 60000;
 
@@ -38,12 +34,6 @@ public class SeatService {
     private final SeatRepository seatRepository;
     private final ThreadPoolTaskScheduler scheduler;
     private final Map<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
-
-    @Scheduled(fixedRate = 1000)
-    public void sendNonMajorSeats() {
-        List<SeatDto> nonMajorSeatDtos = seatStorage.getNonMajorSeats(NON_MAJOR_SUBJECT_QUERY_LIMIT);
-        sseService.propagate(NON_MAJOR_SEATS_EVENT_NAME, SeatsResponse.from(nonMajorSeatDtos));
-    }
 
     public void sendPinSeatsInformation(String token) {
         if (scheduledTasks.containsKey(token)) {

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
@@ -22,7 +22,7 @@ public class SeatStorage {
         this.seats = new ConcurrentHashMap<>();
     }
 
-    public List<SeatDto> getNonMajorSeats(int limit) {
+    public List<SeatDto> getGeneralSeats(int limit) {
         Collection<SeatDto> seatsValue = seats.values();
         return seatsValue.stream()
             .filter(seat -> seat.getSubject().isNonMajor())

--- a/src/main/java/kr/allcll/backend/support/schedule/ScheduledTaskHandler.java
+++ b/src/main/java/kr/allcll/backend/support/schedule/ScheduledTaskHandler.java
@@ -38,7 +38,7 @@ public class ScheduledTaskHandler {
             }
         };
 
-        ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(wrappedTask, period);
+        ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(wrappedTask, period);
 
         tasks.put(taskId, future);
         statuses.put(taskId, running);

--- a/src/main/java/kr/allcll/backend/support/schedule/ScheduledTaskHandler.java
+++ b/src/main/java/kr/allcll/backend/support/schedule/ScheduledTaskHandler.java
@@ -1,0 +1,70 @@
+package kr.allcll.backend.support.schedule;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Slf4j
+public class ScheduledTaskHandler {
+
+    private final ThreadPoolTaskScheduler scheduler;
+    private final Map<String, ScheduledFuture<?>> tasks = new ConcurrentHashMap<>();
+    private final Map<String, AtomicBoolean> statuses = new ConcurrentHashMap<>();
+
+    public ScheduledTaskHandler(int poolSize, String namePrefix, MeterRegistry meterRegistry) {
+        scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(poolSize);
+        scheduler.setThreadNamePrefix(namePrefix);
+        scheduler.initialize();
+        scheduler.setRemoveOnCancelPolicy(true);
+
+        ExecutorServiceMetrics.monitor(meterRegistry, scheduler.getScheduledExecutor(), namePrefix);
+    }
+
+    public String scheduleAtFixedRate(Runnable task, Duration period) {
+        String taskId = UUID.randomUUID().toString();
+        AtomicBoolean running = new AtomicBoolean(true);
+
+        Runnable wrappedTask = () -> {
+            if (running.get()) {
+                task.run();
+            }
+        };
+
+        ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(wrappedTask, period);
+
+        tasks.put(taskId, future);
+        statuses.put(taskId, running);
+        return taskId;
+    }
+
+    public void cancel(String taskId) {
+        ScheduledFuture<?> future = tasks.remove(taskId);
+        if (future != null) {
+            future.cancel(true);
+        }
+        statuses.remove(taskId);
+    }
+
+    public void cancelAll() {
+        tasks.values().forEach(f -> f.cancel(true));
+        tasks.clear();
+        statuses.clear();
+    }
+
+    public boolean isRunning(String taskId) {
+        AtomicBoolean running = statuses.get(taskId);
+        return running != null && running.get();
+    }
+
+    public int getTaskCount() {
+        return tasks.size();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -32,8 +32,6 @@ logging:
           sse: debug
 
 app:
-  scheduling:
-    enabled: true
   runner:
     enabled: true
 

--- a/src/test/java/kr/allcll/backend/domain/seat/GeneralSeatSenderTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/GeneralSeatSenderTest.java
@@ -1,0 +1,83 @@
+package kr.allcll.backend.domain.seat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.verify;
+
+import kr.allcll.backend.support.sse.SseService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class GeneralSeatSenderTest {
+
+    @MockitoBean
+    private SseService sseService;
+
+    @Autowired
+    private GeneralSeatSender generalSeatSender;
+
+    @AfterEach
+    void tearDown() {
+        generalSeatSender.cancel();
+    }
+
+    @Test
+    @DisplayName("교양 여석을 전송한다.")
+    void sendTest() throws InterruptedException {
+        // when
+        generalSeatSender.send();
+        Thread.sleep(1000); // wait for period
+
+        // then
+        verify(sseService, atLeastOnce()).propagate(any(), any());
+    }
+
+    @Test
+    @DisplayName("5초 동안 1초 간격으로 교양 여석을 전송한다.")
+    void sendPeriodicallyTest() throws InterruptedException {
+        // given
+        int period = 5;
+
+        // when
+        generalSeatSender.send();
+        Thread.sleep(period * 1000); // wait for period
+        generalSeatSender.cancel();
+        Thread.sleep(1000); // wait for cancel
+
+        // then
+        verify(sseService, atLeast(period)).propagate(any(), any());
+    }
+
+    @Test
+    @DisplayName("교양 여석 전송을 취소한다.")
+    void cancelTest() throws InterruptedException {
+        // given
+        generalSeatSender.send();
+
+        // when
+        generalSeatSender.cancel();
+        Thread.sleep(1000); // wait for cancel
+        int previousCalls = getMethodCallCount(sseService, "propagate");
+        Thread.sleep(2000); // wait for no more calls
+
+        // then
+        int afterCancelCalls = getMethodCallCount(sseService, "propagate");
+        assertThat(afterCancelCalls).isEqualTo(previousCalls);
+    }
+
+    private int getMethodCallCount(Object object, String methodName) {
+        return mockingDetails(object).getInvocations().stream()
+            .filter(invocation -> invocation.getMethod().getName().equals(methodName))
+            .mapToInt(invocation -> 1)
+            .sum();
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatServiceTest.java
@@ -23,10 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties = "app.scheduling.enabled=true") // 테스트에서 스케줄러 활성화
 class SeatServiceTest {
 
     private static final Logger log = LoggerFactory.getLogger(SeatServiceTest.class);

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
@@ -60,7 +60,7 @@ class SeatStorageTest {
      */
     @Test
     @DisplayName("비전공 과목 여석이 규칙에 맞게 반환된다.")
-    void getNonMajorSeatsTest() {
+    void getGeneralSeatsTest() {
         // given
         Subject subject0 = createSubject("정보보호개론", "003278", "001", "유재석");
         Subject subject1 = createSubject("컴퓨터구조", "003278", "001", "유재석");
@@ -93,7 +93,7 @@ class SeatStorageTest {
 
         // when
         int queryLimit = 5;
-        List<SeatDto> seats = seatStorage.getNonMajorSeats(queryLimit);
+        List<SeatDto> seats = seatStorage.getGeneralSeats(queryLimit);
 
         // then
         assertThat(seats).hasSize(queryLimit)

--- a/src/test/java/kr/allcll/backend/support/schedule/ScheduledTaskHandlerTest.java
+++ b/src/test/java/kr/allcll/backend/support/schedule/ScheduledTaskHandlerTest.java
@@ -1,0 +1,155 @@
+package kr.allcll.backend.support.schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ScheduledTaskHandlerTest {
+
+    @Test
+    @DisplayName("스케줄링 작업을 등록한다.")
+    void scheduledTask() {
+        // given
+        int poolSize = 1;
+        ScheduledTaskHandler scheduledTaskHandler = new ScheduledTaskHandler(
+            poolSize,
+            "test-task",
+            new LoggingMeterRegistry()
+        );
+
+        // when
+        AtomicInteger counter = new AtomicInteger();
+        scheduleTask(scheduledTaskHandler, counter);
+
+        // then
+        assertThat(scheduledTaskHandler.getTaskCount()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("10개의 작업을 스케줄링에 등록한다.")
+    void scheduleManyTask() {
+        // given
+        int taskCount = 10;
+        int poolSize = 10;
+        ScheduledTaskHandler scheduledTaskHandler = new ScheduledTaskHandler(
+            poolSize,
+            "test-task",
+            new LoggingMeterRegistry()
+        );
+
+        // when
+        AtomicInteger counter = new AtomicInteger();
+        for (int i = 0; i < taskCount; i++) {
+            scheduleTask(scheduledTaskHandler, counter);
+        }
+
+        // then
+        assertThat(scheduledTaskHandler.getTaskCount()).isGreaterThanOrEqualTo(taskCount);
+    }
+
+    @Test
+    @DisplayName("스케줄링을 취소하면 작업이 중지된다.")
+    void cancel1() {
+        // given
+        int poolSize = 1;
+        ScheduledTaskHandler scheduledTaskHandler = new ScheduledTaskHandler(
+            poolSize,
+            "test-task",
+            new LoggingMeterRegistry()
+        );
+
+        // when
+        AtomicInteger counter = new AtomicInteger();
+        String taskId = scheduleTask(scheduledTaskHandler, counter);
+
+        assertThat(scheduledTaskHandler.getTaskCount()).isEqualTo(1);
+        assertThat(scheduledTaskHandler.isRunning(taskId)).isTrue();
+
+        scheduledTaskHandler.cancel(taskId);
+
+        int previousCount = counter.get();
+
+        // then
+        await()
+            .atMost(Duration.ofSeconds(1))
+            .untilAsserted(() -> {
+                assertThat(scheduledTaskHandler.getTaskCount()).isEqualTo(0);
+                assertThat(scheduledTaskHandler.isRunning(taskId)).isFalse();
+            });
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        assertThat(counter.get()).isGreaterThanOrEqualTo(previousCount);
+    }
+
+    @Test
+    @DisplayName("2개의 스케줄링 작업 중 1개를 취소한다.")
+    void cancel() {
+        // given
+        int poolSize = 1;
+        ScheduledTaskHandler scheduledTaskHandler = new ScheduledTaskHandler(
+            poolSize,
+            "test-task",
+            new LoggingMeterRegistry()
+        );
+
+        // when
+        AtomicInteger counter = new AtomicInteger();
+        String taskId1 = scheduleTask(scheduledTaskHandler, counter);
+        String taskId2 = scheduleTask(scheduledTaskHandler, counter);
+
+        assertThat(scheduledTaskHandler.getTaskCount()).isEqualTo(2);
+
+        scheduledTaskHandler.cancel(taskId2);
+
+        // then
+        await()
+            .atMost(Duration.ofSeconds(1))
+            .untilAsserted(() -> {
+                assertThat(scheduledTaskHandler.getTaskCount()).isEqualTo(1);
+                assertThat(scheduledTaskHandler.isRunning(taskId1)).isTrue();
+                assertThat(scheduledTaskHandler.isRunning(taskId2)).isFalse();
+            });
+    }
+
+    @Test
+    @DisplayName("모든 작업을 중지한다.")
+    void cancelAllScheduler() {
+        // given
+        int taskCount = 10;
+        int poolSize = 10;
+        ScheduledTaskHandler scheduledTaskHandler = new ScheduledTaskHandler(
+            poolSize,
+            "test-task",
+            new LoggingMeterRegistry()
+        );
+
+        // when
+        AtomicInteger counter = new AtomicInteger();
+        for (int i = 0; i < taskCount; i++) {
+            scheduleTask(scheduledTaskHandler, counter);
+        }
+
+        scheduledTaskHandler.cancelAll();
+
+        // then
+        await()
+            .atMost(Duration.ofSeconds(1))
+            .untilAsserted(() -> assertThat(scheduledTaskHandler.getTaskCount()).isEqualTo(0));
+    }
+
+    private String scheduleTask(ScheduledTaskHandler scheduledTaskHandler, AtomicInteger counter) {
+        return scheduledTaskHandler.scheduleAtFixedRate(
+            () -> System.out.println("Task is running: " + counter.incrementAndGet()),
+            Duration.ofSeconds(1)
+        );
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/sse/SseServiceTest.java
+++ b/src/test/java/kr/allcll/backend/support/sse/SseServiceTest.java
@@ -17,11 +17,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties = "app.scheduling.enabled=false") // 테스트에서 스케줄러 비활성화
 class SseServiceTest {
 
     private static final Logger log = LoggerFactory.getLogger(SseServiceTest.class);


### PR DESCRIPTION
## 작업 내용

스케줄링을 개선하는 작업을 진행했습니다. 스케줄링 개선은 4가지 목표를 갖고 진행했습니다. 
1. 스케줄링 작업마다 별도의 스레드 풀로 관리합니다. (ex. 교양 스케줄링 따로, 전공 스케줄링 따로)
2. 스케줄링 모니터링합니다. 
3. 스케줄링 작업을 제어할 수 있어야 합니다. 
4. 스케줄링이 다른 테스트에 영향을 주면 안됩니다. 

위 목적은 ScheduledTaskHandler.java 클래스를 만들어서 달성했습니다. 그리고 ScheduledTaskHandler.java를 사용해서 교양 스케줄링을 개선해 보았습니다. 
보다가 이해 안되는 부분이 있다면 편하게 물어봐 주세요~~ 😀 

### 1. 스케줄링 작업마다 별도의 스레드 풀로 관리

ScheduledTaskHandler.java 필드와 생성자로 스레드 풀의 크기와 이름을 지정할 수 있습니다. 

```java
public class ScheduledTaskHandler {

    private final ThreadPoolTaskScheduler scheduler;

    ...

    public ScheduledTaskHandler(int poolSize, String namePrefix, MeterRegistry meterRegistry) {
        scheduler = new ThreadPoolTaskScheduler();
        scheduler.setPoolSize(poolSize);
        scheduler.setThreadNamePrefix(namePrefix);
        scheduler.initialize();
        scheduler.setRemoveOnCancelPolicy(true);

        ...
    }
```

### 2. 스케줄링 모니터링

위 코드에서 볼 수 있듯이 생성자에서 MeterRegistry를 주입 받아서 스케줄링을 모니터링합니다. MeterRegistry은 마이크로미터의 api인데, 이걸로 메트릭을 수집할 수 있습니다. 
물론, 아직은 완전히 모니터링할 수 없습니다. 어떤 것을 모니터링해야 하는지 등에 대한 정의는 다른 pr에서 다룰 예정입니다. 메트릭 수집을 위한 여지를 만들었다고 이해해 주시면 감사하겠습니다. 

### 3. 스케줄링 작업을 제어

ScheduledTaskHandler.java 클래스 내부 필드에 tasks와 statuses를 두었습니다. 그리고 cancel, cancelAll, isRunning, getTaskCount 메서드로 스케줄링 작업을 제어할 수 있습니다. 

```java
public class ScheduledTaskHandler {

    ...
    private final Map<String, ScheduledFuture<?>> tasks = new ConcurrentHashMap<>();
    private final Map<String, AtomicBoolean> statuses = new ConcurrentHashMap<>();

    ...

    public void cancel(String taskId) {
        ScheduledFuture<?> future = tasks.remove(taskId);
        if (future != null) {
            future.cancel(true);
        }
        statuses.remove(taskId);
    }

    public void cancelAll() {
        tasks.values().forEach(f -> f.cancel(true));
        tasks.clear();
        statuses.clear();
    }

    public boolean isRunning(String taskId) {
        AtomicBoolean running = statuses.get(taskId);
        return running != null && running.get();
    }

    public int getTaskCount() {
        return tasks.size();
    }
}
```

### 4. 스케줄링이 다른 테스트에 영향을 주면 안됩니다. 

ScheduledTaskHandler.java로 스케줄링이 제어 가능한 상태가 되어, 더이상 다른 테스트에 영향을 주지 않습니다. 
이전에 스케줄링이 다른 테스트에 영향을 준 사례로, `@Scheduled` 어노테이션으로 SSE를 발생하면 sseServiceTest에 영향을 주었습니다. 
이때에는 `@ConditionalOnProperty(name = "app.scheduling.enabled", havingValue = "true", matchIfMissing = true)`로 제어를 했었는데, 이것은 유지보수가 어려운 방식이었습니다. 
이제 스케줄링이 제어 가능해져, `@ConditionalOnProperty` 어노테이션을 모두 제거했습니다. 


## 고민 지점과 리뷰 포인트

- 아직 스케줄링을 제어하는 api를 만들지 않았습니다. 어드민 쪽에 만들어야 하는데, 논의가 필요할 것 같아서 만들지 않았어요. 
- 테스트로 스케줄링이 제어됨을 확실히 확인했는데, 개발 환경에서 실제로 제어가 되는지 보면 좋을 것 같아요. 그럼 제어 api가 필요해요. 
- 기존에는 `@Scheduled`를 사용해서 애플리케이션이 실행되면 자동으로 스케줄링을 시작했어요. 지금은 자동으로 실행되지 않는 것이 디폴트에요. 