### PR TITLE
refactor: 2025-하계 조회 쿼리 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/seat/SeatRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatRepository.java
@@ -15,12 +15,14 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
         + "join s.subject sub "
         + "where s.subject = :subject "
         + "and s.createdDate = :today "
-        + "and sub.isDeleted = false")
+        + "and sub.isDeleted = false "
+        + "and sub.semesterAt = '2025-여름'")
     Optional<Seat> findBySubjectAndCreatedDate(Subject subject, LocalDate today);
 
     @Query("select s from Seat s "
         + "join s.subject sub "
         + "where s.createdDate = :createdDate "
-        + "and sub.isDeleted = false")
+        + "and sub.isDeleted = false "
+        + "and sub.semesterAt = '2025-여름'")
     List<Seat> findAllByCreatedDate(LocalDate createdDate);
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/pin/PinRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/pin/PinRepository.java
@@ -11,24 +11,28 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
     @Query("select p from Pin p "
         + "join fetch p.subject s "
         + "where p.token = :tokenId "
+        + "and p.semesterAt = '2025-여름'"
         + "and s.isDeleted = false")
     List<Pin> findAllByToken(String tokenId);
 
     @Query("select p from Pin p "
         + "where p.subject = :subject "
-        + "and p.token = :token")
+        + "and p.token = :token "
+        + "and p.semesterAt = '2025-여름'")
     Optional<Pin> findBySubjectAndTokenToDelete(Subject subject, String token);
 
     @Query("select case when COUNT(p) > 0 then true else false end from Pin p "
         + "join p.subject s "
         + "where p.subject = :subject "
         + "and p.token = :token "
+        + "and p.semesterAt = '2025-여름'"
         + "and s.isDeleted = false")
     boolean existsBySubjectAndToken(Subject subject, String token);
 
     @Query("select count(p) from Pin p "
         + "join p.subject s "
         + "where p.token = :token "
+        + "and p.semesterAt = '2025-여름'"
         + "and s.isDeleted = false ")
     Long countAllByToken(String token);
 }

--- a/src/main/java/kr/allcll/backend/domain/subject/SubjectRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/SubjectRepository.java
@@ -10,11 +10,13 @@ public interface SubjectRepository extends JpaRepository<Subject, Long>, JpaSpec
 
     @Query("select s from Subject s "
         + "where s.deptCd = :deptCd "
-        + "and s.isDeleted = false")
+        + "and s.isDeleted = false "
+        + "and s.semesterAt = '2025-여름'")
     List<Subject> findAllByDeptCd(String deptCd);
 
     @Query("select s from Subject s "
         + "where s.id = :id "
-        + "and s.isDeleted = false")
+        + "and s.isDeleted = false "
+        + "and s.semesterAt = '2025-여름'")
     Optional<Subject> findById(Long id);
 }

--- a/src/main/java/kr/allcll/backend/support/semester/Semester.java
+++ b/src/main/java/kr/allcll/backend/support/semester/Semester.java
@@ -11,7 +11,7 @@ public enum Semester {
     /*
     2025년 1학기 코드 수정할 경우에 [참고](https://github.com/allcll/allcll-backend/pull/121#discussion_r2118843479)
      */
-    SPRING_25("2025-1", LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 31)),
+    SPRING_25("2025/1학기", LocalDate.of(2025, 2, 1), LocalDate.of(2025, 3, 31)),
     SUMMER_25("2025-여름", LocalDate.of(2025, 6, 1), LocalDate.of(2025, 6, 30)),
     FALL_25("2025-2", LocalDate.of(2025, 8, 1), LocalDate.of(2025, 9, 30)),
     WINTER_25("2025-겨울", LocalDate.of(2025, 12, 1), LocalDate.of(2025, 12, 31)),

--- a/src/test/java/kr/allcll/backend/support/semester/UtilServiceTest.java
+++ b/src/test/java/kr/allcll/backend/support/semester/UtilServiceTest.java
@@ -37,7 +37,7 @@ class UtilServiceTest {
 
         // then
         assertAll(
-            () -> assertThat(semesterResponse.semester()).isEqualTo("2025-1"),
+            () -> assertThat(semesterResponse.semester()).isEqualTo("2025/1학기"),
             () -> assertThat(semesterResponse.period().startDate()).isEqualTo(LocalDate.of(2025, 2, 1)),
             () -> assertThat(semesterResponse.period().endDate()).isEqualTo(LocalDate.of(2025, 3, 31))
         );


### PR DESCRIPTION
## 작업 내용
- `2025-여름`에 해당하는 데이터만 조회하도록 쿼리문을 수정하였습니다.
- 추가로 이전 데이터가 `2025/1학기`를 학기 코드로 가지고 있었다는 것을 반영해두었습니다.
- Star와 Basket은 현재 해당 학기 코드 조건을 반영하지 않았습니다. 이유는 이번 여름학기 서비스 대상이 아니기 때문입니다.

## 고민 지점과 리뷰 포인트
- StarRepository와 BasketRepository에도 학기 코드를 조회쿼리에 걸어둘까요?

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->