### PR TITLE
refactor: 베이스 엔티티 개선

### DIFF
--- a/src/main/java/kr/allcll/backend/support/entity/BaseEntity.java
+++ b/src/main/java/kr/allcll/backend/support/entity/BaseEntity.java
@@ -8,8 +8,20 @@ import java.time.LocalDateTime;
 @EntityListeners(value = {BaseEntityListener.class})
 public abstract class BaseEntity {
 
-    String semesterAt;
-    LocalDateTime createdAt;
-    LocalDateTime deletedAt;
-    boolean isDeleted;
+    protected String semesterAt;
+    protected LocalDateTime createdAt;
+    protected LocalDateTime deletedAt;
+    protected boolean isDeleted;
+
+    void setSemesterAtIfAbsent(String semesterAt) {
+        if (this.semesterAt == null) {
+            this.semesterAt = semesterAt;
+        }
+    }
+
+    void setCreatedAtIfAbsent(LocalDateTime createdAt) {
+        if (this.createdAt == null) {
+            this.createdAt = createdAt;
+        }
+    }
 }

--- a/src/main/java/kr/allcll/backend/support/entity/BaseEntityListener.java
+++ b/src/main/java/kr/allcll/backend/support/entity/BaseEntityListener.java
@@ -1,29 +1,20 @@
 package kr.allcll.backend.support.entity;
 
 import jakarta.persistence.PrePersist;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import kr.allcll.backend.support.semester.Semester;
 
 public class BaseEntityListener {
 
     @PrePersist
-    public void setSemester(BaseEntity entity) {
-        entity.createdAt = LocalDateTime.now();
-        entity.semesterAt = Semester.now();
+    public void initialize(BaseEntity entity) {
+        entity.setSemesterAtIfAbsent(getCurrentSemester());
+        entity.setCreatedAtIfAbsent(LocalDateTime.now());
     }
 
-    private static class Semester {
-
-        private static final int MIDDLE_OF_YEAR_MONTH = 6;
-
-        public static String now() {
-            LocalDateTime now = LocalDateTime.now();
-            int year = now.getYear();
-            int month = now.getMonthValue();
-            return String.format("%d/%s", year, calculateSemester(month));
-        }
-
-        private static String calculateSemester(int month) {
-            return month <= MIDDLE_OF_YEAR_MONTH ? "1학기" : "2학기";
-        }
+    private String getCurrentSemester() {
+        Semester semester = Semester.getCode(LocalDate.now());
+        return semester.getValue();
     }
 }

--- a/src/main/java/kr/allcll/backend/support/semester/Semester.java
+++ b/src/main/java/kr/allcll/backend/support/semester/Semester.java
@@ -9,8 +9,7 @@ import lombok.Getter;
 @Getter
 public enum Semester {
     /*
-    2025년 1학기 코드 수정할 경우에 참고할 내용
-    https://github.com/allcll/allcll-backend/pull/121#discussion_r2118843479
+    2025년 1학기 코드 수정할 경우에 [참고](https://github.com/allcll/allcll-backend/pull/121#discussion_r2118843479)
      */
     SPRING_25("2025-1", LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 31)),
     SUMMER_25("2025-여름", LocalDate.of(2025, 6, 1), LocalDate.of(2025, 6, 30)),

--- a/src/main/java/kr/allcll/backend/support/semester/Semester.java
+++ b/src/main/java/kr/allcll/backend/support/semester/Semester.java
@@ -8,7 +8,11 @@ import lombok.Getter;
 
 @Getter
 public enum Semester {
-    SPRING_25("2025/1학기", LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 31)),
+    /*
+    2025년 1학기 코드 수정할 경우에 참고할 내용
+    https://github.com/allcll/allcll-backend/pull/121#discussion_r2118843479
+     */
+    SPRING_25("2025-1", LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 31)),
     SUMMER_25("2025-여름", LocalDate.of(2025, 6, 1), LocalDate.of(2025, 6, 30)),
     FALL_25("2025-2", LocalDate.of(2025, 8, 1), LocalDate.of(2025, 9, 30)),
     WINTER_25("2025-겨울", LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 31)),

--- a/src/main/java/kr/allcll/backend/support/semester/Semester.java
+++ b/src/main/java/kr/allcll/backend/support/semester/Semester.java
@@ -1,4 +1,4 @@
-package kr.allcll.backend.domain.util;
+package kr.allcll.backend.support.semester;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 public enum Semester {
-    SPRING_25("2025-1", LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 31)),
+    SPRING_25("2025/1학기", LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 31)),
     SUMMER_25("2025-여름", LocalDate.of(2025, 6, 1), LocalDate.of(2025, 6, 30)),
     FALL_25("2025-2", LocalDate.of(2025, 8, 1), LocalDate.of(2025, 9, 30)),
     WINTER_25("2025-겨울", LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 31)),

