### PR TITLE
refactor: 핀과목 sse 스케줄링을 제어한다

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/AdminService.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminService.java
@@ -1,6 +1,7 @@
 package kr.allcll.backend.admin;
 
 import kr.allcll.backend.domain.seat.GeneralSeatSender;
+import kr.allcll.backend.domain.seat.PinSeatSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,12 +10,15 @@ import org.springframework.stereotype.Service;
 public class AdminService {
 
     private final GeneralSeatSender generalSeatSender;
+    private final PinSeatSender pinSeatSender;
 
     public void startScheduling() {
         generalSeatSender.send();
+        pinSeatSender.send();
     }
 
     public void cancelScheduling() {
         generalSeatSender.cancel();
+        pinSeatSender.cancel();
     }
 }

--- a/src/main/java/kr/allcll/backend/support/sse/SseApi.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseApi.java
@@ -1,6 +1,5 @@
 package kr.allcll.backend.support.sse;
 
-import kr.allcll.backend.domain.seat.PinSeatSender;
 import kr.allcll.backend.support.web.ThreadLocalHolder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -14,13 +13,11 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class SseApi {
 
     private final SseService sseService;
-    private final PinSeatSender pinSeatSender;
 
     @GetMapping(value = "/api/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> getServerSentEventConnection() {
         String token = ThreadLocalHolder.SHARED_TOKEN.get();
         SseEmitter emitter = sseService.connect(token);
-        pinSeatSender.send(token);
         return ResponseEntity.ok()
             .header("X-Accel-Buffering", "no")
             .body(emitter);

--- a/src/main/java/kr/allcll/backend/support/sse/SseService.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseService.java
@@ -1,6 +1,7 @@
 package kr.allcll.backend.support.sse;
 
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -48,7 +49,7 @@ public class SseService {
         }
     }
 
-    public boolean isDisconnected(String token) {
-        return sseEmitterStorage.getEmitter(token).isEmpty();
+    public List<String> getConnectedTokens() {
+        return sseEmitterStorage.getUserTokens().stream().toList();
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -47,6 +47,10 @@ management:
     web:
       exposure:
         include: prometheus, health
+  datadog:
+    metrics:
+      export:
+        enabled: false
 
 cookie:
   max-age: 2190D

--- a/src/test/java/kr/allcll/backend/domain/seat/PinSeatSenderTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/PinSeatSenderTest.java
@@ -43,12 +43,12 @@ class PinSeatSenderTest {
     void sendPinSeats() throws InterruptedException {
         // given
         String token = "TEST_TOKEN";
-        when(sseService.isDisconnected(token)).thenReturn(false);
+        when(sseService.getConnectedTokens()).thenReturn(List.of(token));
         when(pinRepository.findAllByToken(token)).thenReturn(List.of());
         when(seatStorage.getSeats(any())).thenReturn(List.of());
 
         // when
-        pinSeatSender.send(token);
+        pinSeatSender.send();
         Thread.sleep(1000);
 
         // then
@@ -60,16 +60,15 @@ class PinSeatSenderTest {
     void cancelPinSeatSending() throws InterruptedException {
         // given
         String token = "TEST_TOKEN";
-        when(sseService.isDisconnected(token)).thenReturn(false).thenReturn(true);
+        when(sseService.getConnectedTokens()).thenReturn(List.of(token)).thenReturn(List.of());
         when(pinRepository.findAllByToken(token)).thenReturn(List.of());
         when(seatStorage.getSeats(any())).thenReturn(List.of());
 
         // when
-        pinSeatSender.send(token);
-        Thread.sleep(2500);
+        pinSeatSender.send();
+        Thread.sleep(1500);
 
         // then
-        verify(sseService, atLeastOnce()).propagate(any(), any(), any());
-        verify(scheduledTaskHandler, times(1)).cancel(token);
+        verify(sseService, times(1)).propagate(any(), any(), any());
     }
 }


### PR DESCRIPTION
## 작업 내용

핀과목 여석을 sse로 전송하던 스케줄링을 제어할 수 있게 수정했어요. 이제 어드민 API를 사용하면 `pin 과목 여석`과 `general 과목 여석` 둘다 제어할 수 있어요. 

pin 과목 여석을 제어할 수 있게 하면서 구조적인 변경이 있었어요. 
pin 과목 여석을 전송하는 sse 이벤트는 사용자가 sse 커넥션을 맺는 시점에 생성되어 1초마다 스케줄링 되었어요. 

```java
public class SseApi {

    private final SseService sseService;
    private final PinSeatSender pinSeatSender;

    @GetMapping(value = "/api/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
    public ResponseEntity<SseEmitter> getServerSentEventConnection() {
        String token = ThreadLocalHolder.SHARED_TOKEN.get();
        SseEmitter emitter = sseService.connect(token);
        pinSeatSender.send(token); // 이 부분
        return ResponseEntity.ok()
            .header("X-Accel-Buffering", "no")
            .body(emitter);
```

스케줄링을 시작하고 끝내는 것의 제어권이 사용자에게 있었다고 할 수 있는데요. 사용자가 커넥션을 맺으면 스케줄링을 시작하니깐요. 

이 제어권을 우리 시스템이 갖고 오도록 수정했어요. general 여석 스케줄링과 동일한 구조인데요. 서버에서 스케줄링을 시작하면, sseStorage에서 현재 연결된 모든 sse 커넥션을 조회하고, 각 token의 pins을 조회해서 보내는 구조에요. 

## 고민 지점과 리뷰 포인트

이전에는 핀과목 여석을 sse로 보내는 스케줄링이 20개의 스레드를 사용했어요. 동시에 20개 스레드에서 사용자에게 pin 과목을 전송하는 건데요. 제어권이 서버에 오면서 구조적으로 하나의 스레드에서 모든 스케줄링하게 되었어요. 이게 얼마나 성능 저하가 있을 지 모르겠어요. 
스케줄링 한 사이클에 걸리는 시간을 측정해보면 좋을 것 같아요. 현재 시간이 없어서 일단 이대로 두기로 했어요. 