### PR TITLE
refactor: 핀과목 여석을 sse로 전송하는 코드 개선

### DIFF
--- a/src/main/java/kr/allcll/backend/config/ScheduleConfig.java
+++ b/src/main/java/kr/allcll/backend/config/ScheduleConfig.java
@@ -6,27 +6,20 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableScheduling
 public class ScheduleConfig {
 
     @Bean
-    public ThreadPoolTaskScheduler threadPoolTaskScheduler() {
-        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        scheduler.setThreadNamePrefix("pin-subjects-sent-scheduler");
-        scheduler.setPoolSize(20);
-        scheduler.setAwaitTerminationSeconds(15);
-        scheduler.setRemoveOnCancelPolicy(true);
-        scheduler.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-        scheduler.initialize();
-        return scheduler;
-    }
-
-    @Bean
     @Qualifier("generalSeatTaskHandler")
     public ScheduledTaskHandler generalSeatTaskHandler(MeterRegistry meterRegistry) {
         return new ScheduledTaskHandler(2, "general-seat-sender", meterRegistry);
+    }
+
+    @Bean
+    @Qualifier("pinSeatTaskHandler")
+    public ScheduledTaskHandler pinSeatTaskHandler(MeterRegistry meterRegistry) {
+        return new ScheduledTaskHandler(20, "pin-seat-sender", meterRegistry);
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/PinSeatSender.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/PinSeatSender.java
@@ -1,0 +1,58 @@
+package kr.allcll.backend.domain.seat;
+
+import java.time.Duration;
+import java.util.List;
+import kr.allcll.backend.domain.seat.dto.SeatDto;
+import kr.allcll.backend.domain.seat.pin.Pin;
+import kr.allcll.backend.domain.seat.pin.PinRepository;
+import kr.allcll.backend.domain.seat.pin.dto.PinSeatsResponse;
+import kr.allcll.backend.domain.subject.Subject;
+import kr.allcll.backend.support.schedule.ScheduledTaskHandler;
+import kr.allcll.backend.support.sse.SseService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PinSeatSender {
+
+    private static final String PIN_EVENT_NAME = "pinSeats";
+    private static final int TASK_DURATION = 1000;
+
+    private final SseService sseService;
+    private final SeatStorage seatStorage;
+    private final PinRepository pinRepository;
+    private final ScheduledTaskHandler scheduledTaskHandler;
+
+    public PinSeatSender(
+        SseService sseService,
+        SeatStorage seatStorage,
+        PinRepository pinRepository,
+        @Qualifier("pinSeatTaskHandler") ScheduledTaskHandler scheduledTaskHandler
+    ) {
+        this.sseService = sseService;
+        this.seatStorage = seatStorage;
+        this.pinRepository = pinRepository;
+        this.scheduledTaskHandler = scheduledTaskHandler;
+    }
+
+    public void send(String token) {
+        scheduledTaskHandler.scheduleAtFixedRate(token, getMajorSeatTask(token), Duration.ofMillis(TASK_DURATION));
+    }
+
+    private Runnable getMajorSeatTask(String token) {
+        return () -> {
+            if (sseService.isDisconnected(token)) {
+                scheduledTaskHandler.cancel(token);
+                return;
+            }
+            List<Pin> pins = pinRepository.findAllByToken(token);
+            List<Subject> subjects = pins.stream()
+                .map(Pin::getSubject)
+                .toList();
+            List<SeatDto> pinSeats = seatStorage.getSeats(subjects);
+            sseService.propagate(token, PIN_EVENT_NAME, PinSeatsResponse.from(pinSeats));
+        };
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
@@ -1,22 +1,10 @@
 package kr.allcll.backend.domain.seat;
 
-import java.time.Duration;
 import java.time.LocalDate;
-import java.util.Date;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledFuture;
 import kr.allcll.backend.domain.seat.dto.PreSeatsResponse;
-import kr.allcll.backend.domain.seat.dto.SeatDto;
-import kr.allcll.backend.domain.seat.pin.Pin;
-import kr.allcll.backend.domain.seat.pin.PinRepository;
-import kr.allcll.backend.domain.seat.pin.dto.PinSeatsResponse;
-import kr.allcll.backend.domain.subject.Subject;
-import kr.allcll.backend.support.sse.SseService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -24,42 +12,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SeatService {
 
-    private static final String PIN_EVENT_NAME = "pinSeats";
-    private static final int TASK_DURATION = 1000;
-    private static final int TASK_PERIOD = 60000;
-
-    private final SseService sseService;
-    private final SeatStorage seatStorage;
-    private final PinRepository pinRepository;
     private final SeatRepository seatRepository;
-    private final ThreadPoolTaskScheduler scheduler;
-    private final Map<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
-
-    public void sendPinSeatsInformation(String token) {
-        if (scheduledTasks.containsKey(token)) {
-            log.info("토큰 {} 에 대해 이미 스케줄된 작업이 존재합니다.", token);
-            return;
-        }
-
-        Runnable task = () -> {
-            List<Pin> pins = pinRepository.findAllByToken(token);
-            List<Subject> subjects = pins.stream()
-                .map(Pin::getSubject)
-                .toList();
-            List<SeatDto> pinSeatDtos = seatStorage.getSeats(subjects);
-            sseService.propagate(token, PIN_EVENT_NAME, PinSeatsResponse.from(pinSeatDtos));
-        };
-
-        ScheduledFuture<?> scheduledFuture = scheduler.scheduleAtFixedRate(task, Duration.ofMillis(TASK_DURATION));
-        scheduledTasks.put(token, scheduledFuture);
-
-        scheduler.schedule(() -> {
-                log.info("토큰 {}: 태스크 종료", token);
-                scheduledFuture.cancel(true);
-                scheduledTasks.remove(token);
-            },
-            new Date(System.currentTimeMillis() + TASK_PERIOD));
-    }
 
     public PreSeatsResponse getAllPreSeats() {
         List<Seat> allByCreatedDate = seatRepository.findAllByCreatedDate((LocalDate.of(2025, 2, 28)));

--- a/src/main/java/kr/allcll/backend/support/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/allcll/backend/support/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 
 @Slf4j
 @RestControllerAdvice
@@ -36,6 +37,19 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleServletException(HttpServletRequest request, ServletException e) {
         log.warn(LOG_FORMAT, request.getMethod(), request.getRequestURI(), getRequestBody(request), e.getMessage());
         return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handleAsyncRequestTimeoutException(
+        HttpServletRequest request,
+        AsyncRequestTimeoutException e
+    ) {
+        if (request.getHeader("ALLCLL-SSE-CONNECT") != null) {
+            log.info(LOG_FORMAT, request.getMethod(), request.getRequestURI(), e.getMessage(),
+                "SSE connection timed out");
+            return ResponseEntity.noContent().build();
+        }
+        return handleException(request, e);
     }
 
     @ExceptionHandler

--- a/src/main/java/kr/allcll/backend/support/schedule/ScheduledTaskHandler.java
+++ b/src/main/java/kr/allcll/backend/support/schedule/ScheduledTaskHandler.java
@@ -32,6 +32,10 @@ public class ScheduledTaskHandler {
     }
 
     public String scheduleAtFixedRate(String taskId, Runnable task, Duration period) {
+        if (tasks.containsKey(taskId)) {
+            log.warn("[ScheduledTaskHandler] Task ID {} 은 이미 스케줄러에 등록되어 있습니다.", taskId);
+            return taskId;
+        }
         ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(task, period);
         tasks.put(taskId, future);
         return taskId;

--- a/src/main/java/kr/allcll/backend/support/sse/SseApi.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseApi.java
@@ -1,7 +1,7 @@
 package kr.allcll.backend.support.sse;
 
+import kr.allcll.backend.domain.seat.PinSeatSender;
 import kr.allcll.backend.support.web.ThreadLocalHolder;
-import kr.allcll.backend.domain.seat.SeatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -14,13 +14,13 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class SseApi {
 
     private final SseService sseService;
-    private final SeatService seatService;
+    private final PinSeatSender pinSeatSender;
 
     @GetMapping(value = "/api/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> getServerSentEventConnection() {
         String token = ThreadLocalHolder.SHARED_TOKEN.get();
         SseEmitter emitter = sseService.connect(token);
-        seatService.sendPinSeatsInformation(token);
+        pinSeatSender.send(token);
         return ResponseEntity.ok()
             .header("X-Accel-Buffering", "no")
             .body(emitter);

--- a/src/main/java/kr/allcll/backend/support/sse/SseService.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseService.java
@@ -47,4 +47,8 @@ public class SseService {
             SseErrorHandler.handle(e);
         }
     }
+
+    public boolean isDisconnected(String token) {
+        return sseEmitterStorage.getEmitter(token).isEmpty();
+    }
 }

--- a/src/test/java/kr/allcll/backend/domain/seat/PinSeatSenderTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/PinSeatSenderTest.java
@@ -1,0 +1,75 @@
+package kr.allcll.backend.domain.seat;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import kr.allcll.backend.domain.seat.pin.PinRepository;
+import kr.allcll.backend.support.schedule.ScheduledTaskHandler;
+import kr.allcll.backend.support.sse.SseService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class PinSeatSenderTest {
+
+    @MockitoBean
+    private SseService sseService;
+
+    @MockitoBean
+    private SeatStorage seatStorage;
+
+    @MockitoBean
+    private PinRepository pinRepository;
+
+    @MockitoSpyBean
+    @Qualifier("pinSeatTaskHandler")
+    private ScheduledTaskHandler scheduledTaskHandler;
+
+    @Autowired
+    private PinSeatSender pinSeatSender;
+
+    @Test
+    @DisplayName("핀 과목 여석을 전송한다.")
+    void sendPinSeats() throws InterruptedException {
+        // given
+        String token = "TEST_TOKEN";
+        when(sseService.isDisconnected(token)).thenReturn(false);
+        when(pinRepository.findAllByToken(token)).thenReturn(List.of());
+        when(seatStorage.getSeats(any())).thenReturn(List.of());
+
+        // when
+        pinSeatSender.send(token);
+        Thread.sleep(1000);
+
+        // then
+        verify(sseService, atLeastOnce()).propagate(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("핀 과목 여석 전송을 취소한다.")
+    void cancelPinSeatSending() throws InterruptedException {
+        // given
+        String token = "TEST_TOKEN";
+        when(sseService.isDisconnected(token)).thenReturn(false).thenReturn(true);
+        when(pinRepository.findAllByToken(token)).thenReturn(List.of());
+        when(seatStorage.getSeats(any())).thenReturn(List.of());
+
+        // when
+        pinSeatSender.send(token);
+        Thread.sleep(2500);
+
+        // then
+        verify(sseService, atLeastOnce()).propagate(any(), any(), any());
+        verify(scheduledTaskHandler, times(1)).cancel(token);
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/schedule/ScheduledTaskHandlerTest.java
+++ b/src/test/java/kr/allcll/backend/support/schedule/ScheduledTaskHandlerTest.java
@@ -146,6 +146,24 @@ class ScheduledTaskHandlerTest {
             .untilAsserted(() -> assertThat(scheduledTaskHandler.getTaskCount()).isEqualTo(0));
     }
 
+    @Test
+    @DisplayName("Task ID가 동일한 작업을 중복 등록할 수 없다.")
+    void duplicateTask() {
+        ScheduledTaskHandler scheduledTaskHandler = new ScheduledTaskHandler(
+            1,
+            "test-task",
+            new LoggingMeterRegistry()
+        );
+
+        // when
+        String taskId = scheduleTask(scheduledTaskHandler, new AtomicInteger());
+        scheduledTaskHandler.scheduleAtFixedRate(taskId, () -> {
+        }, Duration.ofSeconds(1));
+
+        // then
+        assertThat(scheduledTaskHandler.getTaskCount()).isEqualTo(1);
+    }
+
     private String scheduleTask(ScheduledTaskHandler scheduledTaskHandler, AtomicInteger counter) {
         return scheduledTaskHandler.scheduleAtFixedRate(
             () -> System.out.println("Task is running: " + counter.incrementAndGet()),


### PR DESCRIPTION
## 작업 내용

드디어 끔찍한😱 코드를 제거했습니다 🧨 

## 메인 작업: 핀과목 여석을 sse로 전송하는 로직을 별도 클래스로 분리 (SseService -> PinSeatSender)

#105 에서 만든 `ScheduledTaskHandler`를 활용하여 `GeneralSeatSender`와 유사한 기능을 하는 `PinSeatSender`를 만들었습니다. 

다음은 핵심 로직에 대해 설명해 보겠습니다. 가장 고민한 부분은 "작업: PinSeat 전송"을 어떻게 정확히 sse 연결 끊기는 시간과 맞출까였습니다. 
sse 연결 시간은 1분입니다. "작업: PinSeat 전송"도 1분 동안 지속되다가 종료되어야 합니다. 새로운 sse 연결이 시작되면 작업도 새로 시작합니다. 

기존 코드에서 이것을 어떻게 제어했을까요? "작업: PinSeat 전송"를 스케줄러에 등록하고, 이 작업을 1분 뒤에 취소하는 작업도 함께 등록하는 구조였습니다. sse 연결이 발생하면 PinSeat과 관련된 2개의 작업이 등록되는 구조였습니다. 취소하는 작업은 대기큐에서 기다리다가 실행되었을 것이고, 꼭 필요하지 않은 객체가 생성되었기에 힙 메모리가 낭비되겠지만 치명적인 문제는 아니었습니다. 

문제는 다른 곳에 있었습니다. sse 연결이 종료되면 PinSeat도 전송되어서는 안됩니다. 끊긴 연결에 전송을 시도하려는 건 무의미하니깐요. 하지만 기존 코드는 이것을 보장하기 어려웠습니다. sse 연결과 PinSeat 전송 작업이 스케줄링하는 주기를 정확히 맞추는 것은 아주 어렵습니다. 

이번 코드에서는 이것을 제어했습니다. 바로 작업이 실행되기 직전에 sse 연결이 끊겼는지 확인하고, 그렇다면 연결을 끊는 방식입니다. 이를 위해 `sseService.isDisconnected`를 추가했습니다. 

```java
private Runnable getMajorSeatTask(String token) {
    return () -> {
        if (sseService.isDisconnected(token)) {
            scheduledTaskHandler.cancel(token);
            return;
        }
        List<Pin> pins = pinRepository.findAllByToken(token);
        List<Subject> subjects = pins.stream()
            .map(Pin::getSubject)
            .toList();
        List<SeatDto> pinSeats = seatStorage.getSeats(subjects);
        sseService.propagate(token, PIN_EVENT_NAME, PinSeatsResponse.from(pinSeats));
    };
}
```

## sse timeout 시 발생하는 AsyncRequestTimeoutException 제어

spring에서는 sse timeout이 발생하면 AsyncRequestTimeoutException를 발생합니다. 이것을 핸들링하는 ExceptionHandler가 없어서 꽤 긴 로그가 찍히고 있었습니다. 이것을 핸들링하기 위한 코드를 추가했습니다. 

```java
@ExceptionHandler
public ResponseEntity<ErrorResponse> handleAsyncRequestTimeoutException(
    HttpServletRequest request,
    AsyncRequestTimeoutException e
) {
    if (request.getHeader("ALLCLL-SSE-CONNECT") != null) {
        log.info(LOG_FORMAT, request.getMethod(), request.getRequestURI(), e.getMessage(),
            "SSE connection timed out");
        return ResponseEntity.noContent().build();
    }
    return handleException(request, e);
}
```

여기에서 고민한 부분은 sse timeout 시에 발생하는 AsyncRequestTimeoutException 예외와 혹시 발생할지 모르는 AsyncRequestTimeoutException 예외를 구분하는 것입니다. sse timeout 시에 발생하는 AsyncRequestTimeoutException를 로그만 남기고 무시하면 될 것 같습니다. 하지만 지금은 알지 모르는 원인으로 AsyncRequestTimeoutException가 발생할 수 있습니다. AsyncRequestTimeoutException를 한 번에 퉁쳐서 해결하면, 알지 못하는 문제가 발생해도 추적할 기회가 사라집니다. 

sse timeout과 나머지를 어떻게 구분할 수 있을까요? 가장 쉬운 방식은 request path로 구분하는 방식입니다. sse를 연결하는 api는 /api/connect입니다. request 객체를 분석해서 sse 연결 api와 path가 동일하면 sse timeout으로 판단할 수 있습니다. 하지만 이 방식은 api에 의존적이라는 단점이 있습니다. api 스펙은 변경되기 쉬운데 이것에 의존하는 것은 유지보수가 어렵다 판단했습니다. 

다른 방식으로는 헤더의 Accept를 보는 방식입니다. sse는 text/event-stream를 사용합니다. request의 Accept 헤더를 분석하여 text/event-stream를 사용하면 sse timeout으로 판단할 수 있습니다. 하지만 이 방식은 현재 유효하지 않은데요. Request의 Accept는 클라이언트가 제어하는 영역이고, 우리는 /api/connect의 스펙에 요청 Accept를 text/event-stream로 강제하지 않았기 때문입니다. 

저는 커스텀 헤더를 사용했습니다. 요청이 ALLCLL-SSE-CONNECT 라는 헤더를 포함하고 있으면 sse 요청으로 판단하는 것입니다. 이것도 클라이언트에서 설정해야 한다는 점, /api/connect 스펙에서 위 헤더를 강제하지 않는다는 점은 Accept와 동일합니다. 방식이 동일하다면 Accept를 사용해도 될텐데라는 생각이 드는데요. ALLCLL-SSE-CONNECT로 추후 트래킹할 수 있을 가능성을 열어두고자 해당 헤더를 사용하게 되었습니다. [토스페이먼츠: HTTP 헤더로 에러 테스트하기](https://www.tosspayments.com/blog/articles/dev-7)

## 고민 지점과 리뷰 포인트

여전히 해결하지 못한 문제가 존재합니다. GeneralSeatSender와 다르게 PinSeatSender는 제어하는 로직이 없습니다. 이것은 다른 pr에서 다루게습니다. 