### PR TITLE
refactor: 하계 수강신청에 맞추어 로직 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
@@ -16,6 +16,7 @@ public class GeneralSeatSender {
 
     private static final String EVENT_NAME = "nonMajorSeats";
     private static final int QUERY_LIMIT = 20;
+    private static final int SEASON_SEMESTER_QUERY_LIMIT = 39; // 2025-하계 전체 제공을 위한 쿼리 제한 수
     private static final Duration SENDING_PERIOD = Duration.ofSeconds(1);
 
     private final SseService sseService;
@@ -45,7 +46,7 @@ public class GeneralSeatSender {
 
     private Runnable getGeneralSeatTask() {
         return () -> {
-            List<SeatDto> generalSeats = seatStorage.getGeneralSeats(QUERY_LIMIT);
+            List<SeatDto> generalSeats = seatStorage.getGeneralSeats(SEASON_SEMESTER_QUERY_LIMIT);
             sseService.propagate(EVENT_NAME, SeatsResponse.from(generalSeats));
         };
     }

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
@@ -21,7 +21,7 @@ public class SeatService {
     private final SeatStorage seatStorage;
 
     public PreSeatsResponse getAllPreSeats() {
-        List<Seat> allByCreatedDate = seatRepository.findAllByCreatedDate((LocalDate.of(2025, 2, 28)));
+        List<Seat> allByCreatedDate = seatRepository.findAllByCreatedDate((LocalDate.of(2025, 6, 1)));
         return PreSeatsResponse.from(allByCreatedDate);
     }
 

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
@@ -21,7 +21,7 @@ public class SeatService {
     private final SeatStorage seatStorage;
 
     public PreSeatsResponse getAllPreSeats() {
-        List<Seat> allByCreatedDate = seatRepository.findAllByCreatedDate((LocalDate.of(2025, 6, 1)));
+        List<Seat> allByCreatedDate = seatRepository.findAllByCreatedDate(LocalDate.now().minusDays(1));
         return PreSeatsResponse.from(allByCreatedDate);
     }
 

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
@@ -25,7 +25,7 @@ public class SeatStorage {
     public List<SeatDto> getGeneralSeats(int limit) {
         Collection<SeatDto> seatsValue = seats.values();
         return seatsValue.stream()
-            .filter(seat -> seat.getSubject().isNonMajor())
+//            .filter(seat -> seat.getSubject().isNonMajor())
             .filter(seat -> seat.getSeatCount() > 0)
             .sorted(Comparator.comparingInt(SeatDto::getSeatCount))
             .limit(limit)

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatIntegrationTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatIntegrationTest.java
@@ -48,186 +48,186 @@ class SeatIntegrationTest {
         seatStorage.clear();
         generalSeatSender.cancel();
     }
-
-    @Test
-    @DisplayName("1초에 한 번씩 비전공 과목의 좌석 정보 20개를 전송한다.")
-    void sendGeneralSeatTest() {
-        // given
-        String expected = """
-            {
-              "seatResponses": [
-                {
-                  "subjectId": 20,
-                  "seatCount": 1,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 19,
-                  "seatCount": 2,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 18,
-                  "seatCount": 3,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 17,
-                  "seatCount": 4,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 16,
-                  "seatCount": 5,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 15,
-                  "seatCount": 6,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 14,
-                  "seatCount": 7,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 13,
-                  "seatCount": 8,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 12,
-                  "seatCount": 9,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 11,
-                  "seatCount": 10,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 21,
-                  "seatCount": 11,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 22,
-                  "seatCount": 12,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 23,
-                  "seatCount": 13,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 24,
-                  "seatCount": 16,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 25,
-                  "seatCount": 20,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 26,
-                  "seatCount": 25,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 27,
-                  "seatCount": 30,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 28,
-                  "seatCount": 35,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 29,
-                  "seatCount": 40,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                },
-                {
-                  "subjectId": 30,
-                  "seatCount": 50,
-                  "queryTime": "2025-01-28T23:55:23.434294"
-                }
-              ]
-            }
-            """;
-
-        Subject majorSubject1 = SubjectFixture.createMajorSubject(1L, "컴퓨터네트워크", "000001", "001", "유재석");
-        Subject majorSubject2 = SubjectFixture.createMajorSubject(2L, "컴퓨터네트워크", "000001", "002", "유재석");
-        Subject majorSubject3 = SubjectFixture.createMajorSubject(3L, "컴퓨터네트워크", "000001", "003", "유재석");
-        Subject majorSubject4 = SubjectFixture.createMajorSubject(4L, "컴퓨터네트워크", "000001", "004", "유재석");
-        Subject majorSubject5 = SubjectFixture.createMajorSubject(5L, "컴퓨터네트워크", "000001", "005", "유재석");
-        Subject nonMajorSubject1 = SubjectFixture.createNonMajorSubject(11L, "차와문화", "000002", "001", "정형돈");
-        Subject nonMajorSubject2 = SubjectFixture.createNonMajorSubject(12L, "차와문화", "000002", "002", "정형돈");
-        Subject nonMajorSubject3 = SubjectFixture.createNonMajorSubject(13L, "차와문화", "000002", "003", "정형돈");
-        Subject nonMajorSubject4 = SubjectFixture.createNonMajorSubject(14L, "차와문화", "000002", "004", "정형돈");
-        Subject nonMajorSubject5 = SubjectFixture.createNonMajorSubject(15L, "차와문화", "000002", "005", "정형돈");
-        Subject nonMajorSubject6 = SubjectFixture.createNonMajorSubject(16L, "차와문화", "000002", "006", "정형돈");
-        Subject nonMajorSubject7 = SubjectFixture.createNonMajorSubject(17L, "차와문화", "000002", "007", "정형돈");
-        Subject nonMajorSubject8 = SubjectFixture.createNonMajorSubject(18L, "차와문화", "000002", "008", "정형돈");
-        Subject nonMajorSubject9 = SubjectFixture.createNonMajorSubject(19L, "차와문화", "000002", "009", "정형돈");
-        Subject nonMajorSubject10 = SubjectFixture.createNonMajorSubject(20L, "차와문화", "000002", "010", "정형돈");
-        Subject nonMajorSubject11 = SubjectFixture.createNonMajorSubject(21L, "차와문화", "000002", "011", "정형돈");
-        Subject nonMajorSubject12 = SubjectFixture.createNonMajorSubject(22L, "차와문화", "000002", "012", "정형돈");
-        Subject nonMajorSubject13 = SubjectFixture.createNonMajorSubject(23L, "차와문화", "000002", "013", "정형돈");
-        Subject nonMajorSubject14 = SubjectFixture.createNonMajorSubject(24L, "차와문화", "000002", "014", "정형돈");
-        Subject nonMajorSubject15 = SubjectFixture.createNonMajorSubject(25L, "차와문화", "000002", "015", "정형돈");
-        Subject nonMajorSubject16 = SubjectFixture.createNonMajorSubject(26L, "차와문화", "000002", "016", "정형돈");
-        Subject nonMajorSubject17 = SubjectFixture.createNonMajorSubject(27L, "차와문화", "000002", "017", "정형돈");
-        Subject nonMajorSubject18 = SubjectFixture.createNonMajorSubject(28L, "차와문화", "000002", "018", "정형돈");
-        Subject nonMajorSubject19 = SubjectFixture.createNonMajorSubject(29L, "차와문화", "000002", "019", "정형돈");
-        Subject nonMajorSubject20 = SubjectFixture.createNonMajorSubject(30L, "차와문화", "000002", "020", "정형돈");
-        LocalDateTime localDateTime = LocalDateTime.of(2025, 1, 28, 23, 55, 23, 434294000);
-
-        seatStorage.addAll(List.of(
-            new SeatDto(majorSubject1, 20, localDateTime),
-            new SeatDto(majorSubject2, 19, localDateTime),
-            new SeatDto(majorSubject3, 18, localDateTime),
-            new SeatDto(majorSubject4, 17, localDateTime),
-            new SeatDto(majorSubject5, 16, localDateTime),
-            new SeatDto(nonMajorSubject1, 10, localDateTime),
-            new SeatDto(nonMajorSubject2, 9, localDateTime),
-            new SeatDto(nonMajorSubject3, 8, localDateTime),
-            new SeatDto(nonMajorSubject4, 7, localDateTime),
-            new SeatDto(nonMajorSubject5, 6, localDateTime),
-            new SeatDto(nonMajorSubject6, 5, localDateTime),
-            new SeatDto(nonMajorSubject7, 4, localDateTime),
-            new SeatDto(nonMajorSubject8, 3, localDateTime),
-            new SeatDto(nonMajorSubject9, 2, localDateTime),
-            new SeatDto(nonMajorSubject10, 1, localDateTime),
-            new SeatDto(nonMajorSubject11, 11, localDateTime),
-            new SeatDto(nonMajorSubject12, 12, localDateTime),
-            new SeatDto(nonMajorSubject13, 13, localDateTime),
-            new SeatDto(nonMajorSubject14, 16, localDateTime),
-            new SeatDto(nonMajorSubject15, 20, localDateTime),
-            new SeatDto(nonMajorSubject16, 25, localDateTime),
-            new SeatDto(nonMajorSubject17, 30, localDateTime),
-            new SeatDto(nonMajorSubject18, 35, localDateTime),
-            new SeatDto(nonMajorSubject19, 40, localDateTime),
-            new SeatDto(nonMajorSubject20, 50, localDateTime)
-        ));
-
-        // when
-        Response response = RestAssured.given()
-            .accept("text/event-stream")
-            .when()
-            .get("/api/connect")
-            .then()
-            .statusCode(200)
-            .extract()
-            .response();
-
-        // then
-        TestHelper.assertResponseContainsMessage(response, expected);
-    }
+//
+//    @Test
+//    @DisplayName("1초에 한 번씩 비전공 과목의 좌석 정보 20개를 전송한다.")
+//    void sendGeneralSeatTest() {
+//        // given
+//        String expected = """
+//            {
+//              "seatResponses": [
+//                {
+//                  "subjectId": 20,
+//                  "seatCount": 1,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 19,
+//                  "seatCount": 2,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 18,
+//                  "seatCount": 3,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 17,
+//                  "seatCount": 4,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 16,
+//                  "seatCount": 5,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 15,
+//                  "seatCount": 6,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 14,
+//                  "seatCount": 7,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 13,
+//                  "seatCount": 8,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 12,
+//                  "seatCount": 9,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 11,
+//                  "seatCount": 10,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 21,
+//                  "seatCount": 11,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 22,
+//                  "seatCount": 12,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 23,
+//                  "seatCount": 13,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 24,
+//                  "seatCount": 16,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 25,
+//                  "seatCount": 20,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 26,
+//                  "seatCount": 25,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 27,
+//                  "seatCount": 30,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 28,
+//                  "seatCount": 35,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 29,
+//                  "seatCount": 40,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                },
+//                {
+//                  "subjectId": 30,
+//                  "seatCount": 50,
+//                  "queryTime": "2025-01-28T23:55:23.434294"
+//                }
+//              ]
+//            }
+//            """;
+//
+//        Subject majorSubject1 = SubjectFixture.createMajorSubject(1L, "컴퓨터네트워크", "000001", "001", "유재석");
+//        Subject majorSubject2 = SubjectFixture.createMajorSubject(2L, "컴퓨터네트워크", "000001", "002", "유재석");
+//        Subject majorSubject3 = SubjectFixture.createMajorSubject(3L, "컴퓨터네트워크", "000001", "003", "유재석");
+//        Subject majorSubject4 = SubjectFixture.createMajorSubject(4L, "컴퓨터네트워크", "000001", "004", "유재석");
+//        Subject majorSubject5 = SubjectFixture.createMajorSubject(5L, "컴퓨터네트워크", "000001", "005", "유재석");
+//        Subject nonMajorSubject1 = SubjectFixture.createNonMajorSubject(11L, "차와문화", "000002", "001", "정형돈");
+//        Subject nonMajorSubject2 = SubjectFixture.createNonMajorSubject(12L, "차와문화", "000002", "002", "정형돈");
+//        Subject nonMajorSubject3 = SubjectFixture.createNonMajorSubject(13L, "차와문화", "000002", "003", "정형돈");
+//        Subject nonMajorSubject4 = SubjectFixture.createNonMajorSubject(14L, "차와문화", "000002", "004", "정형돈");
+//        Subject nonMajorSubject5 = SubjectFixture.createNonMajorSubject(15L, "차와문화", "000002", "005", "정형돈");
+//        Subject nonMajorSubject6 = SubjectFixture.createNonMajorSubject(16L, "차와문화", "000002", "006", "정형돈");
+//        Subject nonMajorSubject7 = SubjectFixture.createNonMajorSubject(17L, "차와문화", "000002", "007", "정형돈");
+//        Subject nonMajorSubject8 = SubjectFixture.createNonMajorSubject(18L, "차와문화", "000002", "008", "정형돈");
+//        Subject nonMajorSubject9 = SubjectFixture.createNonMajorSubject(19L, "차와문화", "000002", "009", "정형돈");
+//        Subject nonMajorSubject10 = SubjectFixture.createNonMajorSubject(20L, "차와문화", "000002", "010", "정형돈");
+//        Subject nonMajorSubject11 = SubjectFixture.createNonMajorSubject(21L, "차와문화", "000002", "011", "정형돈");
+//        Subject nonMajorSubject12 = SubjectFixture.createNonMajorSubject(22L, "차와문화", "000002", "012", "정형돈");
+//        Subject nonMajorSubject13 = SubjectFixture.createNonMajorSubject(23L, "차와문화", "000002", "013", "정형돈");
+//        Subject nonMajorSubject14 = SubjectFixture.createNonMajorSubject(24L, "차와문화", "000002", "014", "정형돈");
+//        Subject nonMajorSubject15 = SubjectFixture.createNonMajorSubject(25L, "차와문화", "000002", "015", "정형돈");
+//        Subject nonMajorSubject16 = SubjectFixture.createNonMajorSubject(26L, "차와문화", "000002", "016", "정형돈");
+//        Subject nonMajorSubject17 = SubjectFixture.createNonMajorSubject(27L, "차와문화", "000002", "017", "정형돈");
+//        Subject nonMajorSubject18 = SubjectFixture.createNonMajorSubject(28L, "차와문화", "000002", "018", "정형돈");
+//        Subject nonMajorSubject19 = SubjectFixture.createNonMajorSubject(29L, "차와문화", "000002", "019", "정형돈");
+//        Subject nonMajorSubject20 = SubjectFixture.createNonMajorSubject(30L, "차와문화", "000002", "020", "정형돈");
+//        LocalDateTime localDateTime = LocalDateTime.of(2025, 1, 28, 23, 55, 23, 434294000);
+//
+//        seatStorage.addAll(List.of(
+//            new SeatDto(majorSubject1, 20, localDateTime),
+//            new SeatDto(majorSubject2, 19, localDateTime),
+//            new SeatDto(majorSubject3, 18, localDateTime),
+//            new SeatDto(majorSubject4, 17, localDateTime),
+//            new SeatDto(majorSubject5, 16, localDateTime),
+//            new SeatDto(nonMajorSubject1, 10, localDateTime),
+//            new SeatDto(nonMajorSubject2, 9, localDateTime),
+//            new SeatDto(nonMajorSubject3, 8, localDateTime),
+//            new SeatDto(nonMajorSubject4, 7, localDateTime),
+//            new SeatDto(nonMajorSubject5, 6, localDateTime),
+//            new SeatDto(nonMajorSubject6, 5, localDateTime),
+//            new SeatDto(nonMajorSubject7, 4, localDateTime),
+//            new SeatDto(nonMajorSubject8, 3, localDateTime),
+//            new SeatDto(nonMajorSubject9, 2, localDateTime),
+//            new SeatDto(nonMajorSubject10, 1, localDateTime),
+//            new SeatDto(nonMajorSubject11, 11, localDateTime),
+//            new SeatDto(nonMajorSubject12, 12, localDateTime),
+//            new SeatDto(nonMajorSubject13, 13, localDateTime),
+//            new SeatDto(nonMajorSubject14, 16, localDateTime),
+//            new SeatDto(nonMajorSubject15, 20, localDateTime),
+//            new SeatDto(nonMajorSubject16, 25, localDateTime),
+//            new SeatDto(nonMajorSubject17, 30, localDateTime),
+//            new SeatDto(nonMajorSubject18, 35, localDateTime),
+//            new SeatDto(nonMajorSubject19, 40, localDateTime),
+//            new SeatDto(nonMajorSubject20, 50, localDateTime)
+//        ));
+//
+//        // when
+//        Response response = RestAssured.given()
+//            .accept("text/event-stream")
+//            .when()
+//            .get("/api/connect")
+//            .then()
+//            .statusCode(200)
+//            .extract()
+//            .response();
+//
+//        // then
+//        TestHelper.assertResponseContainsMessage(response, expected);
+//    }
 
     private static class TestHelper {
 


### PR DESCRIPTION
## 작업 내용
### 하계 수강 신청을 위한 로직 수정
저희가 이번 계절 수강 신청때에는 과목이 많이 없다보니 교양만 제공하는 것이 아닌 전체 과목을 제공하기로 했잖아요?  limit을 그래서 20개로 했었는데, 이번엔 창의학기제 제외 전체 과목 수인 39개로 늘렸습니다.
그리고 nonMajor인지 확인 후 필터링 하는 것도 제외했습니다.
새로운 api를 파기에는 프론트와도 맞추어야하는 것이고, 재사용하는 방향으로 논의가 되었다고 생각하고 있어서요. 우선은 그냥 주석 처리를 포함하여 기존 코드를 수정했습니다.
그리고 `/api/preSeat`을 수정했어요. 하드코딩되어있던데,,,, 전 날 크롤링 과목을 제공하면 되잖아요? 그래서 그 전날을 받아오게 했어요.
그런데 수강신청이 끝나고 며칠 지나면 마지막 정보를 전달해주기 힘들겠네요...크롤링을 더 안할테니까요. 근데 하드코딩하니까 너무 놓치기 쉬운 것 같아서 우선 그렇게 수정했습니다.

### 테스트 주석 처리
위의 변경에 따라, 교양만 전송하고, limit이 20개로 제한하는 기능의 테스트가 터져요.
그런데 우선은 재사용하기로 합의가 되었으니 주석처리를 하고 추후 주석 제거를 하는 방향이 맞다고 판단하여 주석 처리를 진행했습니다.

## 고민 지점과 리뷰 포인트
getAllPreSeat()에 대해 수정한 것 어떤지 의견 주면 감사하겠습니다. 수강신청이 끝나고 며칠 지나고 저 메서드를 호출하면 유효한 정보를 제공 못해주자나요. 마지막 날 정보도 못주고.....그게 걸리긴해요.

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->