### PR TITLE
refactor: PinSeatSender 코드 개선

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
@@ -3,6 +3,10 @@ package kr.allcll.backend.domain.seat;
 import java.time.LocalDate;
 import java.util.List;
 import kr.allcll.backend.domain.seat.dto.PreSeatsResponse;
+import kr.allcll.backend.domain.seat.dto.SeatDto;
+import kr.allcll.backend.domain.seat.pin.Pin;
+import kr.allcll.backend.domain.seat.pin.PinRepository;
+import kr.allcll.backend.domain.subject.Subject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,9 +17,19 @@ import org.springframework.stereotype.Service;
 public class SeatService {
 
     private final SeatRepository seatRepository;
+    private final PinRepository pinRepository;
+    private final SeatStorage seatStorage;
 
     public PreSeatsResponse getAllPreSeats() {
         List<Seat> allByCreatedDate = seatRepository.findAllByCreatedDate((LocalDate.of(2025, 2, 28)));
         return PreSeatsResponse.from(allByCreatedDate);
+    }
+
+    public List<SeatDto> getPinSeats(String token) {
+        List<Pin> pins = pinRepository.findAllByToken(token);
+        List<Subject> subjects = pins.stream()
+            .map(Pin::getSubject)
+            .toList();
+        return seatStorage.getSeats(subjects);
     }
 }

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatIntegrationTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatIntegrationTest.java
@@ -50,7 +50,7 @@ class SeatIntegrationTest {
     }
 
     @Test
