### PR TITLE
feat: admin api에 권한 부여

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/AdminApi.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminApi.java
@@ -1,5 +1,6 @@
 package kr.allcll.backend.admin;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,15 +11,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminApi {
 
     private final AdminService adminService;
+    private final AdminRequestValidator validator;
 
     @PostMapping("/api/admin/scheduler/start")
-    public ResponseEntity<Void> startScheduling() {
+    public ResponseEntity<Void> startScheduling(HttpServletRequest request) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
         adminService.startScheduling();
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/api/admin/scheduler/cancel")
-    public ResponseEntity<Void> cancelScheduling() {
+    public ResponseEntity<Void> cancelScheduling(HttpServletRequest request) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
         adminService.cancelScheduling();
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kr/allcll/backend/admin/AdminRequestValidator.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminRequestValidator.java
@@ -1,0 +1,36 @@
+package kr.allcll.backend.admin;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdminRequestValidator {
+
+    private static final String AUTH_HEADER = "X-ADMIN-TOKEN";
+    private static final long REQUEST_INTERVAL_SECONDS = 5;
+
+    private final Map<String, Long> lastRequestTimeByIp = new ConcurrentHashMap<>();
+
+    @Value("${admin.token}")
+    private String adminToken;
+
+    public boolean isUnauthorized(HttpServletRequest request) {
+        String token = request.getHeader(AUTH_HEADER);
+        return !adminToken.equals(token);
+    }
+
+    public boolean isRateLimited(HttpServletRequest request) {
+        String ip = request.getRemoteAddr();
+        long now = Instant.now().getEpochSecond();
+
+        Long lastTime = lastRequestTimeByIp.get(ip);
+        lastRequestTimeByIp.put(ip, now);
+
+        System.out.println("IP: " + ip + ", Last Request Time: " + lastTime + ", Now: " + now);
+        return lastTime != null && now - lastTime < REQUEST_INTERVAL_SECONDS;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -55,3 +55,6 @@ cookie:
   same-site: strict
   domain: localhost
   path: /
+
+admin:
+  token:


### PR DESCRIPTION
## 작업 내용

admin api에 권한을 추가했습니다. 여러 방법 중 가장 공수가 적게 드는 방법을 택했어요. 

admin api에만 X-ADMIN-HEADER으로 권한을 확인하게 했어요. 어드민 토큰은 개발과 운영 환경 yml에 설정이 필요해요. 
혹시나 브루트포스 해킹 시도가 있을 수 있어서, 5초에 한 번만 요청을 날릴 수 있도록 제한을 두었어요. 
