### PR TITLE
refactor: 항상 서브모듈 최신 커밋 가져오도록 수정

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -46,8 +46,12 @@ jobs:
       - name: Checkout Main Repository with Submodules
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          fetch-depth: 0
+
+      - name: Update submodules to latest commit
+        run: |
+          git submodule update --init --remote --merge
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,6 +34,10 @@ jobs:
           submodules: recursive
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
+      - name: 서브모듈 최신 커밋으로 업데이트
+        run: |
+          git submodule update --init --remote --merge
+
       - name: JDK 21 세팅
         uses: actions/setup-java@v4
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "allcll-crawler"]
 	path = allcll-crawler
 	url = git@github.com:allcll/allcll-crawler.git
+	branch = main


### PR DESCRIPTION
## 작업 내용
서브모듈 업데이트를 백엔드 배포 및 테스트와 동시에 하도록 워크플로우에 추가했습니다. 이러지 않으면 백엔드 코드는 변경 없고 서브모듈에 수정이 생기면 백엔드 코드도 항상 해시 갱신 하는 작업이 필요해요. 그래서 자동으로 가장 최신 해시 가져오도록 변경했습니다. (그래두 러너를 다시 돌려서 재배포 과정은 필요하겠지요)