-    @DisplayName("1초에 한 번씩 비전공 과목의 좌석 정보 10개를 전송한다.")
+    @DisplayName("1초에 한 번씩 비전공 과목의 좌석 정보 20개를 전송한다.")
     void sendGeneralSeatTest() {
         // given
         String expected = """

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatIntegrationTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatIntegrationTest.java
@@ -105,6 +105,56 @@ class SeatIntegrationTest {
                   "subjectId": 11,
                   "seatCount": 10,
                   "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 21,
+                  "seatCount": 11,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 22,
+                  "seatCount": 12,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 23,
+                  "seatCount": 13,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 24,
+                  "seatCount": 16,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 25,
+                  "seatCount": 20,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 26,
+                  "seatCount": 25,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 27,
+                  "seatCount": 30,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 28,
+                  "seatCount": 35,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 29,
+                  "seatCount": 40,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 30,
+                  "seatCount": 50,
+                  "queryTime": "2025-01-28T23:55:23.434294"
                 }
               ]
             }
@@ -125,6 +175,16 @@ class SeatIntegrationTest {
         Subject nonMajorSubject8 = SubjectFixture.createNonMajorSubject(18L, "차와문화", "000002", "008", "정형돈");
         Subject nonMajorSubject9 = SubjectFixture.createNonMajorSubject(19L, "차와문화", "000002", "009", "정형돈");
         Subject nonMajorSubject10 = SubjectFixture.createNonMajorSubject(20L, "차와문화", "000002", "010", "정형돈");
+        Subject nonMajorSubject11 = SubjectFixture.createNonMajorSubject(21L, "차와문화", "000002", "011", "정형돈");
+        Subject nonMajorSubject12 = SubjectFixture.createNonMajorSubject(22L, "차와문화", "000002", "012", "정형돈");
+        Subject nonMajorSubject13 = SubjectFixture.createNonMajorSubject(23L, "차와문화", "000002", "013", "정형돈");
+        Subject nonMajorSubject14 = SubjectFixture.createNonMajorSubject(24L, "차와문화", "000002", "014", "정형돈");
+        Subject nonMajorSubject15 = SubjectFixture.createNonMajorSubject(25L, "차와문화", "000002", "015", "정형돈");
+        Subject nonMajorSubject16 = SubjectFixture.createNonMajorSubject(26L, "차와문화", "000002", "016", "정형돈");
+        Subject nonMajorSubject17 = SubjectFixture.createNonMajorSubject(27L, "차와문화", "000002", "017", "정형돈");
+        Subject nonMajorSubject18 = SubjectFixture.createNonMajorSubject(28L, "차와문화", "000002", "018", "정형돈");
+        Subject nonMajorSubject19 = SubjectFixture.createNonMajorSubject(29L, "차와문화", "000002", "019", "정형돈");
+        Subject nonMajorSubject20 = SubjectFixture.createNonMajorSubject(30L, "차와문화", "000002", "020", "정형돈");
         LocalDateTime localDateTime = LocalDateTime.of(2025, 1, 28, 23, 55, 23, 434294000);
 
         seatStorage.addAll(List.of(
@@ -142,7 +202,17 @@ class SeatIntegrationTest {
             new SeatDto(nonMajorSubject7, 4, localDateTime),
             new SeatDto(nonMajorSubject8, 3, localDateTime),
             new SeatDto(nonMajorSubject9, 2, localDateTime),
-            new SeatDto(nonMajorSubject10, 1, localDateTime)
+            new SeatDto(nonMajorSubject10, 1, localDateTime),
+            new SeatDto(nonMajorSubject11, 11, localDateTime),
+            new SeatDto(nonMajorSubject12, 12, localDateTime),
+            new SeatDto(nonMajorSubject13, 13, localDateTime),
+            new SeatDto(nonMajorSubject14, 16, localDateTime),
+            new SeatDto(nonMajorSubject15, 20, localDateTime),
+            new SeatDto(nonMajorSubject16, 25, localDateTime),
+            new SeatDto(nonMajorSubject17, 30, localDateTime),
+            new SeatDto(nonMajorSubject18, 35, localDateTime),
+            new SeatDto(nonMajorSubject19, 40, localDateTime),
+            new SeatDto(nonMajorSubject20, 50, localDateTime)
         ));
 
         // when

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatIntegrationTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatIntegrationTest.java
@@ -1,0 +1,195 @@
+package kr.allcll.backend.domain.seat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.time.LocalDateTime;
+import java.util.List;
+import kr.allcll.backend.domain.seat.dto.SeatDto;
+import kr.allcll.backend.domain.subject.Subject;
+import kr.allcll.backend.fixture.SubjectFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class SeatIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(SeatIntegrationTest.class);
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private SeatStorage seatStorage;
+
+    @Autowired
+    private GeneralSeatSender generalSeatSender;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        generalSeatSender.send();
+    }
+
+    @AfterEach
+    void tearDown() {
+        seatStorage.clear();
+        generalSeatSender.cancel();
+    }
+
+    @Test
+    @DisplayName("1초에 한 번씩 비전공 과목의 좌석 정보 10개를 전송한다.")
+    void sendGeneralSeatTest() {
+        // given
+        String expected = """
+            {
+              "seatResponses": [
+                {
+                  "subjectId": 20,
+                  "seatCount": 1,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 19,
+                  "seatCount": 2,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 18,
+                  "seatCount": 3,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 17,
+                  "seatCount": 4,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 16,
+                  "seatCount": 5,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 15,
+                  "seatCount": 6,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 14,
+                  "seatCount": 7,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 13,
+                  "seatCount": 8,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 12,
+                  "seatCount": 9,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                },
+                {
+                  "subjectId": 11,
+                  "seatCount": 10,
+                  "queryTime": "2025-01-28T23:55:23.434294"
+                }
+              ]
+            }
+            """;
+
+        Subject majorSubject1 = SubjectFixture.createMajorSubject(1L, "컴퓨터네트워크", "000001", "001", "유재석");
+        Subject majorSubject2 = SubjectFixture.createMajorSubject(2L, "컴퓨터네트워크", "000001", "002", "유재석");
+        Subject majorSubject3 = SubjectFixture.createMajorSubject(3L, "컴퓨터네트워크", "000001", "003", "유재석");
+        Subject majorSubject4 = SubjectFixture.createMajorSubject(4L, "컴퓨터네트워크", "000001", "004", "유재석");
+        Subject majorSubject5 = SubjectFixture.createMajorSubject(5L, "컴퓨터네트워크", "000001", "005", "유재석");
+        Subject nonMajorSubject1 = SubjectFixture.createNonMajorSubject(11L, "차와문화", "000002", "001", "정형돈");
+        Subject nonMajorSubject2 = SubjectFixture.createNonMajorSubject(12L, "차와문화", "000002", "002", "정형돈");
+        Subject nonMajorSubject3 = SubjectFixture.createNonMajorSubject(13L, "차와문화", "000002", "003", "정형돈");
+        Subject nonMajorSubject4 = SubjectFixture.createNonMajorSubject(14L, "차와문화", "000002", "004", "정형돈");
+        Subject nonMajorSubject5 = SubjectFixture.createNonMajorSubject(15L, "차와문화", "000002", "005", "정형돈");
+        Subject nonMajorSubject6 = SubjectFixture.createNonMajorSubject(16L, "차와문화", "000002", "006", "정형돈");
+        Subject nonMajorSubject7 = SubjectFixture.createNonMajorSubject(17L, "차와문화", "000002", "007", "정형돈");
+        Subject nonMajorSubject8 = SubjectFixture.createNonMajorSubject(18L, "차와문화", "000002", "008", "정형돈");
+        Subject nonMajorSubject9 = SubjectFixture.createNonMajorSubject(19L, "차와문화", "000002", "009", "정형돈");
+        Subject nonMajorSubject10 = SubjectFixture.createNonMajorSubject(20L, "차와문화", "000002", "010", "정형돈");
+        LocalDateTime localDateTime = LocalDateTime.of(2025, 1, 28, 23, 55, 23, 434294000);
+
+        seatStorage.addAll(List.of(
+            new SeatDto(majorSubject1, 20, localDateTime),
+            new SeatDto(majorSubject2, 19, localDateTime),
+            new SeatDto(majorSubject3, 18, localDateTime),
+            new SeatDto(majorSubject4, 17, localDateTime),
+            new SeatDto(majorSubject5, 16, localDateTime),
+            new SeatDto(nonMajorSubject1, 10, localDateTime),
+            new SeatDto(nonMajorSubject2, 9, localDateTime),
+            new SeatDto(nonMajorSubject3, 8, localDateTime),
+            new SeatDto(nonMajorSubject4, 7, localDateTime),
+            new SeatDto(nonMajorSubject5, 6, localDateTime),
+            new SeatDto(nonMajorSubject6, 5, localDateTime),
+            new SeatDto(nonMajorSubject7, 4, localDateTime),
+            new SeatDto(nonMajorSubject8, 3, localDateTime),
+            new SeatDto(nonMajorSubject9, 2, localDateTime),
+            new SeatDto(nonMajorSubject10, 1, localDateTime)
+        ));
+
+        // when
+        Response response = RestAssured.given()
+            .accept("text/event-stream")
+            .when()
+            .get("/api/connect")
+            .then()
+            .statusCode(200)
+            .extract()
+            .response();
+
+        // then
+        TestHelper.assertResponseContainsMessage(response, expected);
+    }
+
+    private static class TestHelper {
+
+        private static final long TIMEOUT = 1000;
+
+        public static void assertResponseContainsMessage(Response response, String message) {
+            String eventReceived = readResponse(response);
+            String whitespacesRemovedMessage = message.replaceAll("\\s+", "");
+            assertThat(eventReceived).containsIgnoringWhitespaces(whitespacesRemovedMessage);
+        }
+
+        private static String readResponse(Response response) {
+            String body = response.getBody().asString();
+            try (BufferedReader reader = new BufferedReader(new StringReader(body))) {
+                return readLines(reader);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static String readLines(BufferedReader reader) throws IOException {
+            StringBuilder lines = new StringBuilder();
+            String line;
+            long startTime = System.currentTimeMillis();
+            while ((line = reader.readLine()) != null) {
+                log.info("Received: {}", line);
+                lines.append(line).append("\n");
+                if (System.currentTimeMillis() - startTime > TIMEOUT) {
+                    break;
+                }
+            }
+            return lines.toString();
+        }
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatServiceTest.java
@@ -1,192 +1,96 @@
 package kr.allcll.backend.domain.seat;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.restassured.RestAssured;
-import io.restassured.response.Response;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.StringReader;
 import java.time.LocalDateTime;
 import java.util.List;
 import kr.allcll.backend.domain.seat.dto.SeatDto;
+import kr.allcll.backend.domain.seat.pin.Pin;
+import kr.allcll.backend.domain.seat.pin.PinRepository;
 import kr.allcll.backend.domain.subject.Subject;
+import kr.allcll.backend.domain.subject.SubjectRepository;
 import kr.allcll.backend.fixture.SubjectFixture;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.server.LocalServerPort;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class SeatServiceTest {
 
-    private static final Logger log = LoggerFactory.getLogger(SeatServiceTest.class);
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private SeatService seatService;
 
-    @LocalServerPort
-    private int port;
+    @Autowired
+    private SubjectRepository subjectRepository;
+
+    @Autowired
+    private PinRepository pinRepository;
 
     @Autowired
     private SeatStorage seatStorage;
+    @Autowired
+    private PinSeatSender pinSeatSender;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
     }
 
-    @DisplayName("1초에 한 번씩 비전공 과목의 좌석 정보 10개를 전송한다.")
+    @AfterEach
+    void tearDown() {
+        seatStorage.clear();
+        pinRepository.deleteAll();
+        subjectRepository.deleteAllInBatch();
+    }
+
     @Test
-    void sendNonMajorSeatInfoTest() throws JsonProcessingException {
+    @DisplayName("핀 등록한 과목의 여석을 조회한다.")
+    void getPinSeatsTest() {
         // given
-        String expected = """
-            {
-              "seatResponses": [
-                {
-                  "subjectId": 11,
-                  "seatCount": 10,
-                  "queryTime": "2025-1-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 12,
-                  "seatCount": 9,
-                  "queryTime": "2025-1-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 13,
-                  "seatCount": 8,
-                  "queryTime": "2025-1-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 14,
-                  "seatCount": 7,
-                  "queryTime": "2025-1-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 15,
-                  "seatCount": 6,
-                  "queryTime": "2025-1-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 16,
-                  "seatCount": 5,
-                  "queryTime": "2025-1-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 17,
-                  "seatCount": 4,
-                  "queryTime": "2025-1-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 18,
-                  "seatCount": 3,
-                  "queryTime": "2025-1-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 19,
-                  "seatCount": 2,
-                  "queryTime": "2025-1-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 20,
-                  "seatCount": 1,
-                  "queryTime": "2025-1-28T23:55:23.434294"
-                }
-              ]
-            }
-            """;
+        String token = "token";
 
-        Subject majorSubject1 = SubjectFixture.createMajorSubject(1L, "컴퓨터네트워크", "000001", "001", "유재석");
-        Subject majorSubject2 = SubjectFixture.createMajorSubject(2L, "컴퓨터네트워크", "000001", "002", "유재석");
-        Subject majorSubject3 = SubjectFixture.createMajorSubject(3L, "컴퓨터네트워크", "000001", "003", "유재석");
-        Subject majorSubject4 = SubjectFixture.createMajorSubject(4L, "컴퓨터네트워크", "000001", "004", "유재석");
-        Subject majorSubject5 = SubjectFixture.createMajorSubject(5L, "컴퓨터네트워크", "000001", "005", "유재석");
-        Subject nonMajorSubject1 = SubjectFixture.createNonMajorSubject(11L, "차와문화", "000002", "001", "정형돈");
-        Subject nonMajorSubject2 = SubjectFixture.createNonMajorSubject(12L, "차와문화", "000002", "002", "정형돈");
-        Subject nonMajorSubject3 = SubjectFixture.createNonMajorSubject(13L, "차와문화", "000002", "003", "정형돈");
-        Subject nonMajorSubject4 = SubjectFixture.createNonMajorSubject(14L, "차와문화", "000002", "004", "정형돈");
-        Subject nonMajorSubject5 = SubjectFixture.createNonMajorSubject(15L, "차와문화", "000002", "005", "정형돈");
-        Subject nonMajorSubject6 = SubjectFixture.createNonMajorSubject(16L, "차와문화", "000002", "006", "정형돈");
-        Subject nonMajorSubject7 = SubjectFixture.createNonMajorSubject(17L, "차와문화", "000002", "007", "정형돈");
-        Subject nonMajorSubject8 = SubjectFixture.createNonMajorSubject(18L, "차와문화", "000002", "008", "정형돈");
-        Subject nonMajorSubject9 = SubjectFixture.createNonMajorSubject(19L, "차와문화", "000002", "009", "정형돈");
-        Subject nonMajorSubject10 = SubjectFixture.createNonMajorSubject(20L, "차와문화", "000002", "010", "정형돈");
-        LocalDateTime localDateTime = LocalDateTime.of(2025, 1, 28, 23, 55, 23, 434294000);
+        Subject subject1 = SubjectFixture.createSubject("컴퓨터네트워크", "000001", "001", "유재석");
+        Subject subject2 = SubjectFixture.createSubject("컴퓨터네트워크", "000001", "002", "유재석");
+        Subject subject3 = SubjectFixture.createSubject("컴퓨터네트워크", "000001", "003", "유재석");
+        Subject subject4 = SubjectFixture.createSubject("컴퓨터네트워크", "000001", "004", "유재석");
+        Subject subject5 = SubjectFixture.createSubject("컴퓨터네트워크", "000001", "005", "유재석");
+        subjectRepository.saveAll(List.of(subject1, subject2, subject3, subject4, subject5));
 
-        seatStorage.addAll(List.of(
-            new SeatDto(majorSubject1, 20, localDateTime),
-            new SeatDto(majorSubject2, 19, localDateTime),
-            new SeatDto(majorSubject3, 18, localDateTime),
-            new SeatDto(majorSubject4, 17, localDateTime),
-            new SeatDto(majorSubject5, 16, localDateTime),
-            new SeatDto(nonMajorSubject1, 10, localDateTime),
-            new SeatDto(nonMajorSubject2, 9, localDateTime),
-            new SeatDto(nonMajorSubject3, 8, localDateTime),
-            new SeatDto(nonMajorSubject4, 7, localDateTime),
-            new SeatDto(nonMajorSubject5, 6, localDateTime),
-            new SeatDto(nonMajorSubject6, 5, localDateTime),
-            new SeatDto(nonMajorSubject7, 4, localDateTime),
-            new SeatDto(nonMajorSubject8, 3, localDateTime),
-            new SeatDto(nonMajorSubject9, 2, localDateTime),
-            new SeatDto(nonMajorSubject10, 1, localDateTime)
-        ));
+        Pin pin1 = new Pin(token, subject1);
+        Pin pin2 = new Pin(token, subject2);
+        Pin pin3 = new Pin(token, subject3);
+        Pin pin4 = new Pin(token, subject4);
+        Pin pin5 = new Pin(token, subject5);
+        pinRepository.saveAll(List.of(pin1, pin2, pin3, pin4, pin5));
+
+        LocalDateTime now = LocalDateTime.now();
+        SeatDto seat1 = new SeatDto(subject1, 1, now);
+        SeatDto seat2 = new SeatDto(subject2, 2, now);
+        SeatDto seat3 = new SeatDto(subject3, 3, now);
+        SeatDto seat4 = new SeatDto(subject4, 4, now);
+        SeatDto seat5 = new SeatDto(subject5, 5, now);
+        seatStorage.addAll(List.of(seat1, seat2, seat3, seat4, seat5));
 
         // when
-        Response response = RestAssured.given()
-            .accept("text/event-stream")
-            .when()
-            .get("/api/connect")
-            .then()
-            .statusCode(200)
-            .extract()
-            .response();
+        List<SeatDto> pinSeats = seatService.getPinSeats(token);
 
         // then
-        TestHelper.assertResponseContainsMessage(response, objectMapper.readTree(expected).asText());
+        assertThat(pinSeats).hasSize(5)
+            .extracting(
+                pinSeat -> pinSeat.getSubject().getId(),
+                SeatDto::getSeatCount,
+                SeatDto::getQueryTime
+            )
+            .containsExactly(
+                tuple(1L, 1, now),
+                tuple(2L, 2, now),
+                tuple(3L, 3, now),
+                tuple(4L, 4, now),
+                tuple(5L, 5, now)
+            );
     }
-
-    private static class TestHelper {
-
-        private static final long TIMEOUT = 1000;
-
-        public static void assertResponseIsEqualsToMessage(Response response, String message) {
-            String eventReceived = readResponse(response);
-            assertThat(eventReceived).isEqualTo(message);
-        }
-
-        public static void assertResponseContainsMessage(Response response, String... messages) {
-            String eventReceived = readResponse(response);
-            assertThat(eventReceived).contains(messages);
-        }
-
-        private static String readResponse(Response response) {
-            String body = response.getBody().asString();
-            try (BufferedReader reader = new BufferedReader(new StringReader(body))) {
-                return readLines(reader);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        private static String readLines(BufferedReader reader) throws IOException {
-            StringBuilder lines = new StringBuilder();
-            String line;
-            long startTime = System.currentTimeMillis();
-            while ((line = reader.readLine()) != null) {
-                log.info("Received: {}", line);
-                lines.append(line).append("\n");
-                if (System.currentTimeMillis() - startTime > TIMEOUT) {
-                    break;
-                }
-            }
-            return lines.toString();
-        }
-    }
-
 }


### PR DESCRIPTION
## 작업 내용

핀 등록한 과목의 여석을 조회하는 로직을 PinSeatSender에서 SeatService로 옮겼습니다. 바로 아래 코드입니다. 아래 코드에서 주석으로 표시한 부분은 여석을 조회하는 로직으로, 이 책임을 SeatService로 이동하는 것이 적절하다 생각했습니다. 

```java
private Runnable getPinSeatTask(String token) {
    return () -> {
        if (sseService.isDisconnected(token)) {
            scheduledTaskHandler.cancel(token);
            return;
        }

        // 로직의 시작 부분
        List<Pin> pins = pinRepository.findAllByToken(token);
        List<Subject> subjects = pins.stream()
            .map(Pin::getSubject)
            .toList();
        List<SeatDto> pinSeats = seatStorage.getSeats(subjects);
        // 로직의 끝 부분
        sseService.propagate(token, PIN_EVENT_NAME, PinSeatsResponse.from(pinSeats));
    };
}
```

추가로 테스트 코드도 수정했어요. 

## 고민 지점과 리뷰 포인트

- **커밋 단위로 보면 이해하기 쉬울 거예요!** 
- 기존에 SeatService에는 비전공 여석을 SSE로 잘 전송하는지에 대한 테스트가 있었어요. 이것이 실제 SSE 커넥션을 맺고 데이터를 push 하는 전체 로직을 검증하더라고요. 통합 테스트의 느낌이 난다고 생각해서 `SeatIntegrationTest`로 통합 테스트 클래스를 분리해서 옮겼어요. 