### PR TITLE
hotfix: Subject 필터링 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/subject/SubjectService.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/SubjectService.java
@@ -2,6 +2,7 @@ package kr.allcll.backend.domain.subject;
 
 import java.util.List;
 import kr.allcll.backend.domain.subject.dto.SubjectsResponse;
+import kr.allcll.backend.support.semester.Semester;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
@@ -21,7 +22,8 @@ public class SubjectService {
         String classCode,
         String professorName
     ) {
-        Specification<Subject> condition = getCondition(subjectId, subjectName, subjectCode, classCode, professorName);
+        Specification<Subject> condition = getCondition(subjectId, subjectName, subjectCode, classCode, professorName,
+            Semester.now());
         List<Subject> subjects = subjectRepository.findAll(condition);
         return SubjectsResponse.from(subjects);
     }
@@ -31,14 +33,14 @@ public class SubjectService {
         String subjectName,
         String subjectCode,
         String classCode,
-        String professorName
+        String professorName,
+        String semesterAt
     ) {
-        return Specification.where(
-                SubjectSpecifications.hasSubjectId(subjectId))
+        return Specification.where(SubjectSpecifications.hasSubjectId(subjectId))
             .and(SubjectSpecifications.hasSubjectName(subjectName))
             .and(SubjectSpecifications.hasSubjectCode(subjectCode))
             .and(SubjectSpecifications.hasClassCode(classCode))
-            .and(SubjectSpecifications.hasProfessorName(professorName)
-            );
+            .and(SubjectSpecifications.hasProfessorName(professorName))
+            .and(SubjectSpecifications.hasSemesterAt(semesterAt));
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/subject/SubjectSpecifications.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/SubjectSpecifications.java
@@ -33,4 +33,9 @@ public class SubjectSpecifications {
         return ((root, query, builder) ->
             departmentCode == null ? null : builder.equal(root.get("deptCd"), departmentCode));
     }
+
+    public static Specification<Subject> hasSemesterAt(String semesterAt) {
+        return ((root, query, builder) ->
+            semesterAt == null ? null : builder.equal(root.get("semesterAt"), semesterAt));
+    }
 }


### PR DESCRIPTION
## 작업 내용
subject 전체조회를 하면 지금까지 모든 과목을 조회한다는 이슈가 터졌습니다. 이번 학기 꺼만 조회해야하잖아요. 그래서 필터링에 걸어뒀습니다. condition 사용은 나중에 개선해도 될 것 같습니다.