--- a/src/main/java/kr/allcll/backend/support/semester/SemesterResponse.java
+++ b/src/main/java/kr/allcll/backend/support/semester/SemesterResponse.java
@@ -1,7 +1,6 @@
-package kr.allcll.backend.domain.util.dto;
+package kr.allcll.backend.support.semester;
 
 import java.time.LocalDate;
-import kr.allcll.backend.domain.util.Semester;
 
 public record SemesterResponse(
     String code,

--- a/src/main/java/kr/allcll/backend/support/semester/UtilApi.java
+++ b/src/main/java/kr/allcll/backend/support/semester/UtilApi.java
@@ -1,6 +1,5 @@
-package kr.allcll.backend.domain.util;
+package kr.allcll.backend.support.semester;
 
-import kr.allcll.backend.domain.util.dto.SemesterResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/kr/allcll/backend/support/semester/UtilService.java
+++ b/src/main/java/kr/allcll/backend/support/semester/UtilService.java
@@ -1,8 +1,7 @@
-package kr.allcll.backend.domain.util;
+package kr.allcll.backend.support.semester;
 
 import java.time.Clock;
 import java.time.LocalDate;
-import kr.allcll.backend.domain.util.dto.SemesterResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/test/java/kr/allcll/backend/support/semester/SemesterTest.java
+++ b/src/test/java/kr/allcll/backend/support/semester/SemesterTest.java
@@ -1,4 +1,4 @@
-package kr.allcll.backend.domain.util;
+package kr.allcll.backend.support.semester;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;

--- a/src/test/java/kr/allcll/backend/support/semester/UtilApiTest.java
+++ b/src/test/java/kr/allcll/backend/support/semester/UtilApiTest.java
@@ -1,4 +1,4 @@
-package kr.allcll.backend.domain.util;
+package kr.allcll.backend.support.semester;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -6,8 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
-import kr.allcll.backend.domain.util.dto.SemesterResponse;
-import kr.allcll.backend.domain.util.dto.SemesterResponse.Period;
+import kr.allcll.backend.support.semester.SemesterResponse.Period;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/kr/allcll/backend/support/semester/UtilServiceTest.java
+++ b/src/test/java/kr/allcll/backend/support/semester/UtilServiceTest.java
@@ -1,4 +1,4 @@
-package kr.allcll.backend.domain.util;
+package kr.allcll.backend.support.semester;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -8,7 +8,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import kr.allcll.backend.domain.util.dto.SemesterResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## 작업 내용

베이스 엔티티가 하는 역할 중, semester_at을 세팅하는 것이 있습니다. 
이전 로직에서는 현재 semester를 알기 위해서 BaseEntityListener 내부에 별도 객체를 생성해서 사용했어요. 
당시에는 학기 정보를 알 방법이 없었기에 내부에 간단한 객체를 만들었어요. 

```java
public class BaseEntityListener {

    @PrePersist
    public void setSemester(BaseEntity entity) {
        entity.createdAt = LocalDateTime.now();
        entity.semesterAt = Semester.now();
    }

    private static class Semester {

        private static final int MIDDLE_OF_YEAR_MONTH = 6;

        public static String now() {
            LocalDateTime now = LocalDateTime.now();
            int year = now.getYear();
            int month = now.getMonthValue();
            return String.format("%d/%s", year, calculateSemester(month));
        }

        private static String calculateSemester(int month) {
            return month <= MIDDLE_OF_YEAR_MONTH ? "1학기" : "2학기";
        }
}
```

하지만 이후에 Semester라는 enum이 생성되었어요. 

```java
@Getter
public enum Semester {
    SPRING_25("2025/1학기", LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 31)),
    SUMMER_25("2025-여름", LocalDate.of(2025, 6, 1), LocalDate.of(2025, 6, 30)),
    FALL_25("2025-2", LocalDate.of(2025, 8, 1), LocalDate.of(2025, 9, 30)),
    WINTER_25("2025-겨울", LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 31)),
    SPRING_26("2026-1", LocalDate.of(2026, 2, 1), LocalDate.of(2026, 3, 31)),
    ;
    private final String value;
    private final LocalDate startDate;
    private final LocalDate endDate;
    Semester(String value, LocalDate startDate, LocalDate endDate) {
        this.value = value;
        this.startDate = startDate;
        this.endDate = endDate;
    }
    public static Semester getCode(LocalDate date) {
        return Arrays.stream(values())
            .filter(semester -> isDateInRange(semester, date))
            .findFirst()
            .orElse(getNextSemester(date));
    }
```

Semester 객체와 Semester enum이 두개나 존재하고, 서로의 로직이 달랐어요. 
동일한 정보 원천을 만들기 위해 EntityListener 내부의 Semester를 삭제하고 Semester enum을 사용하게 수정했어요. 

추가로 semester를 domain 패키지에서 support 패키지로 이동했어요. 
하나의 도메인이라고 보기엔 도메인을 도와주는 역할을 한다고 생각해서요! 
