### PR TITLE
feat: TimeTable 기능 구현

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/timetable/TimeTableRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/TimeTableRepository.java
@@ -18,6 +18,12 @@ public interface TimeTableRepository extends JpaRepository<TimeTable, Long> {
 
     @Query("""
         SELECT t FROM TimeTable t 
+        WHERE t.id = :id
+        """)
+    Optional<TimeTable> findById(@Param("id") Long id);
+
+    @Query("""
+        SELECT t FROM TimeTable t 
         WHERE t.id = :id 
         AND t.token = :token
         """)

--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/CustomSchedule.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/CustomSchedule.java
@@ -1,0 +1,106 @@
+package kr.allcll.backend.domain.timetable.schedule;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.TableGenerator;
+import java.time.LocalTime;
+import kr.allcll.backend.domain.timetable.TimeTable;
+import kr.allcll.backend.support.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "custom_schedule")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomSchedule extends BaseEntity {
+
+    @Id
+    @Column(name = "id")
+    @TableGenerator(
+        name = "schedule_id_generator",
+        table = "id_generator",
+        pkColumnName = "gen_name",
+        valueColumnName = "gen_val",
+        pkColumnValue = "schedule",
+        allocationSize = 1
+    )
+    @GeneratedValue(strategy = GenerationType.TABLE, generator = "schedule_id_generator")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "timetable_id")
+    private TimeTable timeTable;
+
+    @Column(name = "subject_name")
+    private String subjectName;
+
+    @Column(name = "professor_name")
+    private String professorName;
+
+    @Column(name = "location")
+    private String location;
+
+    @Column(name = "day_of_weeks")
+    private String dayOfWeeks;
+
+    @Column(name = "start_time")
+    private LocalTime startTime;
+
+    @Column(name = "end_time")
+    private LocalTime endTime;
+
+    public CustomSchedule(
+        TimeTable timeTable,
+        String subjectName,
+        String professorName,
+        String location,
+        String dayOfWeeks,
+        LocalTime startTime,
+        LocalTime endTime
+    ) {
+        this.timeTable = timeTable;
+        this.subjectName = subjectName;
+        this.professorName = professorName;
+        this.location = location;
+        this.dayOfWeeks = dayOfWeeks;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public void updateSchedule(
+        String subjectName,
+        String professorName,
+        String location,
+        String dayOfWeeks,
+        LocalTime startTime,
+        LocalTime endTime
+    ) {
+        if (subjectName != null) {
+            this.subjectName = subjectName;
+        }
+        if (professorName != null) {
+            this.professorName = professorName;
+        }
+        if (location != null) {
+            this.location = location;
+        }
+        if (dayOfWeeks != null) {
+            this.dayOfWeeks = dayOfWeeks;
+        }
+        if (startTime != null) {
+            this.startTime = startTime;
+        }
+        if (endTime != null) {
+            this.endTime = endTime;
+        }
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/CustomScheduleRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/CustomScheduleRepository.java
@@ -1,0 +1,41 @@
+package kr.allcll.backend.domain.timetable.schedule;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomScheduleRepository extends JpaRepository<CustomSchedule, Long> {
+
+    @Query("""
+        SELECT cs FROM CustomSchedule cs 
+        WHERE cs.timeTable.id = :timetableId 
+        AND cs.isDeleted = false
+        """)
+    List<CustomSchedule> findAllByTimeTableId(@Param("timetableId") Long timetableId);
+
+    @Query("""
+        SELECT cs
+        FROM CustomSchedule cs
+        WHERE cs.id = :scheduleId
+        AND cs.timeTable.id = :timetableId
+        """)
+    Optional<CustomSchedule> findByIdAndTimeTableId(
+        @Param("scheduleId") Long scheduleId,
+        @Param("timetableId") Long timetableId
+    );
+
+    @Modifying
+    @Query("""
+        DELETE FROM CustomSchedule cs 
+        WHERE cs.id = :id 
+        AND cs.timeTable.id = :timeTableId
+        """)
+    int deleteByIdAndTimeTableId(
+        @Param("id") Long id,
+        @Param("timeTableId") Long timeTableId);
+}

--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/OfficialSchedule.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/OfficialSchedule.java
@@ -1,0 +1,51 @@
+package kr.allcll.backend.domain.timetable.schedule;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.TableGenerator;
+import kr.allcll.backend.domain.subject.Subject;
+import kr.allcll.backend.domain.timetable.TimeTable;
+import kr.allcll.backend.support.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "official_schedule")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OfficialSchedule extends BaseEntity {
+
+    @Id
+    @Column(name = "id")
+    @TableGenerator(
+        name = "schedule_id_generator",
+        table = "id_generator",
+        pkColumnName = "gen_name",
+        valueColumnName = "gen_val",
+        pkColumnValue = "schedule",
+        allocationSize = 1
+    )
+    @GeneratedValue(strategy = GenerationType.TABLE, generator = "schedule_id_generator")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "timetable_id")
+    private TimeTable timeTable;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subject_id", nullable = false)
+    private Subject subject;
+
+    public OfficialSchedule(TimeTable timeTable, Subject subject) {
+        this.timeTable = timeTable;
+        this.subject = subject;
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/OfficialScheduleRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/OfficialScheduleRepository.java
@@ -1,0 +1,39 @@
+package kr.allcll.backend.domain.timetable.schedule;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OfficialScheduleRepository extends JpaRepository<OfficialSchedule, Long> {
+
+    @Query("""
+        SELECT os FROM OfficialSchedule os 
+        WHERE os.timeTable.id = :timetableId 
+        """)
+    List<OfficialSchedule> findAllByTimeTableId(@Param("timetableId") Long timetableId);
+
+    @Modifying
+    @Query("""
+        DELETE FROM OfficialSchedule os 
+        WHERE os.id = :id 
+        AND os.timeTable.id = :timeTableId
+        """)
+    int deleteByIdAndTimeTableId(
+        @Param("id") Long id,
+        @Param("timeTableId") Long timeTableId);
+
+    @Query("""
+        SELECT CASE WHEN COUNT(os) > 0 THEN TRUE ELSE FALSE END
+        FROM OfficialSchedule os
+        WHERE os.timeTable.id = :timetableId
+        AND os.subject.id = :subjectId
+        """)
+    boolean existsByTimeTableIdAndSubjectId(
+        @Param("timetableId") Long timetableId,
+        @Param("subjectId") Long subjectId
+    );
+}

--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/ScheduleApi.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/ScheduleApi.java
@@ -1,0 +1,77 @@
+package kr.allcll.backend.domain.timetable.schedule;
+
+import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleCreateRequest;
+import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleResponse;
+import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleUpdateRequest;
+import kr.allcll.backend.domain.timetable.schedule.dto.TimeTableDetailResponse;
+import kr.allcll.backend.support.web.ThreadLocalHolder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/timetables")
+@RequiredArgsConstructor
+public class ScheduleApi {
+
+    private final ScheduleService scheduleService;
+
+    @PostMapping("/{timeTableId}/schedules")
+    public ResponseEntity<ScheduleResponse> addSchedule(
+        @PathVariable(name = "timeTableId") Long timeTableId,
+        @RequestBody ScheduleCreateRequest scheduleRequest
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(
+                scheduleService.addSchedule(
+                    timeTableId,
+                    scheduleRequest,
+                    ThreadLocalHolder.SHARED_TOKEN.get())
+            );
+    }
+
+    @GetMapping("/{timeTableId}/schedules")
+    public ResponseEntity<TimeTableDetailResponse> getTimeTableWithSchedules(
+        @PathVariable(name = "timeTableId") Long timeTableId
+    ) {
+        return ResponseEntity.ok(
+            scheduleService.getTimeTableWithSchedules(timeTableId, ThreadLocalHolder.SHARED_TOKEN.get())
+        );
+    }
+
+    @PatchMapping("/{timeTableId}/schedules/{scheduleId}")
+    public ResponseEntity<ScheduleResponse> updateSchedule(
+        @PathVariable(name = "timeTableId") Long timeTableId,
+        @PathVariable(name = "scheduleId") Long scheduleId,
+        @RequestBody ScheduleUpdateRequest updateRequest
+    ) {
+        ScheduleResponse updated = scheduleService.updateSchedule(
+            timeTableId,
+            scheduleId,
+            updateRequest,
+            ThreadLocalHolder.SHARED_TOKEN.get()
+        );
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("{timeTableId}/schedules/{scheduleId}")
+    public ResponseEntity<Void> deleteSchedule(
+        @PathVariable(name = "timeTableId") Long timeTableId,
+        @PathVariable(name = "scheduleId") Long scheduleId
+    ) {
+        scheduleService.deleteSchedule(
+            timeTableId,
+            scheduleId,
+            ThreadLocalHolder.SHARED_TOKEN.get()
+        );
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/ScheduleService.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/ScheduleService.java
@@ -1,0 +1,140 @@
+package kr.allcll.backend.domain.timetable.schedule;
+
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import kr.allcll.backend.domain.subject.Subject;
+import kr.allcll.backend.domain.subject.SubjectRepository;
+import kr.allcll.backend.domain.timetable.TimeTable;
+import kr.allcll.backend.domain.timetable.TimeTableRepository;
+import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleCreateRequest;
+import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleResponse;
+import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleUpdateRequest;
+import kr.allcll.backend.domain.timetable.schedule.dto.TimeTableDetailResponse;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final TimeTableRepository timeTableRepository;
+    private final SubjectRepository subjectRepository;
+    private final OfficialScheduleRepository officialScheduleRepository;
+    private final CustomScheduleRepository customScheduleRepository;
+
+    @Transactional
+    public ScheduleResponse addSchedule(
+        Long timeTableId,
+        ScheduleCreateRequest request,
+        String token
+    ) {
+        TimeTable timeTable = getAuthorizedTimeTable(timeTableId, token);
+
+        if (request.scheduleType() == ScheduleType.OFFICIAL) {
+            validateDuplicatedSubject(request, timeTable);
+            Subject subject = subjectRepository.findById(request.subjectId())
+                .orElseThrow(() -> new AllcllException(AllcllErrorCode.SUBJECT_NOT_FOUND));
+
+            OfficialSchedule schedule = new OfficialSchedule(timeTable, subject);
+            officialScheduleRepository.save(schedule);
+
+            return ScheduleResponse.fromOfficial(schedule, subject);
+
+        } else {
+            CustomSchedule schedule = new CustomSchedule(
+                timeTable,
+                request.subjectName(),
+                request.professorName(),
+                request.location(),
+                request.dayOfWeeks(),
+                LocalTime.parse(request.startTime()),
+                LocalTime.parse(request.endTime())
+            );
+            customScheduleRepository.save(schedule);
+            return ScheduleResponse.fromCustom(schedule);
+        }
+    }
+
+    public TimeTableDetailResponse getTimeTableWithSchedules(Long timeTableId, String token) {
+        TimeTable timeTable = getAuthorizedTimeTable(timeTableId, token);
+
+        List<ScheduleResponse> schedules = Stream.concat(
+                officialScheduleRepository.findAllByTimeTableId(timeTableId).stream()
+                    .map(s -> ScheduleResponse.fromOfficial(s, s.getSubject())),
+                customScheduleRepository.findAllByTimeTableId(timeTableId).stream()
+                    .map(ScheduleResponse::fromCustom)
+            )
+            .sorted(Comparator.comparing(ScheduleResponse::scheduleId))
+            .collect(Collectors.toList());
+
+        return TimeTableDetailResponse.from(timeTable, schedules);
+    }
+
+    @Transactional
+    public ScheduleResponse updateSchedule(
+        Long timetableId,
+        Long scheduleId,
+        ScheduleUpdateRequest request,
+        String token
+    ) {
+        TimeTable timeTable = getAuthorizedTimeTable(timetableId, token);
+
+        CustomSchedule schedule = customScheduleRepository
+            .findByIdAndTimeTableId(scheduleId, timeTable.getId())
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.SCHEDULE_NOT_FOUND));
+
+        schedule.updateSchedule(
+            request.subjectName(),
+            request.professorName(),
+            request.location(),
+            request.dayOfWeeks(),
+            request.startTime() != null ? LocalTime.parse(request.startTime()) : null,
+            request.endTime() != null ? LocalTime.parse(request.endTime()) : null
+        );
+
+        return ScheduleResponse.fromCustom(schedule);
+    }
+
+    @Transactional
+    public void deleteSchedule(
+        Long timeTableId,
+        Long scheduleId,
+        String token
+    ) {
+        TimeTable timeTable = getAuthorizedTimeTable(timeTableId, token);
+
+        int deletedCustom = customScheduleRepository.deleteByIdAndTimeTableId(scheduleId, timeTable.getId());
+        if (deletedCustom > 0) {
+            return;
+        }
+
+        int deletedOfficial = officialScheduleRepository.deleteByIdAndTimeTableId(scheduleId, timeTable.getId());
+        if (deletedOfficial > 0) {
+            return;
+        }
+
+        throw new AllcllException(AllcllErrorCode.SCHEDULE_NOT_FOUND);
+    }
+
+    private TimeTable getAuthorizedTimeTable(Long timeTableId, String token) {
+        TimeTable timeTable = timeTableRepository.findById(timeTableId)
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.TIMETABLE_NOT_FOUND));
+        if (!timeTable.getToken().equals(token)) {
+            throw new AllcllException(AllcllErrorCode.UNAUTHORIZED_ACCESS);
+        }
+        return timeTable;
+    }
+
+    private void validateDuplicatedSubject(ScheduleCreateRequest request, TimeTable timeTable) {
+        if (officialScheduleRepository.existsByTimeTableIdAndSubjectId(timeTable.getId(), request.subjectId())) {
+            throw new AllcllException(AllcllErrorCode.DUPLICATE_SCHEDULE);
+        }
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/ScheduleType.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/ScheduleType.java
@@ -1,0 +1,19 @@
+package kr.allcll.backend.domain.timetable.schedule;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ScheduleType {
+    OFFICIAL,
+    CUSTOM;
+
+    @JsonCreator
+    public static ScheduleType from(String value) {
+        return ScheduleType.valueOf(value.toUpperCase());
+    }
+
+    @JsonValue
+    public String toValue() {
+        return this.name().toLowerCase();
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/dto/ScheduleCreateRequest.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/dto/ScheduleCreateRequest.java
@@ -1,0 +1,18 @@
+package kr.allcll.backend.domain.timetable.schedule.dto;
+
+import kr.allcll.backend.domain.timetable.schedule.ScheduleType;
+import org.antlr.v4.runtime.misc.NotNull;
+
+public record ScheduleCreateRequest(
+    @NotNull
+    ScheduleType scheduleType,
+    Long subjectId,
+    String subjectName,
+    String professorName,
+    String location,
+    String dayOfWeeks,
+    String startTime,
+    String endTime
+) {
+
+}

--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/dto/ScheduleResponse.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/dto/ScheduleResponse.java
@@ -1,0 +1,47 @@
+package kr.allcll.backend.domain.timetable.schedule.dto;
+
+import kr.allcll.backend.domain.subject.Subject;
+import kr.allcll.backend.domain.timetable.schedule.CustomSchedule;
+import kr.allcll.backend.domain.timetable.schedule.OfficialSchedule;
+import kr.allcll.backend.domain.timetable.schedule.ScheduleType;
+
+public record ScheduleResponse(
+    Long scheduleId,
+    String scheduleType,
+    Long subjectId,
+    String subjectName,
+    String professorName,
+    String location,
+    String dayOfWeeks,
+    String startTime,
+    String endTime
+) {
+
+    public static ScheduleResponse fromOfficial(OfficialSchedule schedule, Subject subject) {
+        return new ScheduleResponse(
+            schedule.getId(),
+            ScheduleType.OFFICIAL.toValue(),
+            subject.getId(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+    }
+
+    public static ScheduleResponse fromCustom(CustomSchedule schedule) {
+        return new ScheduleResponse(
+            schedule.getId(),
+            ScheduleType.CUSTOM.toValue(),
+            null,
+            schedule.getSubjectName(),
+            schedule.getProfessorName(),
+            schedule.getLocation(),
+            schedule.getDayOfWeeks(),
+            schedule.getStartTime().toString(),
+            schedule.getEndTime().toString()
+        );
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/dto/ScheduleUpdateRequest.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/dto/ScheduleUpdateRequest.java
@@ -1,0 +1,12 @@
+package kr.allcll.backend.domain.timetable.schedule.dto;
+
+public record ScheduleUpdateRequest(
+    String subjectName,
+    String professorName,
+    String location,
+    String dayOfWeeks,
+    String startTime,
+    String endTime
+) {
+
+}

--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/dto/TimeTableDetailResponse.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/dto/TimeTableDetailResponse.java
@@ -1,0 +1,21 @@
+package kr.allcll.backend.domain.timetable.schedule.dto;
+
+import java.util.List;
+import kr.allcll.backend.domain.timetable.TimeTable;
+
+public record TimeTableDetailResponse(
+    Long timetableId,
+    String timetableName,
+    String semester,
+    List<ScheduleResponse> schedules
+) {
+
+    public static TimeTableDetailResponse from(TimeTable timeTable, List<ScheduleResponse> schedules) {
+        return new TimeTableDetailResponse(
+            timeTable.getId(),
+            timeTable.getTimeTableName(),
+            timeTable.getSemester().getValue(),
+            schedules
+        );
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
@@ -24,7 +24,8 @@ public enum AllcllErrorCode {
     TIMETABLE_NOT_FOUND("시간표를 찾을 수 없습니다."),
     UNAUTHORIZED_ACCESS("접근 권한이 없습니다."),
     INVALID_SEMESTER("유효하지 않은 학기입니다."),
-    ;
+    SCHEDULE_NOT_FOUND("일정을 찾을 수 없습니다."),
+    DUPLICATE_SCHEDULE("이미 시간표에 등록된 일정입니다.");
 
     private String message;
 

--- a/src/test/java/kr/allcll/backend/domain/timetable/schedule/ScheduleApiTest.java
+++ b/src/test/java/kr/allcll/backend/domain/timetable/schedule/ScheduleApiTest.java
@@ -1,0 +1,345 @@
+package kr.allcll.backend.domain.timetable.schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import java.util.List;
+import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleCreateRequest;
+import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleResponse;
+import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleUpdateRequest;
+import kr.allcll.backend.domain.timetable.schedule.dto.TimeTableDetailResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(ScheduleApi.class)
+class ScheduleApiTest {
+
+    private static final String BASE_URL = "/api/timetables";
+    private static final String VALID_TOKEN = "adminToken";
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ScheduleService scheduleService;
+
+    @Test
+    @DisplayName("시간표 일정에 커스텀 과목을 정상적으로 등록할 때 요청과 응답을 확인한다.")
+    void addCustomSchedule() throws Exception {
+        // given
+        ScheduleCreateRequest request = new ScheduleCreateRequest(
+            ScheduleType.CUSTOM,
+            null,
+            "커스텀 과목",
+            "커스텀 교수",
+            "커스텀 강의실 위치",
+            "커스텀 요일",
+            "09:00",
+            "10:30"
+        );
+        ScheduleResponse response = new ScheduleResponse(
+            1L,
+            ScheduleType.CUSTOM.toValue(),
+            null,
+            "커스텀 과목",
+            "커스텀 교수",
+            "커스텀 강의실 위치",
+            "커스텀 요일",
+            "09:00",
+            "10:30"
+        );
+        when(scheduleService.addSchedule(eq(1L), any(ScheduleCreateRequest.class), eq(VALID_TOKEN)))
+            .thenReturn(response);
+
+        String expected = """
+            {
+                "scheduleId": 1,
+                "scheduleType": "custom",
+                "subjectId": null,
+                "subjectName": "커스텀 과목",
+                "professorName": "커스텀 교수",
+                "location": "커스텀 강의실 위치",
+                "dayOfWeeks": "커스텀 요일",
+                "startTime": "09:00",
+                "endTime": "10:30"
+            }
+            """;
+
+        // when
+        MvcResult result = mockMvc.perform(post(BASE_URL + "/{timeTableId}/schedules", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .cookie(new Cookie("token", VALID_TOKEN)))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        // then
+        assertThat(result.getResponse().getContentAsString()).isEqualToIgnoringWhitespace(expected);
+    }
+
+    @Test
+    @DisplayName("시간표 일정에 공식 과목을 정상적으로 등록할 때 요청과 응답을 확인한다.")
+    void addOfficialSchedule() throws Exception {
+        // given
+        ScheduleCreateRequest request = new ScheduleCreateRequest(
+            ScheduleType.OFFICIAL,
+            1L,
+            "공식 과목",
+            "공식 교수",
+            null,
+            null,
+            null,
+            null
+        );
+        ScheduleResponse response = new ScheduleResponse(
+            1L,
+            ScheduleType.OFFICIAL.toValue(),
+            1L,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        when(scheduleService.addSchedule(eq(1L), any(ScheduleCreateRequest.class), eq(VALID_TOKEN)))
+            .thenReturn(response);
+
+        String expected = """
+            {
+                "scheduleId": 1,
+                "scheduleType": "official",
+                "subjectId": 1,
+                "subjectName": null,
+                "professorName": null,
+                "location": null,
+                "dayOfWeeks": null,
+                "startTime": null,
+                "endTime": null
+            }
+            """;
+
+        // when
+        MvcResult result = mockMvc.perform(post(BASE_URL + "/{timeTableId}/schedules", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .cookie(new Cookie("token", VALID_TOKEN)))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        // then
+        assertThat(result.getResponse().getContentAsString()).isEqualToIgnoringWhitespace(expected);
+    }
+
+    @Test
+    @DisplayName("특정 시간표의 등록된 일정 목록을 정상적으로 조회할 때 요청과 응답을 확인한다.")
+    void getTimeTableWithSchedules() throws Exception {
+        // given
+        TimeTableDetailResponse response = new TimeTableDetailResponse(
+            1L,
+            "새 시간표",
+            "2025-2",
+            List.of(
+                new ScheduleResponse(
+                    1L,
+                    ScheduleType.OFFICIAL.toValue(),
+                    1L,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                ),
+                new ScheduleResponse(
+                    2L,
+                    ScheduleType.CUSTOM.toValue(),
+                    null,
+                    "커스텀 과목",
+                    "커스텀 교수",
+                    "커스텀 강의실 위치",
+                    "커스텀 요일",
+                    "09:00",
+                    "10:30"
+                )
+            )
+        );
+        when(scheduleService.getTimeTableWithSchedules(eq(1L), eq(VALID_TOKEN)))
+            .thenReturn(response);
+
+        String expected = """
+            {
+                "timetableId": 1,
+                "timetableName": "새 시간표",
+                "semester": "2025-2",
+                "schedules": [
+                    {
+                        "scheduleId": 1,
+                        "scheduleType": "official",
+                        "subjectId": 1,
+                        "subjectName": null,
+                        "professorName": null,
+                        "location": null,
+                        "dayOfWeeks": null,
+                        "startTime": null,
+                        "endTime": null
+                    },
+                    {
+                        "scheduleId": 2,
+                        "scheduleType": "custom",
+                        "subjectId": null,
+                        "subjectName": "커스텀 과목",
+                        "professorName": "커스텀 교수",
+                        "location": "커스텀 강의실 위치",
+                        "dayOfWeeks": "커스텀 요일",
+                        "startTime": "09:00",
+                        "endTime": "10:30"
+                    }
+                ]
+            }
+            """;
+
+        // when
+        MvcResult result = mockMvc.perform(get(BASE_URL + "/{timeTableId}/schedules", 1L)
+                .cookie(new Cookie("token", VALID_TOKEN)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        // then
+        assertThat(result.getResponse().getContentAsString()).isEqualToIgnoringWhitespace(expected);
+    }
+
+    @Test
+    @DisplayName("커스텀 스케줄의 전체 정보를 정상적으로 수정할 때 요청과 응답을 확인한다.")
+    void updateEntireCustomSchedule() throws Exception {
+        // given
+        ScheduleUpdateRequest request = new ScheduleUpdateRequest(
+            "수정된 커스텀 과목",
+            "수정된 교수",
+            "수정된 강의실 위치",
+            "수정된 요일",
+            "09:00",
+            "10:30"
+        );
+        ScheduleResponse response = new ScheduleResponse(
+            1L,
+            ScheduleType.CUSTOM.toValue(),
+            null,
+            "수정된 커스텀 과목",
+            "수정된 교수",
+            "수정된 강의실 위치",
+            "수정된 요일",
+            "09:00",
+            "10:30"
+        );
+        when(scheduleService.updateSchedule(eq(1L), eq(1L), any(ScheduleUpdateRequest.class), eq(VALID_TOKEN)))
+            .thenReturn(response);
+
+        String expected = """
+            {
+                "scheduleId": 1,
+                "scheduleType": "custom",
+                "subjectId": null,
+                "subjectName": "수정된 커스텀 과목",
+                "professorName": "수정된 교수",
+                "location": "수정된 강의실 위치",
+                "dayOfWeeks": "수정된 요일",
+                "startTime": "09:00",
+                "endTime": "10:30"
+            }
+            """;
+
+        // when
+        MvcResult result = mockMvc.perform(patch(BASE_URL + "/{timeTableId}/schedules/{scheduleId}", 1L, 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .cookie(new Cookie("token", VALID_TOKEN)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        // then
+        assertThat(result.getResponse().getContentAsString()).isEqualToIgnoringWhitespace(expected);
+    }
+
+    @Test
+    @DisplayName("커스텀 스케줄의 일부 정보를 정상적으로 수정할 때 요청과 응답을 확인한다.")
+    void updatePartialCustomSchedule() throws Exception {
+        // given
+        ScheduleUpdateRequest request = new ScheduleUpdateRequest(
+            "수정된 커스텀 과목",
+            "수정된 교수님 성함",
+            "수정된 강의실 위치",
+            null,
+            null,
+            null
+        );
+        ScheduleResponse response = new ScheduleResponse(
+            1L,
+            ScheduleType.CUSTOM.toValue(),
+            null,
+            "수정된 커스텀 과목",
+            "수정된 교수님 성함",
+            "수정된 강의실 위치",
+            "기존 요일",
+            "09:00",
+            "10:30"
+        );
+        when(scheduleService.updateSchedule(eq(1L), eq(1L), any(ScheduleUpdateRequest.class), eq(VALID_TOKEN)))
+            .thenReturn(response);
+
+        String expected = """
+            {
+                "scheduleId": 1,
+                "scheduleType": "custom",
+                "subjectId": null,
+                "subjectName": "수정된 커스텀 과목",
+                "professorName": "수정된 교수님 성함",
+                "location": "수정된 강의실 위치",
+                "dayOfWeeks": "기존 요일",
+                "startTime": "09:00",
+                "endTime": "10:30"
+            }
+            """;
+
+        // when
+        MvcResult result = mockMvc.perform(patch(BASE_URL + "/{timeTableId}/schedules/{scheduleId}", 1L, 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .cookie(new Cookie("token", VALID_TOKEN)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        // then
+        assertThat(result.getResponse().getContentAsString()).isEqualToIgnoringWhitespace(expected);
+    }
+
+    @Test
+    @DisplayName("일정을 정상적으로 삭제할 때의 요청과 응답을 확인한다.")
+    void deleteSchedule() throws Exception {
+        // given
+        doNothing().when(scheduleService).deleteSchedule(eq(1L), eq(1L), eq(VALID_TOKEN));
+
+        // when, then
+        mockMvc.perform(delete(BASE_URL + "/{timeTableId}/schedules/{scheduleId}", 1L, 1L)
+                .cookie(new Cookie("token", VALID_TOKEN)))
+            .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/timetable/schedule/ScheduleServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/timetable/schedule/ScheduleServiceTest.java
@@ -1,0 +1,319 @@
+package kr.allcll.backend.domain.timetable.schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalTime;
+import kr.allcll.backend.domain.subject.Subject;
+import kr.allcll.backend.domain.subject.SubjectRepository;
+import kr.allcll.backend.domain.timetable.TimeTable;
+import kr.allcll.backend.domain.timetable.TimeTableRepository;
+import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleCreateRequest;
+import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleResponse;
+import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleUpdateRequest;
+import kr.allcll.backend.domain.timetable.schedule.dto.TimeTableDetailResponse;
+import kr.allcll.backend.fixture.SubjectFixture;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.backend.support.semester.Semester;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+class ScheduleServiceTest {
+
+    private static final String VALID_TOKEN = "adminToken";
+    private static final String INVALID_TOKEN = "invalidToken";
+    private static final Long NOT_FOUND_ID = 999L;
+
+    @Autowired
+    private ScheduleService scheduleService;
+
+    @Autowired
+    private OfficialScheduleRepository officialScheduleRepository;
+
+    @Autowired
+    private CustomScheduleRepository customScheduleRepository;
+
+    @Autowired
+    private TimeTableRepository timeTableRepository;
+
+    @Autowired
+    private SubjectRepository subjectRepository;
+
+    private TimeTable timeTable;
+    private Subject subject;
+
+    @BeforeEach
+    void setUp() {
+        officialScheduleRepository.deleteAll();
+        customScheduleRepository.deleteAll();
+        timeTableRepository.deleteAll();
+        subjectRepository.deleteAll();
+
+        timeTable = timeTableRepository.save(
+            new TimeTable(
+                VALID_TOKEN,
+                "테스트 시간표",
+                Semester.FALL_25
+            )
+        );
+        subject = subjectRepository.save(
+            SubjectFixture.createSubject(
+                "데이터베이스",
+                "003278",
+                "001",
+                "변재욱")
+        );
+    }
+
+    @Test
+    @DisplayName("커스텀 스케줄을 정상 추가한다.")
+    void addCustomSchedule() {
+        ScheduleCreateRequest request = new ScheduleCreateRequest(
+            ScheduleType.CUSTOM,
+            null,
+            "커스텀 과목",
+            "커스텀 교수",
+            "커스텀 강의실 위치",
+            "커스텀 요일",
+            "09:00",
+            "10:30"
+        );
+
+        ScheduleResponse response = scheduleService.addSchedule(timeTable.getId(), request, VALID_TOKEN);
+
+        assertThat(response.scheduleType()).isEqualTo("custom");
+        assertThat(response.subjectId()).isNull();
+        assertThat(response.subjectName()).isEqualTo("커스텀 과목");
+        assertThat(response.professorName()).isEqualTo("커스텀 교수");
+        assertThat(response.location()).isEqualTo("커스텀 강의실 위치");
+        assertThat(response.dayOfWeeks()).isEqualTo("커스텀 요일");
+        assertThat(response.startTime()).isEqualTo("09:00");
+        assertThat(response.endTime()).isEqualTo("10:30");
+
+        CustomSchedule saved = customScheduleRepository.findByIdAndTimeTableId(response.scheduleId(), timeTable.getId())
+            .orElseThrow();
+        assertThat(saved.getTimeTable().getId()).isEqualTo(timeTable.getId());
+    }
+
+    @Test
+    @DisplayName("공식 스케줄을 정상 추가한다.")
+    void addOfficialSchedule() {
+        ScheduleCreateRequest request = new ScheduleCreateRequest(
+            ScheduleType.OFFICIAL,
+            subject.getId(),
+            null, null, null, null, null, null
+        );
+
+        ScheduleResponse response = scheduleService.addSchedule(timeTable.getId(), request, VALID_TOKEN);
+
+        assertThat(response.scheduleType()).isEqualTo("official");
+        assertThat(response.subjectId()).isEqualTo(subject.getId());
+
+        OfficialSchedule saved = officialScheduleRepository.findAllByTimeTableId(timeTable.getId()).get(0);
+        assertThat(saved.getTimeTable().getId()).isEqualTo(timeTable.getId());
+        assertThat(saved.getSubject().getId()).isEqualTo(subject.getId());
+    }
+
+    @Test
+    @DisplayName("동일한 공식 스케줄을 중복 등록하면 예외가 발생한다.")
+    void addDuplicateOfficialScheduleThrowsException() {
+        // given
+        ScheduleCreateRequest request = new ScheduleCreateRequest(
+            ScheduleType.OFFICIAL,
+            subject.getId(),
+            null, null, null, null, null, null
+        );
+
+        scheduleService.addSchedule(timeTable.getId(), request, VALID_TOKEN);
+
+        // when, then
+        assertThatThrownBy(() ->
+            scheduleService.addSchedule(timeTable.getId(), request, VALID_TOKEN)
+        )
+            .isInstanceOf(AllcllException.class)
+            .hasMessageContaining(AllcllErrorCode.DUPLICATE_SCHEDULE.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 시간표에 추가 시 예외가 발생한다.")
+    void addScheduleIfTimeTableNotFoundThrowsException() {
+        ScheduleCreateRequest request = new ScheduleCreateRequest(
+            ScheduleType.CUSTOM,
+            null,
+            "커스텀 과목",
+            "커스텀 교수님 성함",
+            "커스텀 강의실 위치",
+            "커스텀 요일",
+            "09:00",
+            "10:30"
+        );
+        assertThatThrownBy(() ->
+            scheduleService.addSchedule(NOT_FOUND_ID, request, VALID_TOKEN)
+        ).isInstanceOf(AllcllException.class)
+            .hasMessageContaining(AllcllErrorCode.TIMETABLE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("토큰 불일치 시 예외가 발생한다.")
+    void addScheduleThrowsUnauthorizedAccess() {
+        ScheduleCreateRequest request = new ScheduleCreateRequest(
+            ScheduleType.CUSTOM,
+            null,
+            "커스텀 과목",
+            "커스텀 교수님 성함",
+            "커스텀 강의실 위치",
+            "커스텀 요일",
+            "09:00",
+            "10:30"
+        );
+        assertThatThrownBy(() ->
+            scheduleService.addSchedule(timeTable.getId(), request, INVALID_TOKEN)
+        ).isInstanceOf(AllcllException.class)
+            .hasMessageContaining(AllcllErrorCode.UNAUTHORIZED_ACCESS.getMessage());
+    }
+
+    @Test
+    @DisplayName("공식 일정 추가 시 해당 과목이 존재하지 않을 경우 예외가 발생한다.")
+    void addOfficialScheduleThrowsSubjectNotFound() {
+        ScheduleCreateRequest request = new ScheduleCreateRequest(
+            ScheduleType.OFFICIAL,
+            NOT_FOUND_ID,
+            null, null, null, null, null, null
+        );
+        assertThatThrownBy(() ->
+            scheduleService.addSchedule(timeTable.getId(), request, VALID_TOKEN)
+        ).isInstanceOf(AllcllException.class)
+            .hasMessageContaining(AllcllErrorCode.SUBJECT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("특정 시간표의 일정 목록을 정상 조회한다.")
+    void getTimeTableWithSchedule() {
+        OfficialSchedule officialSchedule = officialScheduleRepository.save(new OfficialSchedule(timeTable, subject));
+        CustomSchedule customSchedule = customScheduleRepository.save(
+            new CustomSchedule(
+                timeTable,
+                "커스텀 과목",
+                "커스텀 교수님 성함",
+                "커스텀 강의실 위치",
+                "커스텀 요일",
+                LocalTime.of(9, 0),
+                LocalTime.of(10, 30)
+            ));
+
+        TimeTableDetailResponse detailResponse = scheduleService.getTimeTableWithSchedules(
+            timeTable.getId(), VALID_TOKEN
+        );
+        assertThat(detailResponse.timetableId()).isEqualTo(timeTable.getId());
+        assertThat(detailResponse.schedules()).extracting("scheduleId")
+            .containsExactly(officialSchedule.getId(), customSchedule.getId());
+    }
+
+    @Test
+    @DisplayName("커스텀 일정의 모든 정보가 정상적으로 수정되는지 확인한다.")
+    void updateEntireCustomSchedule() {
+        CustomSchedule customSchedule = customScheduleRepository.save(
+            new CustomSchedule(
+                timeTable,
+                "커스텀 과목",
+                "커스텀 교수님 성함",
+                "커스텀 강의실 위치",
+                "커스텀 요일",
+                LocalTime.of(9, 0),
+                LocalTime.of(10, 30)
+            ));
+        ScheduleUpdateRequest request = new ScheduleUpdateRequest(
+            "수정된 커스텀 과목",
+            "수정된 교수님 성함",
+            "수정된 강의실 위치",
+            "수정된 요일",
+            "10:30",
+            "12:00"
+        );
+
+        ScheduleResponse response = scheduleService.updateSchedule(
+            timeTable.getId(),
+            customSchedule.getId(),
+            request,
+            VALID_TOKEN
+        );
+        assertThat(response.subjectName()).isEqualTo("수정된 커스텀 과목");
+        assertThat(response.professorName()).isEqualTo("수정된 교수님 성함");
+        assertThat(response.location()).isEqualTo("수정된 강의실 위치");
+        assertThat(response.dayOfWeeks()).isEqualTo("수정된 요일");
+        assertThat(response.startTime()).isEqualTo("10:30");
+        assertThat(response.endTime()).isEqualTo("12:00");
+
+        CustomSchedule updated = customScheduleRepository.findById(customSchedule.getId()).orElseThrow();
+        assertThat(updated.getSubjectName()).isEqualTo("수정된 커스텀 과목");
+    }
+
+    @Test
+    @DisplayName("커스텀 일정의 일부 정보가 정상적으로 수정되는지 확인한다.")
+    void updatePartialCustomSchedule() {
+        CustomSchedule customSchedule = customScheduleRepository.save(
+            new CustomSchedule(
+                timeTable,
+                "커스텀 과목",
+                "커스텀 교수님 성함",
+                "커스텀 강의실 위치",
+                "커스텀 요일",
+                LocalTime.of(9, 0),
+                LocalTime.of(10, 30)
+            ));
+        ScheduleUpdateRequest request = new ScheduleUpdateRequest(
+            "수정된 커스텀 과목",
+            "수정된 교수님 성함",
+            null, null, null, null
+        );
+
+        ScheduleResponse response = scheduleService.updateSchedule(
+            timeTable.getId(),
+            customSchedule.getId(),
+            request,
+            VALID_TOKEN
+        );
+        assertThat(response.subjectName()).isEqualTo("수정된 커스텀 과목");
+        assertThat(response.professorName()).isEqualTo("수정된 교수님 성함");
+        assertThat(response.location()).isEqualTo("커스텀 강의실 위치");
+        assertThat(response.dayOfWeeks()).isEqualTo("커스텀 요일");
+        assertThat(response.startTime()).isEqualTo("09:00");
+        assertThat(response.endTime()).isEqualTo("10:30");
+
+        CustomSchedule updated = customScheduleRepository.findById(customSchedule.getId()).orElseThrow();
+        assertThat(updated.getSubjectName()).isEqualTo("수정된 커스텀 과목");
+    }
+
+    @Test
+    @DisplayName("커스텀 일정이 정상적으로 삭제되는지 확인한다.")
+    void deleteSchedule() {
+        CustomSchedule customSchedule = customScheduleRepository.save(
+            new CustomSchedule(
+                timeTable,
+                "커스텀 과목",
+                "커스텀 교수님 성함",
+                "커스텀 강의실 위치",
+                "커스텀 요일",
+                LocalTime.of(9, 0),
+                LocalTime.of(10, 30)
+            ));
+        scheduleService.deleteSchedule(timeTable.getId(), customSchedule.getId(), VALID_TOKEN);
+        assertThat(customScheduleRepository.existsById(customSchedule.getId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("삭제할 일정이 존재하지 않을 경우 예외가 발생한다.")
+    void deleteScheduleThrowsNotFound() {
+        assertThatThrownBy(() ->
+            scheduleService.deleteSchedule(timeTable.getId(), NOT_FOUND_ID, VALID_TOKEN)
+        ).isInstanceOf(AllcllException.class)
+            .hasMessageContaining(AllcllErrorCode.SCHEDULE_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## 작업 내용
--
###용어 정리
[Schedule]
시간표에 등록 가능한 일정은 두가지 종류입니다.
- Official: 학사정보시스템 내에 존재하는 과목에 대한 일정입니다. 이는 
- Custom: 사용자가 직접 등록하고 수정할 수 있는 일정입니다.

[DB 구조 설계]
Official 일정에 등록되는 과목 데이터는 프론트에서 관리하고 처리하기 때문에 subjectId로 요청과 응답을 주고 받습니다.
Custom 일정에 등록되는 정보(ex 강의 제목, 교수님 성함, 강의실 위치, 강의 요일, 강의 시작 시간 및 종료 시간)들은 클라이언트에서 직접 받아서 요청을 받고 응답을 내려줍니다.
Official과 Custom의 요청 및 응답값 형태가 다르기 때문에 DB 구조 설계에 대한 생각고민을 많이 해보았습니다. (해당 내용은 노션에 문서화 해두었습니다.)
팀원들과 논의해본 결과, OfficialShedule과 CustomSchedule 엔티티를 따로 나누어 관리하는 방향으로 결정했습니다.
<img width="1240" height="1150" alt="image" src="https://github.com/user-attachments/assets/2ff91cd5-3880-4d32-96ae-97e40c8ec0ec" />
DB 성능과 데이터 정합성 및 안정성을 고려하여 채택하였습니다. 자세한 내용은 노션을 참고해주세요!

🚨 OfficialShedule과 CustomSchedule 엔티티의 ID 생성 방식은  `@GeneratedValue(strategy = GenerationType.IDENTITY)`가 아닙니다. @TableGenerator를 사용해 ID 생성 방식을 바꾸었습니다. @TableGenerator는 기본 키 생성을 위해 별도의 데이터베이스 테이블을 사용해서 일련번호를 관리하는 전략입니다. 이를 통해 ID를 한 곳에서 생성할 수 있게 하였습니다. 데이터 정합성을 위해 Schedule이라는 공통 속성을 가지고 있는 엔티티를 Official과 Custom으로 나누었기 때문에, GenerationType.IDENTITY 방식을 사용하게 된다면 각 엔티티마다 독립적인 ID가 생성되어 문제가 발생할 수 있는 것을 방지하고자 도입해봤습니다. 
<img width="637" height="386" alt="스크린샷 2025-07-22 오전 1 42 29" src="https://github.com/user-attachments/assets/e173b0b7-071a-4aa8-99b9-8e2d789336cb" />
위처럼 ID 생성을 위한 테이블이 하나 추가되어 한 곳에서 ID가 관리됩니다. 
이해를 위해 간단한 예시를 들어보자면, 
1. CustomSchedule 생성 -> ID: 1 부여
2. OfficialSchedule 생성 -> ID: 2 부여
3. CustomSchedule 생성 -> ID: 3 부여
4. CustomSchedule 생성 -> ID: 4 부여 
처럼 ID가 독립적으로 생성되지 않게 됩니다.

[구현한 기능]
특정 시간표(TimeTable) 내의 일정(Schedule)을 등록하는 CRUD를 구현하였습니다.
C: 특정 시간표 내 일정을 추가한다.
- Official 일정인 경우 해당 과목 ID가 이미 등록되어 있을 경우 예외를 던져 중복을 방지하도록 했습니다.

R: 특정 시간표 내 등록된 모든 일정들을 조회한다.
- 특정 시간표 내에 등록된 모든 Official 및 Custom 일정들을 조회합니다.
- @TableGenerator를 사용해 ID를 생성하였기 때문에, 조회 데이터를 넘겨줄 때는 1부터 sort하여 넘겨주도록 구현했습니다.

U: 특정 시간표 내 등록된 Custom 일정을 수정한다.
    - > Official 일정 수정은 사용자가 직접 하지 않고, DB에서 동기화되는 것을 생각했습니다.
          해당 부분에 대한 내용은 <고민 지점과 리뷰 포인트>에서 자세히 언급하도록 하겠습니다!
    
D: 특정 시간표 내 일정을 삭제한다.

[테스트 코드 및 postman 검증]
✅ 둘 다 정상 작동 확인했습니다!

## 고민 지점과 리뷰 포인트
1. 특정 시간표(TimeTable) 내에 등록된 모든 일정들을 조회하는 api의 엔드포인트에 대한 고민입니다.
 - /api/timetables/{timetableId}
 - /api/timetables/{timetableId}/schedules (현재 코드에 적용된 엔드포인트)

2. Schedule 종류가 Official, Custom 두 개이다 보니, 비즈니스 로직에 분기 처리를 해야하는 부분이 존재합니다. 이에 따라 로직이 상대적으로 복잡해졌습니다. (특히 조회나 삭제 부분) 가독성이 너무 떨어진다면 이야기 해주세요! 방식을 제안해주셔도 좋습니다~

3. API 명세에도 나와있듯이, 현재는 일정 수정 시 Custom 일정만 수정하도록 구현하였습니다! 
    해당 내용과 관련된 고민 사항은 다음과 같습니다. 
- 수정 시에 Official 일정과 Custom 일정을 모두 수정하도록 할건지
- Custom만 수정 가능하도록 할건지
이 부분은 프론트와 더 논의가 필요해보입니다. 

이에 대한 저의 생각은 사용자가 Custom의 정보만 수정하도록 하고, Official의 정보는 사용자가 직접 수정하지 못하도록 하는 것입니다.
하지만, Official에 대한 정보가 변경될 가능성이 존재합니다. 이는 DB에 존재하는 과목 데이터가 동기화된다면 해결되는 부분이라고 생각합니다. 어차피 OfficialSchedule은 Subject 엔티티를 참조하고 있으며, 프론트와 백엔드는 해당 과목의 ID를 통해 요청과 응답을 처리하기 때문입니다.

여기서 우려되는 점은, 백엔드 DB의 과목 데이터와 프론트에서 관리하는 과목 데이터의 불일치 문제입니다.
이에 관한 데이터 정합성 이슈가 전에 논의된 바 있습니다. (https://github.com/allcll/allcll-backend/issues/128)
해당 내용을 빠르게 적용하여 데이터 정합성을 맞춘다면, 문제가 될 점은 없다고 판단됩니다.
다른 분들의 의견도 공유해주세요!

4. 테스트 코드에서 더 검증이 필요해보이는 부분이 있다면 알려주세요!