### PR TITLE
fix: 유효하지 않은 시간 요청값 처리 로직 구현

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/ScheduleService.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/ScheduleService.java
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ScheduleService {
 
-    private final String DELIMITER = ":";
+    private static final String DELIMITER = ":";
 
     private final TimeTableRepository timeTableRepository;
     private final SubjectRepository subjectRepository;

--- a/src/main/java/kr/allcll/backend/domain/timetable/schedule/ScheduleService.java
+++ b/src/main/java/kr/allcll/backend/domain/timetable/schedule/ScheduleService.java
@@ -27,6 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ScheduleService {
 
+    private final String DELIMITER = ":";
+
     private final TimeTableRepository timeTableRepository;
     private final SubjectRepository subjectRepository;
     private final OfficialScheduleRepository officialScheduleRepository;
@@ -145,7 +147,7 @@ public class ScheduleService {
                 String endTimeRequest = normalizeTimeFormat(timeSlot.endTime());
                 return new TimeSlotDto(timeSlot.dayOfWeeks(), startTimeRequest, endTimeRequest);
             })
-            .collect(Collectors.toList());
+            .toList();
     }
 
     private void validateTimeSlots(List<TimeSlotDto> timeSlots) {
@@ -161,7 +163,6 @@ public class ScheduleService {
     }
 
     private String normalizeTimeFormat(String time) {
-        final String DELIMITER = ":";
         List<String> timeParts = Arrays.stream(time.split(DELIMITER)).toList();
 
         String hour = getNormalizedHour(timeParts.get(0));


### PR DESCRIPTION
## 작업 내용
1. 유효하지 않은 시간 요청값을 처리하는 로직을 구현했습니다.
2. 처리 로직에 대한 테스트를 작성하여 검증하였습니다.
3. 포스트맨으로 더블 체크 완료했습니다.
---

<현재 에러 상황>
CustomSchedule 등록 및 수정 시, 디폴트 값(=0시 or 00분)으로 설정 후 요청을 보내면 500 애러가 발생합니다.
이는 유효하지 않은 요청값이 넘어와서 LocalTime.parse 과정에서 에러가 발생하는 것으로 추측됩니다.

다음은 시간 요청값 예시입니다.
<img width="458" height="33" alt="스크린샷 2025-07-26 오후 8 23 46" src="https://github.com/user-attachments/assets/8a69e6d1-704f-457f-aa5a-2f3084b58f82" />

여러 상황을 가정하여 qa를 진행해본 토대로, 유효하지 않은 시간 요청값이 넘어오는 경우를 정리해보았습니다.
1. startTime 설정하지 않을 경우 
> - ui상의 디폴트 값은 0시 00분으로 표시됩니다.
> - 요청값으로는 "" 이 넘어옵니다.

2. 시 or 분을 설정 하지 않을 경우 
> - ui상의 디폴트 값은 0시 or 00분입니다.
> - 요청값으로는 "undefined:00" or "00:undefined"이 넘어옵니다.

3. 시간 설정값이 한 자리일 경우
> - 요청값으로 "7:00" "9:00" 포맷으로 넘어옵니다.
> - LocalTime이 파싱할 수 있는 포맷으로 변경하려면 한 자리수일 경우 두자리로 채워줘야 합니다.  ex) "07:00" "09:00"
>    그렇지 않으면 에러가 발생하는 것을 확인했습니다.

위의 예시들을 토대로 유효하지 않은 요청값들이 들어왔을 경우 정상 동작하도록 구현했습니다.

## 고민 지점과 리뷰 포인트
혹시라도 제가 언급드린 예시 말고, 에러가 날만한 다른 예시가 있다면 말씀해주세요!
