### PR TITLE
refactor: 개발서버 배포 workflow 수정

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -19,6 +19,15 @@ jobs:
         shell: bash
 
     steps:
+      - name: set SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          eval "$(ssh-agent -s)"
+          ssh-add ~/.ssh/id_ed25519
+
       - name: Checkout application-dev.yml to config path
         uses: actions/checkout@v4
         with:
@@ -34,8 +43,11 @@ jobs:
           mkdir -p /home/ubuntu/app
           cp config/application-dev.yml /home/ubuntu/app/application-dev.yml
 
-      - name: CheckOut
+      - name: Checkout Main Repository with Submodules
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4


### PR DESCRIPTION
## 작업 내용
SSH 키를 적용하고, 서브모듈을 잘 가져올 수 있도록 workflow를 수정했습니다.
[이전 pr](https://github.com/allcll/allcll-backend/pull/135) 보다 이게 먼저 머지되어야해요! 이유는 pr이 머지되면 workflow가 돌아가기 때문입니다~!

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->