### PR TITLE
feat: SeatStorage 로깅 추가 

### DIFF
--- a/src/main/java/kr/allcll/backend/config/ExternalPreInvoker.java
+++ b/src/main/java/kr/allcll/backend/config/ExternalPreInvoker.java
@@ -19,7 +19,7 @@ public class ExternalPreInvoker {
 
     @Retryable(
         maxAttempts = 12 * 60 * 7,
-        backoff = @Backoff(delay = 100, multiplier = 1.5, maxDelay = 5000)
+        backoff = @Backoff(delay = 5000, multiplier = 1.5, maxDelay = 10000)
     )
     public void sendSseConnectionToExternal() {
         try {

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
@@ -57,6 +57,10 @@ public class SeatStorage {
         seatDtos.forEach(this::add);
     }
 
+    public List<SeatDto> getAll() {
+        return new ArrayList<>(seats.values());
+    }
+
     public void clear() {
         seats.clear();
     }

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatStorageLogger.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatStorageLogger.java
@@ -1,0 +1,48 @@
+package kr.allcll.backend.domain.seat;
+
+import java.util.stream.Collectors;
+import kr.allcll.backend.domain.seat.dto.SeatDto;
+import kr.allcll.backend.domain.subject.Subject;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SeatStorageLogger {
+
+    private final SeatStorage seatStorage;
+
+    public SeatStorageLogger(SeatStorage seatStorage) {
+        this.seatStorage = seatStorage;
+    }
+
+    @Scheduled(fixedRate = 10000)
+    public void logSeats() {
+        String jsonArray = seatStorage.getAll().stream()
+            .map(this::toJson)
+            .collect(Collectors.joining(",", "[", "]"));
+
+        log.info("[SEAT_STORAGE_METRICS] {}", jsonArray);
+    }
+
+    private String toJson(SeatDto seat) {
+        Subject subject = seat.getSubject();
+        return String.format(
+            """
+                {
+                    "subjectId":%d,
+                    "curiNo":"%s",
+                    "class":"%s",
+                    "seatCount":%d,
+                    "queryTime":"%s"
+                }
+                """,
+            subject.getId(),
+            subject.getCuriNo(),
+            subject.getClassName(),
+            seat.getSeatCount(),
+            seat.getQueryTime()
+        );
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,15 +1,13 @@
 <configuration>
   <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE">
     <encoder>
-      <!-- 콘솔에 로그 출력 형식 -->
       <pattern>${LOG_PATTERN}</pattern>
     </encoder>
   </appender>
 
   <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="ERROR-ROLLING">
     <encoder>
-      <!-- 날짜, 시간, 로그 레벨, 스레드 이름, 로거 이름, 메시지 형식 -->
-      <pattern>${LOG_PATTERN}</pattern>
+      <pattern>${LOG_FILE_PATTERN}</pattern>
     </encoder>
     <file>${LOG_PATH}/spring-boot-application-error.log</file>
     <filter class="ch.qos.logback.classic.filter.LevelFilter">
@@ -25,8 +23,7 @@
 
   <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="WARN-ROLLING">
     <encoder>
-      <!-- 날짜, 시간, 로그 레벨, 스레드 이름, 로거 이름, 메시지 형식 -->
-      <pattern>${LOG_PATTERN}</pattern>
+      <pattern>${LOG_FILE_PATTERN}</pattern>
     </encoder>
     <file>${LOG_PATH}/spring-boot-application-warn.log</file>
     <filter class="ch.qos.logback.classic.filter.LevelFilter">
@@ -42,8 +39,7 @@
 
   <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="INFO-ROLLING">
     <encoder>
-      <!-- 날짜, 시간, 로그 레벨, 스레드 이름, 로거 이름, 메시지 형식 -->
-      <pattern>${LOG_PATTERN}</pattern>
+      <pattern>${LOG_FILE_PATTERN}</pattern>
     </encoder>
     <file>${LOG_PATH}/spring-boot-application-info.log</file>
     <filter class="ch.qos.logback.classic.filter.LevelFilter">
@@ -59,8 +55,7 @@
 
   <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="DEBUG-ROLLING">
     <encoder>
-      <!-- 날짜, 시간, 로그 레벨, 스레드 이름, 로거 이름, 메시지 형식 -->
-      <pattern>${LOG_PATTERN}</pattern>
+      <pattern>${LOG_FILE_PATTERN}</pattern>
     </encoder>
     <file>${LOG_PATH}/spring-boot-application-debug.log</file>
     <filter class="ch.qos.logback.classic.filter.LevelFilter">
@@ -74,13 +69,16 @@
     </rollingPolicy>
   </appender>
 
-  <!-- 로그 패턴에 색상 적용 %clr(pattern){color} -->
   <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 
-  <!-- log 변수 값 설정 -->
   <property name="LOG_PATTERN"
     value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
+  <property name="LOG_FILE_PATTERN"
+    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %-5level ${PID:-} --- [%15.15thread] %-40.40logger{36} : %msg%n"/>
+
+  <!--  ec2와 local 에서의 로그 경로 분리  -->
   <property name="LOG_PATH" value="${LOG_PATH:-/home/ubuntu/app/logs}"/>
+  <property name="LOCAL_LOG_PATH" value="./logs"/>
 
   <springProfile name="default">
     <root level="INFO">
@@ -88,9 +86,14 @@
     </root>
   </springProfile>
 
+  <!--  local 에서는 콘솔과 파일 모두에 로그 생성  -->
   <springProfile name="local">
+    <property name="LOG_PATH" value="${LOCAL_LOG_PATH}"/>
     <root level="INFO">
       <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="ERROR-ROLLING"/>
+      <appender-ref ref="WARN-ROLLING"/>
+      <appender-ref ref="INFO-ROLLING"/>
     </root>
   </springProfile>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -17,7 +17,7 @@
     </filter>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <fileNamePattern>${LOG_PATH}/spring-boot-application-error.%d{yyyy-MM-dd}.log</fileNamePattern>
-      <maxHistory>30</maxHistory>
+      <maxHistory>7</maxHistory>
     </rollingPolicy>
   </appender>
 
@@ -33,7 +33,7 @@
     </filter>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <fileNamePattern>${LOG_PATH}/spring-boot-application-warn.%d{yyyy-MM-dd}.log</fileNamePattern>
-      <maxHistory>30</maxHistory>
+      <maxHistory>7</maxHistory>
     </rollingPolicy>
   </appender>
 
@@ -49,7 +49,7 @@
     </filter>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <fileNamePattern>${LOG_PATH}/spring-boot-application-info.%d{yyyy-MM-dd}.log</fileNamePattern>
-      <maxHistory>30</maxHistory>
+      <maxHistory>7</maxHistory>
     </rollingPolicy>
   </appender>
 
@@ -65,7 +65,7 @@
     </filter>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <fileNamePattern>${LOG_PATH}/spring-boot-application-debug.%d{yyyy-MM-dd}.log</fileNamePattern>
-      <maxHistory>30</maxHistory>
+      <maxHistory>7</maxHistory>
     </rollingPolicy>
   </appender>
 


### PR DESCRIPTION
## 작업 내용

- SeatStorage에 어떤 데이터가 들어있는지 확인할 필요가 있어요. 메트릭으로 수집하여 했는데, 시각화하는 게 마땅치 않아서 일단 로깅을 하였어요. 
- 로그 롤링 주기를 30일 -> 7일로 낮췄어요. 디스크 용량이 부족해서요. 
- Logback 파일도 수정했어요. 주요 변경 사항으로는 `기존에 로컬에서는 콘솔로만 로그를 기록함` -> `로컬에서 콘솔과 파일로 로그를 기록함`입니다. 