### PR TITLE
refactor: GeneralSeatSender클래스 가독성 개선

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
@@ -33,14 +33,14 @@ public class GeneralSeatSender {
     }
 
     public void send() {
-        if (scheduledTaskHandler.getTaskCount() > 0) {
+        if (hasActiveSchedule()) {
             return;
         }
         scheduledTaskHandler.scheduleAtFixedRate(getGeneralSeatTask(), SENDING_PERIOD);
     }
 
-    public void cancel() {
-        scheduledTaskHandler.cancelAll();
+    private boolean hasActiveSchedule() {
+        return scheduledTaskHandler.getTaskCount() > 0;
     }
 
     private Runnable getGeneralSeatTask() {
@@ -48,5 +48,9 @@ public class GeneralSeatSender {
             List<SeatDto> generalSeats = seatStorage.getGeneralSeats(QUERY_LIMIT);
             sseService.propagate(EVENT_NAME, SeatsResponse.from(generalSeats));
         };
+    }
+
+    public void cancel() {
+        scheduledTaskHandler.cancelAll();
     }
 }

--- a/src/test/java/kr/allcll/backend/domain/seat/GeneralSeatSenderTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/GeneralSeatSenderTest.java
@@ -11,6 +11,7 @@ import kr.allcll.backend.support.sse.SseService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -55,6 +56,23 @@ class GeneralSeatSenderTest {
 
         // then
         verify(sseService, atLeast(period)).propagate(any(), any());
+    }
+
+    @Test
+    @DisplayName("중복 여석 전송을 방지한다.")
+    void preventDuplicateSendingTest() throws InterruptedException {
+        // given
+        int period = 2;
+        generalSeatSender.send();
+        Thread.sleep(100); // wait for first send
+
+        // when
+        generalSeatSender.send();
+        Thread.sleep(period * 1000); // wait for period
+
+        // then
+        int buffer = 1;
+        verify(sseService, Mockito.atMost(period + buffer)).propagate(any(), any());
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
작업한 내용은 간단해서 커밋 별로 보지 않아도 괜찮을 것 같아요! 전체로 봐주세요. 

아래 2가지 작업을 했어요. 
- `hasActiveSchedule()` 메서드 분리
- 중복 스케줄링을 방지하는 로직에 대한 테스트 추가

### `hasActiveSchedule()` 메서드 분리 
교양 과목을 전송하는 로직에는 중복해서 스케줄링을 등록할 수 없는 조건이 존재해요. 아래 if문 조건이 그에 해당해요. 
지금은 이 조건이 무엇을 의미하는지 알지만, 시간이 흐르면 모를 수 있을 수 있고, 새로 온보딩하는 팀원은 이것이 왜 존재해야 하는 조건인지 모를 것 같더군요. 
그래서 의미있는 메서드명을 부여했어요! 

```java

public void send() {
    if (scheduledTaskHandler.getTaskCount() > 0) {
        return;
    }
    scheduledTaskHandler.scheduleAtFixedRate(getGeneralSeatTask(), SENDING_PERIOD);
}
```

### 중복 스케줄링을 방지하는 로직에 대한 테스트 추가
말 그대로 중복 스케줄링을 방지하는 로직을 테스트했어요. 바로 위에 언급한 if문을 검증하는 것이에요! 이 테스트가 없더군요. 
