### PR TITLE
feat: 서비스 기간 조회 api를 수정합니다

### DIFF
--- a/src/main/java/kr/allcll/backend/config/ClockConfig.java
+++ b/src/main/java/kr/allcll/backend/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package kr.allcll.backend.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+
+}

--- a/src/main/java/kr/allcll/backend/domain/util/Semester.java
+++ b/src/main/java/kr/allcll/backend/domain/util/Semester.java
@@ -7,7 +7,7 @@ import kr.allcll.backend.support.exception.AllcllException;
 import lombok.Getter;
 
 @Getter
-public enum SemesterCode {
+public enum Semester {
     SPRING_25("2025-1", LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 31)),
     SUMMER_25("2025-여름", LocalDate.of(2025, 6, 1), LocalDate.of(2025, 6, 30)),
     FALL_25("2025-2", LocalDate.of(2025, 8, 1), LocalDate.of(2025, 9, 30)),
@@ -18,28 +18,28 @@ public enum SemesterCode {
     private final LocalDate startDate;
     private final LocalDate endDate;
 
-    SemesterCode(String value, LocalDate startDate, LocalDate endDate) {
+    Semester(String value, LocalDate startDate, LocalDate endDate) {
         this.value = value;
         this.startDate = startDate;
         this.endDate = endDate;
     }
 
-    public static SemesterCode getCode(LocalDate date) {
+    public static Semester getCode(LocalDate date) {
         return Arrays.stream(values())
-            .filter(semesterCode -> isDateInRange(semesterCode, date))
+            .filter(semester -> isDateInRange(semester, date))
             .findFirst()
             .orElse(getNextSemester(date));
     }
 
-    private static boolean isDateInRange(SemesterCode semesterCode, LocalDate date) {
-        LocalDate startDate = semesterCode.getStartDate();
-        LocalDate endDate = semesterCode.getEndDate();
+    private static boolean isDateInRange(Semester semester, LocalDate date) {
+        LocalDate startDate = semester.getStartDate();
+        LocalDate endDate = semester.getEndDate();
         return !startDate.isAfter(date) && !endDate.isBefore(date);
     }
 
-    private static SemesterCode getNextSemester(LocalDate date) {
+    private static Semester getNextSemester(LocalDate date) {
         return Arrays.stream(values())
-            .filter(semesterCode -> semesterCode.getStartDate().isAfter(date))
+            .filter(semester -> semester.getStartDate().isAfter(date))
             .findFirst()
             .orElseThrow(() -> new AllcllException(AllcllErrorCode.SEMESTER_NOT_FOUND));
     }

--- a/src/main/java/kr/allcll/backend/domain/util/Semester.java
+++ b/src/main/java/kr/allcll/backend/domain/util/Semester.java
@@ -12,6 +12,7 @@ public enum Semester {
     SUMMER_25("2025-여름", LocalDate.of(2025, 6, 1), LocalDate.of(2025, 6, 30)),
     FALL_25("2025-2", LocalDate.of(2025, 8, 1), LocalDate.of(2025, 9, 30)),
     WINTER_25("2025-겨울", LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 31)),
+    SPRING_26("2026-1", LocalDate.of(2026, 2, 1), LocalDate.of(2026, 3, 31)),
     ;
 
     private final String value;

--- a/src/main/java/kr/allcll/backend/domain/util/SemesterCode.java
+++ b/src/main/java/kr/allcll/backend/domain/util/SemesterCode.java
@@ -26,8 +26,20 @@ public enum SemesterCode {
 
     public static SemesterCode getCode(LocalDate date) {
         return Arrays.stream(values())
-            .filter(semesterCode -> !semesterCode.startDate.isAfter(date))
-            .filter(semesterCode -> !semesterCode.endDate.isBefore(date))
+            .filter(semesterCode -> isDateInRange(semesterCode, date))
+            .findFirst()
+            .orElse(getNextSemester(date));
+    }
+
+    private static boolean isDateInRange(SemesterCode semesterCode, LocalDate date) {
+        LocalDate startDate = semesterCode.getStartDate();
+        LocalDate endDate = semesterCode.getEndDate();
+        return !startDate.isAfter(date) && !endDate.isBefore(date);
+    }
+
+    private static SemesterCode getNextSemester(LocalDate date) {
+        return Arrays.stream(values())
+            .filter(semesterCode -> semesterCode.getStartDate().isAfter(date))
             .findFirst()
             .orElseThrow(() -> new AllcllException(AllcllErrorCode.SEMESTER_NOT_FOUND));
     }

--- a/src/main/java/kr/allcll/backend/domain/util/UtilApi.java
+++ b/src/main/java/kr/allcll/backend/domain/util/UtilApi.java
@@ -14,7 +14,7 @@ public class UtilApi {
 
     @GetMapping("/api/service/semester")
     public ResponseEntity<SemesterResponse> getSemester() {
-        SemesterResponse semesterResponse = utilService.getSemester();
-        return ResponseEntity.ok(semesterResponse);
+        SemesterResponse response = utilService.getSemester();
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/util/UtilService.java
+++ b/src/main/java/kr/allcll/backend/domain/util/UtilService.java
@@ -1,5 +1,6 @@
 package kr.allcll.backend.domain.util;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import kr.allcll.backend.domain.util.dto.SemesterResponse;
 import lombok.RequiredArgsConstructor;
@@ -9,8 +10,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UtilService {
 
+    private final Clock clock;
+
     public SemesterResponse getSemester() {
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(clock);
         SemesterCode currentSemesterCode = SemesterCode.getCode(now);
         return SemesterResponse.from(currentSemesterCode);
     }

--- a/src/main/java/kr/allcll/backend/domain/util/UtilService.java
+++ b/src/main/java/kr/allcll/backend/domain/util/UtilService.java
@@ -14,8 +14,8 @@ public class UtilService {
 
     public SemesterResponse getSemester() {
         LocalDate now = LocalDate.now(clock);
-        SemesterCode currentSemesterCode = SemesterCode.getCode(now);
-        return SemesterResponse.from(currentSemesterCode);
+        Semester currentSemester = Semester.getCode(now);
+        return SemesterResponse.from(currentSemester);
     }
 
 }

--- a/src/main/java/kr/allcll/backend/domain/util/dto/SemesterResponse.java
+++ b/src/main/java/kr/allcll/backend/domain/util/dto/SemesterResponse.java
@@ -4,12 +4,14 @@ import java.time.LocalDate;
 import kr.allcll.backend.domain.util.SemesterCode;
 
 public record SemesterResponse(
+    String code,
     String semester,
     Period period
 ) {
 
     public static SemesterResponse from(SemesterCode semesterCode) {
         return new SemesterResponse(
+            semesterCode.name(),
             semesterCode.getValue(),
             new Period(semesterCode.getStartDate(), semesterCode.getEndDate())
         );

--- a/src/main/java/kr/allcll/backend/domain/util/dto/SemesterResponse.java
+++ b/src/main/java/kr/allcll/backend/domain/util/dto/SemesterResponse.java
@@ -1,7 +1,7 @@
 package kr.allcll.backend.domain.util.dto;
 
 import java.time.LocalDate;
-import kr.allcll.backend.domain.util.SemesterCode;
+import kr.allcll.backend.domain.util.Semester;
 
 public record SemesterResponse(
     String code,
@@ -9,11 +9,11 @@ public record SemesterResponse(
     Period period
 ) {
 
-    public static SemesterResponse from(SemesterCode semesterCode) {
+    public static SemesterResponse from(Semester semester) {
         return new SemesterResponse(
-            semesterCode.name(),
-            semesterCode.getValue(),
-            new Period(semesterCode.getStartDate(), semesterCode.getEndDate())
+            semester.name(),
+            semester.getValue(),
+            new Period(semester.getStartDate(), semester.getEndDate())
         );
     }
 

--- a/src/test/java/kr/allcll/backend/domain/util/SemesterTest.java
+++ b/src/test/java/kr/allcll/backend/domain/util/SemesterTest.java
@@ -1,14 +1,15 @@
 package kr.allcll.backend.domain.util;
 
-import java.time.LocalDate;
-import kr.allcll.backend.support.exception.AllcllException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.time.LocalDate;
+import kr.allcll.backend.support.exception.AllcllException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class SemesterCodeTest {
+class SemesterTest {
 
     @Test
     @DisplayName("학기 시작일에 해당하는 코드가 반환되어야 한다.")
@@ -19,10 +20,10 @@ class SemesterCodeTest {
         LocalDate winterStart = LocalDate.of(2025, 12, 1);
 
         assertAll(
-            () -> assertThat(SemesterCode.getCode(springStart)).isEqualTo(SemesterCode.SPRING_25),
-            () -> assertThat(SemesterCode.getCode(summerStart)).isEqualTo(SemesterCode.SUMMER_25),
-            () -> assertThat(SemesterCode.getCode(fallStart)).isEqualTo(SemesterCode.FALL_25),
-            () -> assertThat(SemesterCode.getCode(winterStart)).isEqualTo(SemesterCode.WINTER_25)
+            () -> assertThat(Semester.getCode(springStart)).isEqualTo(Semester.SPRING_25),
+            () -> assertThat(Semester.getCode(summerStart)).isEqualTo(Semester.SUMMER_25),
+            () -> assertThat(Semester.getCode(fallStart)).isEqualTo(Semester.FALL_25),
+            () -> assertThat(Semester.getCode(winterStart)).isEqualTo(Semester.WINTER_25)
         );
     }
 
@@ -35,10 +36,10 @@ class SemesterCodeTest {
         LocalDate winterEnd = LocalDate.of(2025, 12, 31);
 
         assertAll(
-            () -> assertThat(SemesterCode.getCode(springEnd)).isEqualTo(SemesterCode.SPRING_25),
-            () -> assertThat(SemesterCode.getCode(summerEnd)).isEqualTo(SemesterCode.SUMMER_25),
-            () -> assertThat(SemesterCode.getCode(fallEnd)).isEqualTo(SemesterCode.FALL_25),
-            () -> assertThat(SemesterCode.getCode(winterEnd)).isEqualTo(SemesterCode.WINTER_25)
+            () -> assertThat(Semester.getCode(springEnd)).isEqualTo(Semester.SPRING_25),
+            () -> assertThat(Semester.getCode(summerEnd)).isEqualTo(Semester.SUMMER_25),
+            () -> assertThat(Semester.getCode(fallEnd)).isEqualTo(Semester.FALL_25),
+            () -> assertThat(Semester.getCode(winterEnd)).isEqualTo(Semester.WINTER_25)
         );
     }
 
@@ -51,10 +52,10 @@ class SemesterCodeTest {
         LocalDate winterMiddle = LocalDate.of(2025, 12, 15);
 
         assertAll(
-            () -> assertThat(SemesterCode.getCode(springMiddle)).isEqualTo(SemesterCode.SPRING_25),
-            () -> assertThat(SemesterCode.getCode(summerMiddle)).isEqualTo(SemesterCode.SUMMER_25),
-            () -> assertThat(SemesterCode.getCode(fallMiddle)).isEqualTo(SemesterCode.FALL_25),
-            () -> assertThat(SemesterCode.getCode(winterMiddle)).isEqualTo(SemesterCode.WINTER_25)
+            () -> assertThat(Semester.getCode(springMiddle)).isEqualTo(Semester.SPRING_25),
+            () -> assertThat(Semester.getCode(summerMiddle)).isEqualTo(Semester.SUMMER_25),
+            () -> assertThat(Semester.getCode(fallMiddle)).isEqualTo(Semester.FALL_25),
+            () -> assertThat(Semester.getCode(winterMiddle)).isEqualTo(Semester.WINTER_25)
         );
     }
 
@@ -67,13 +68,13 @@ class SemesterCodeTest {
         LocalDate beforeWinter = LocalDate.of(2025, 11, 30);
 
         assertAll(
-            () -> assertThatThrownBy(() -> SemesterCode.getCode(beforeSpring))
+            () -> assertThatThrownBy(() -> Semester.getCode(beforeSpring))
                 .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> SemesterCode.getCode(beforeSummer))
+            () -> assertThatThrownBy(() -> Semester.getCode(beforeSummer))
                 .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> SemesterCode.getCode(beforeFall))
+            () -> assertThatThrownBy(() -> Semester.getCode(beforeFall))
                 .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> SemesterCode.getCode(beforeWinter))
+            () -> assertThatThrownBy(() -> Semester.getCode(beforeWinter))
                 .isInstanceOf(AllcllException.class)
         );
     }
@@ -87,13 +88,13 @@ class SemesterCodeTest {
         LocalDate afterWinter = LocalDate.of(2026, 1, 1);
 
         assertAll(
-            () -> assertThatThrownBy(() -> SemesterCode.getCode(afterSpring))
+            () -> assertThatThrownBy(() -> Semester.getCode(afterSpring))
                 .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> SemesterCode.getCode(afterSummer))
+            () -> assertThatThrownBy(() -> Semester.getCode(afterSummer))
                 .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> SemesterCode.getCode(afterFall))
+            () -> assertThatThrownBy(() -> Semester.getCode(afterFall))
                 .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> SemesterCode.getCode(afterWinter))
+            () -> assertThatThrownBy(() -> Semester.getCode(afterWinter))
                 .isInstanceOf(AllcllException.class)
         );
     }
@@ -106,11 +107,11 @@ class SemesterCodeTest {
         LocalDate betweenFallAndWinter = LocalDate.of(2025, 10, 15);
 
         assertAll(
-            () -> assertThatThrownBy(() -> SemesterCode.getCode(betweenSpringAndSummer))
+            () -> assertThatThrownBy(() -> Semester.getCode(betweenSpringAndSummer))
                 .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> SemesterCode.getCode(betweenSummerAndFall))
+            () -> assertThatThrownBy(() -> Semester.getCode(betweenSummerAndFall))
                 .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> SemesterCode.getCode(betweenFallAndWinter))
+            () -> assertThatThrownBy(() -> Semester.getCode(betweenFallAndWinter))
                 .isInstanceOf(AllcllException.class)
         );
     }

--- a/src/test/java/kr/allcll/backend/domain/util/SemesterTest.java
+++ b/src/test/java/kr/allcll/backend/domain/util/SemesterTest.java
@@ -1,11 +1,9 @@
 package kr.allcll.backend.domain.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDate;
-import kr.allcll.backend.support.exception.AllcllException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -60,7 +58,7 @@ class SemesterTest {
     }
 
     @Test
-    @DisplayName("학기 시작일 하루 전 날짜는 예외를 발생시켜야 한다.")
+    @DisplayName("학기 시작일 하루 전 날짜는 다음 학기를 반환되어야 한다.")
     void shouldThrowExceptionWhenBeforeStartDate() {
         LocalDate beforeSpring = LocalDate.of(2025, 1, 31);
         LocalDate beforeSummer = LocalDate.of(2025, 5, 31);
@@ -68,19 +66,15 @@ class SemesterTest {
         LocalDate beforeWinter = LocalDate.of(2025, 11, 30);
 
         assertAll(
-            () -> assertThatThrownBy(() -> Semester.getCode(beforeSpring))
-                .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> Semester.getCode(beforeSummer))
-                .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> Semester.getCode(beforeFall))
-                .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> Semester.getCode(beforeWinter))
-                .isInstanceOf(AllcllException.class)
+            () -> assertThat(Semester.getCode(beforeSpring)).isEqualTo(Semester.SPRING_25),
+            () -> assertThat(Semester.getCode(beforeSummer)).isEqualTo(Semester.SUMMER_25),
+            () -> assertThat(Semester.getCode(beforeFall)).isEqualTo(Semester.FALL_25),
+            () -> assertThat(Semester.getCode(beforeWinter)).isEqualTo(Semester.WINTER_25)
         );
     }
 
     @Test
-    @DisplayName("학기 종료일 하루 후 날짜는 예외를 발생시켜야 한다.")
+    @DisplayName("학기 종료일 하루 후 날짜는 다음 학기를 반환되어야 한다.")
     void shouldThrowExceptionWhenAfterEndDate() {
         LocalDate afterSpring = LocalDate.of(2025, 4, 1);
         LocalDate afterSummer = LocalDate.of(2025, 7, 1);
@@ -88,31 +82,10 @@ class SemesterTest {
         LocalDate afterWinter = LocalDate.of(2026, 1, 1);
 
         assertAll(
-            () -> assertThatThrownBy(() -> Semester.getCode(afterSpring))
-                .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> Semester.getCode(afterSummer))
-                .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> Semester.getCode(afterFall))
-                .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> Semester.getCode(afterWinter))
-                .isInstanceOf(AllcllException.class)
-        );
-    }
-
-    @Test
-    @DisplayName("학기와 학기 사이의 날짜는 예외를 발생시켜야 한다.")
-    void shouldThrowExceptionWhenBetweenSemesters() {
-        LocalDate betweenSpringAndSummer = LocalDate.of(2025, 4, 15);
-        LocalDate betweenSummerAndFall = LocalDate.of(2025, 7, 15);
-        LocalDate betweenFallAndWinter = LocalDate.of(2025, 10, 15);
-
-        assertAll(
-            () -> assertThatThrownBy(() -> Semester.getCode(betweenSpringAndSummer))
-                .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> Semester.getCode(betweenSummerAndFall))
-                .isInstanceOf(AllcllException.class),
-            () -> assertThatThrownBy(() -> Semester.getCode(betweenFallAndWinter))
-                .isInstanceOf(AllcllException.class)
+            () -> assertThat(Semester.getCode(afterSpring)).isEqualTo(Semester.SUMMER_25),
+            () -> assertThat(Semester.getCode(afterSummer)).isEqualTo(Semester.FALL_25),
+            () -> assertThat(Semester.getCode(afterFall)).isEqualTo(Semester.WINTER_25),
+            () -> assertThat(Semester.getCode(afterWinter)).isEqualTo(Semester.SPRING_26)
         );
     }
 }

--- a/src/test/java/kr/allcll/backend/domain/util/UtilApiTest.java
+++ b/src/test/java/kr/allcll/backend/domain/util/UtilApiTest.java
@@ -1,18 +1,19 @@
 package kr.allcll.backend.domain.util;
 
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import java.time.LocalDate;
 import kr.allcll.backend.domain.util.dto.SemesterResponse;
 import kr.allcll.backend.domain.util.dto.SemesterResponse.Period;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import static org.mockito.Mockito.when;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UtilApi.class)
 class UtilApiTest {
@@ -29,7 +30,8 @@ class UtilApiTest {
         // given
         String expected = """
             {
-                "semester": "2025-1",
+                "code": "SPRING_25",
+                "semesterCode": "2025-1",
                 "period": {
                     "startDate": "2025-02-01",
                     "endDate": "2025-03-31"
@@ -39,12 +41,13 @@ class UtilApiTest {
 
         when(utilService.getSemester())
             .thenReturn(new SemesterResponse(
+                "SPRING_25",
                 "2025-1",
                 new Period(LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 31)))
             );
 
         // when, then
-        mockMvc.perform(get("/api/service/semester"))
+        mockMvc.perform(get("/api/service/semesterCode"))
             .andExpect(status().isOk())
             .andExpect(content().json(expected));
     }

--- a/src/test/java/kr/allcll/backend/domain/util/UtilApiTest.java
+++ b/src/test/java/kr/allcll/backend/domain/util/UtilApiTest.java
@@ -31,7 +31,7 @@ class UtilApiTest {
         String expected = """
             {
                 "code": "SPRING_25",
-                "semesterCode": "2025-1",
+                "semester": "2025-1",
                 "period": {
                     "startDate": "2025-02-01",
                     "endDate": "2025-03-31"
@@ -47,7 +47,7 @@ class UtilApiTest {
             );
 
         // when, then
-        mockMvc.perform(get("/api/service/semesterCode"))
+        mockMvc.perform(get("/api/service/semester"))
             .andExpect(status().isOk())
             .andExpect(content().json(expected));
     }

--- a/src/test/java/kr/allcll/backend/domain/util/UtilServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/util/UtilServiceTest.java
@@ -1,14 +1,20 @@
 package kr.allcll.backend.domain.util;
 
-import java.time.LocalDate;
-import kr.allcll.backend.domain.util.dto.SemesterResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import kr.allcll.backend.domain.util.dto.SemesterResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class UtilServiceTest {
@@ -16,10 +22,18 @@ class UtilServiceTest {
     @Autowired
     private UtilService utilService;
 
+    @MockitoBean
+    private Clock clock;
+
     @Test
-    @DisplayName("현재 학기 정보를 조회한다.")
+    @DisplayName("학기 기간 내인 경우에 학기 정보를 조회한다.")
     void getSemesterTest() {
         // when
+        Instant instant = Instant.parse("2025-02-01T00:00:00Z");
+        ZoneId zoneId = ZoneId.systemDefault();
+        when(clock.instant()).thenReturn(instant);
+        when(clock.getZone()).thenReturn(zoneId);
+
         SemesterResponse semesterResponse = utilService.getSemester();
 
         // then
@@ -27,6 +41,26 @@ class UtilServiceTest {
             () -> assertThat(semesterResponse.semester()).isEqualTo("2025-1"),
             () -> assertThat(semesterResponse.period().startDate()).isEqualTo(LocalDate.of(2025, 2, 1)),
             () -> assertThat(semesterResponse.period().endDate()).isEqualTo(LocalDate.of(2025, 3, 31))
+        );
+    }
+
+    @Test
+    @DisplayName("학기 기간 외인 경우에 다음 학기 정보를 조회한다.")
+    void getNextSemesterTest() {
+        // when
+        Instant instant = Instant.parse("2025-05-01T00:00:00Z");
+        ZoneId zoneId = ZoneId.systemDefault();
+        when(clock.instant()).thenReturn(instant);
+        when(clock.getZone()).thenReturn(zoneId);
+
+        SemesterResponse semesterResponse = utilService.getSemester();
+
+        // then
+        assertAll(
+            () -> assertThat(semesterResponse.code()).isEqualTo("SUMMER_25"),
+            () -> assertThat(semesterResponse.semester()).isEqualTo("2025-여름"),
+            () -> assertThat(semesterResponse.period().startDate()).isEqualTo(LocalDate.of(2025, 6, 1)),
+            () -> assertThat(semesterResponse.period().endDate()).isEqualTo(LocalDate.of(2025, 6, 30))
         );
     }
 }


### PR DESCRIPTION
## 작업 내용
#109 이슈에 작성한 내용을 진행했습니다. 

## 고민 지점과 리뷰 포인트

- 테스트에서 시간 제어를 위해 Clock을 사용했습니다. 
- 애플리케이션 코드에는 현재 시간 Clock을 Bean으로 등록했고, 테스트 코드에서는 관련 테스트에서 모킹하는 방식을 택했습니다. 
- 테스트 코드에서 테스트용 고정 시간 Clock을 TestBean으로 등록해서 사용하는 방법도 있습니다. 이 방법을 선택하지 않은 이유는, 시간에 의존적인 테스트가 하나 밖에 없기 때문에 과하다는 생각을 했습니다. 