### PR TITLE
feat: CustomSchedule 등록 및 수정 시 TimeSlot 시간 검증 로직 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/ScheduleService.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/ScheduleService.java
@@ -1,5 +1,6 @@
 package kr.allcll.backend.domain.timetable.schedule;
 
+import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -12,6 +13,7 @@ import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleCreateRequest;
 import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleDeleteRequest;
 import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleResponse;
 import kr.allcll.backend.domain.timetable.schedule.dto.ScheduleUpdateRequest;
+import kr.allcll.backend.domain.timetable.schedule.dto.TimeSlotDto;
 import kr.allcll.backend.domain.timetable.schedule.dto.TimeTableDetailResponse;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
 import kr.allcll.backend.support.exception.AllcllException;
@@ -35,6 +37,8 @@ public class ScheduleService {
         ScheduleCreateRequest request,
         String token
     ) {
+        validateTimeSlots(request.timeSlots());
+
         TimeTable timeTable = getAuthorizedTimeTable(timeTableId, token);
 
         if (ScheduleType.fromValue(request.scheduleType()) == ScheduleType.OFFICIAL) {
@@ -82,6 +86,8 @@ public class ScheduleService {
         ScheduleUpdateRequest request,
         String token
     ) {
+        validateTimeSlots(request.timeSlots());
+
         TimeTable timeTable = getAuthorizedTimeTable(timetableId, token);
 
         CustomSchedule schedule = customScheduleRepository
@@ -127,5 +133,17 @@ public class ScheduleService {
         if (officialScheduleRepository.existsByTimeTableIdAndSubjectId(timeTable.getId(), request.subjectId())) {
             throw new AllcllException(AllcllErrorCode.DUPLICATE_SCHEDULE);
         }
+    }
+
+    private void validateTimeSlots(List<TimeSlotDto> timeSlots) {
+        timeSlots.forEach(
+            timeSlot -> {
+                LocalTime startTime = LocalTime.parse(timeSlot.startTime());
+                LocalTime endTime = LocalTime.parse(timeSlot.endTime());
+                if (startTime.isAfter(endTime)) {
+                    throw new AllcllException(AllcllErrorCode.INVALID_TIME);
+                }
+            }
+        );
     }
 }

--- a/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
@@ -28,7 +28,7 @@ public enum AllcllErrorCode {
     DUPLICATE_SCHEDULE("이미 시간표에 등록된 일정입니다."),
     JSON_CONVERT_ERROR("TimeSlot JSON 변환 중 오류가 발생했습니다."),
     INVALID_SCHEDULE_TYPE("유효하지 않은 일정 타입입니다."),
-    ;
+    INVALID_TIME("시작 시간이 종료 시간보다 늦습니다.");
 
     private String message;
 

--- a/src/test/java/kr/allcll/backend/domain/timetable/schedule/ScheduleServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/timetable/schedule/ScheduleServiceTest.java
@@ -355,6 +355,39 @@ class ScheduleServiceTest {
     }
 
     @Test
+    @DisplayName("커스텀 일정 추가 시 시작 시간이 종료 시간보다 늦은 경우 예외가 발생한다.")
+    void addCustomScheduleIfInvalidTimeThrowsException() {
+        //given
+        TimeTable timeTable = timeTableRepository.save(
+            new TimeTable(
+                VALID_TOKEN,
+                "테스트 시간표",
+                Semester.FALL_25
+            )
+        );
+        TimeSlotDto timeSlot = new TimeSlotDto(
+            "월",
+            "10:30",
+            "09:00"
+        );
+
+        ScheduleCreateRequest request = new ScheduleCreateRequest(
+            ScheduleType.CUSTOM.getValue(),
+            null,
+            "커스텀 과목",
+            "커스텀 교수",
+            "커스텀 강의실 위치",
+            List.of(timeSlot)
+        );
+
+        //when, then
+        assertThatThrownBy(() ->
+            scheduleService.addSchedule(timeTable.getId(), request, VALID_TOKEN)
+        ).isInstanceOf(AllcllException.class)
+            .hasMessageContaining(AllcllErrorCode.INVALID_TIME.getMessage());
+    }
+
+    @Test
     @DisplayName("특정 시간표의 일정 목록을 정상 조회한다.")
     void getTimeTableWithSchedule() {
         //given


### PR DESCRIPTION
## 작업 내용
CustomSchedule 등록 및 수정 시, TimeSlot 내에 StartTime과 EndTime가 정상 입력되었는지 검증하는 로직을 추가하였습니다. 
- startTime이 endTime보다 늦은 경우, INVALID_TIME 예외를 던지도록 구현하였습니다.
- 해당 부분을 검증하는 테스트 또한 작성하였습니다.

## 고민 지점과 리뷰 포인트
그런데, 지금 DB를 보니 
[{"endTime": "7:undefined", "startTime": "2:undefined", "dayOfWeeks": "월"}] 
해당 값과 같이, undefined 형태로 들어와있는 것을 확인했습니다.
이는 백엔드에서 처리하는 것보다는 프론트에서 "00"으로 처리한 후 보내주는 것이 맞다고 생각하는데 어떻게 생각하시나요?
해당 부분 논의가 필요할 듯 합니다!
