### PR TITLE
refactor: 여석 전송 로직 정책 롤백

### DIFF
--- a/src/main/java/kr/allcll/backend/client/ExternalClient.java
+++ b/src/main/java/kr/allcll/backend/client/ExternalClient.java
@@ -9,8 +9,8 @@ import kr.allcll.backend.domain.subject.SubjectRepository;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
 import kr.allcll.backend.support.exception.AllcllException;
 import kr.allcll.backend.support.semester.Semester;
+import kr.allcll.crawler.seat.AllSeatBuffer;
 import kr.allcll.crawler.seat.ChangeSubjectsResponse;
-import kr.allcll.crawler.seat.ChangedSubjectBuffer;
 import kr.allcll.crawler.seat.PinSubjectUpdateRequest;
 import kr.allcll.crawler.seat.TargetSubjectService;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,8 @@ public class ExternalClient {
 
     // 외부 의존성
     private final TargetSubjectService targetSubjectService;
-    private final ChangedSubjectBuffer changedSubjectBuffer;
+    //    private final ChangedSubjectBuffer changedSubjectBuffer;
+    private final AllSeatBuffer allSeatBuffer;
 
     private final SeatStorage seatStorage;
     private final SubjectRepository subjectRepository;
@@ -36,7 +37,7 @@ public class ExternalClient {
     }
 
     public void getAllTargetSubjects() {
-        List<ChangeSubjectsResponse> allChangedSubject = changedSubjectBuffer.getAllAndFlush();
+        List<ChangeSubjectsResponse> allChangedSubject = allSeatBuffer.getAllAndFlush();
         for (ChangeSubjectsResponse eachChange : allChangedSubject) {
             Long subjectId = eachChange.subjectId();
             Subject subject = subjectRepository.findById(subjectId, Semester.now())
@@ -44,8 +45,8 @@ public class ExternalClient {
             seatStorage.add(
                 new SeatDto(subject,
                     eachChange.remainSeat(),
-                    LocalDateTime.now(), //TODO: 추후 버퍼 쪽으로 이동
-                    eachChange.changeStatus()
+                    LocalDateTime.now() //TODO: 추후 버퍼 쪽으로 이동
+//                    eachChange.changeStatus()
                 )
             );
         }

--- a/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class GeneralSeatSender {
 
     private static final String EVENT_NAME = "nonMajorSeats";
-    private static final int QUERY_LIMIT = 40;
+    private static final int QUERY_LIMIT = 20;
     private static final int SEASON_SEMESTER_QUERY_LIMIT = 39; // 2025-하계 전체 제공을 위한 쿼리 제한 수
     private static final Duration SENDING_PERIOD = Duration.ofSeconds(1);
 
@@ -46,7 +46,7 @@ public class GeneralSeatSender {
 
     private Runnable getGeneralSeatTask() {
         return () -> {
-            List<SeatDto> generalSeats = seatStorage.getGeneralSeats();
+            List<SeatDto> generalSeats = seatStorage.getGeneralSeats(QUERY_LIMIT);
             sseService.propagate(EVENT_NAME, SeatsResponse.from(generalSeats));
         };
     }

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
@@ -1,7 +1,5 @@
 package kr.allcll.backend.domain.seat;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -25,13 +23,13 @@ public class SeatStorage {
         this.seats = new ConcurrentHashMap<>();
     }
 
-    public List<SeatDto> getGeneralSeats() {
+    public List<SeatDto> getGeneralSeats(int limit) {
         Collection<SeatDto> seatsValue = seats.values();
         return seatsValue.stream()
             .filter(seat -> seat.getSubject().isNonMajor())
-            .filter(seat ->
-                Duration.between(seat.getQueryTime(), LocalDateTime.now()).getSeconds() <= LIMIT_QUERY_TIME)
+            .filter(seat -> seat.getSeatCount() > 0)
             .sorted(Comparator.comparingInt(SeatDto::getSeatCount))
+            .limit(limit)
             .toList();
     }
 
@@ -41,10 +39,7 @@ public class SeatStorage {
             seats::add,
             () -> logSubjectMissing(subject)
         ));
-        return seats.stream()
-            .filter(seat ->
-                Duration.between(seat.getQueryTime(), LocalDateTime.now()).getSeconds() <= LIMIT_QUERY_TIME)
-            .toList();
+        return seats;
     }
 
     private Optional<SeatDto> findSeat(Subject subject) {

--- a/src/main/java/kr/allcll/backend/domain/seat/dto/SeatDto.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/dto/SeatDto.java
@@ -2,7 +2,6 @@ package kr.allcll.backend.domain.seat.dto;
 
 import java.time.LocalDateTime;
 import kr.allcll.backend.domain.subject.Subject;
-import kr.allcll.crawler.seat.ChangeStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,5 +12,5 @@ public class SeatDto {
     private Subject subject;
     private int seatCount;
     private LocalDateTime queryTime;
-    private ChangeStatus changeStatus;
+//    private ChangeStatus changeStatus;
 }

--- a/src/test/java/kr/allcll/backend/client/ExternalClientTest.java
+++ b/src/test/java/kr/allcll/backend/client/ExternalClientTest.java
@@ -72,28 +72,28 @@ class ExternalClientTest {
                 subjectB.getId()
             );
     }
-
-    @Test
-    @DisplayName("변경 감지 과목들의 정상 수신을 확인한다.")
-    void getAllTargetSubjects() {
-        // given
-        Subject subjectA = subjectRepository
-            .save(SubjectFixture.createNonMajorSubject("차와문화", "123456", "001", "김보예"));
-        Subject subjectB = subjectRepository
-            .save(SubjectFixture.createNonMajorSubject("차와문화", "123456", "002", "김보예"));
-        changedSubjectBuffer.add(new ChangeSubjectsResponse(subjectA.getId(), ChangeStatus.IN, 10));
-        changedSubjectBuffer.add(new ChangeSubjectsResponse(subjectB.getId(), ChangeStatus.IN, 15));
-
-        // when
-        externalClient.getAllTargetSubjects();
-        List<SeatDto> allSeatDtos = seatStorage.getAll();
-
-        // then
-        assertThat(allSeatDtos).hasSize(2)
-            .extracting(SeatDto::getSubject, SeatDto::getSeatCount)
-            .containsExactly(
-                tuple(subjectA, 10),
-                tuple(subjectB, 15)
-            );
-    }
+//
+//    @Test
+//    @DisplayName("변경 감지 과목들의 정상 수신을 확인한다.")
+//    void getAllTargetSubjects() {
+//        // given
+//        Subject subjectA = subjectRepository
+//            .save(SubjectFixture.createNonMajorSubject("차와문화", "123456", "001", "김보예"));
+//        Subject subjectB = subjectRepository
+//            .save(SubjectFixture.createNonMajorSubject("차와문화", "123456", "002", "김보예"));
+//        changedSubjectBuffer.add(new ChangeSubjectsResponse(subjectA.getId(), ChangeStatus.IN, 10));
+//        changedSubjectBuffer.add(new ChangeSubjectsResponse(subjectB.getId(), ChangeStatus.IN, 15));
+//
+//        // when
+//        externalClient.getAllTargetSubjects();
+//        List<SeatDto> allSeatDtos = seatStorage.getAll();
+//
+//        // then
+//        assertThat(allSeatDtos).hasSize(2)
+//            .extracting(SeatDto::getSubject, SeatDto::getSeatCount)
+//            .containsExactly(
+//                tuple(subjectA, 10),
+//                tuple(subjectB, 15)
+//            );
+//    }
 }

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatServiceTest.java
@@ -69,11 +69,11 @@ class SeatServiceTest {
         pinRepository.saveAll(List.of(pin1, pin2, pin3, pin4, pin5));
 
         LocalDateTime now = LocalDateTime.now();
-        SeatDto seat1 = new SeatDto(subject1, 1, now, ChangeStatus.IN);
-        SeatDto seat2 = new SeatDto(subject2, 2, now, ChangeStatus.IN);
-        SeatDto seat3 = new SeatDto(subject3, 3, now, ChangeStatus.IN);
-        SeatDto seat4 = new SeatDto(subject4, 4, now, ChangeStatus.IN);
-        SeatDto seat5 = new SeatDto(subject5, 5, now, ChangeStatus.IN);
+        SeatDto seat1 = new SeatDto(subject1, 1, now);
+        SeatDto seat2 = new SeatDto(subject2, 2, now);
+        SeatDto seat3 = new SeatDto(subject3, 3, now);
+        SeatDto seat4 = new SeatDto(subject4, 4, now);
+        SeatDto seat5 = new SeatDto(subject5, 5, now);
         seatStorage.addAll(List.of(seat1, seat2, seat3, seat4, seat5));
 
         // when

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import kr.allcll.backend.domain.seat.dto.SeatDto;
 import kr.allcll.backend.domain.subject.Subject;
 import kr.allcll.backend.domain.subject.SubjectRepository;
-import kr.allcll.crawler.seat.ChangeStatus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
@@ -41,9 +41,9 @@ class SeatStorageTest {
         subjectRepository.save(subject);
 
         // when
-        SeatDto previousSeatDto = new SeatDto(subject, 10, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto previousSeatDto = new SeatDto(subject, 10, LocalDateTime.now());
         seatStorage.add(previousSeatDto);
-        SeatDto updatedSeatDto = new SeatDto(subject, 5, LocalDateTime.now(), ChangeStatus.UPDATE);
+        SeatDto updatedSeatDto = new SeatDto(subject, 5, LocalDateTime.now());
         seatStorage.add(updatedSeatDto);
 
         // then
@@ -77,29 +77,28 @@ class SeatStorageTest {
         subjectRepository.saveAll(
             List.of(subject0, subject1, subject2, subject3, subject4, subject5, subject6, subject7, subject8, subject9,
                 subject10));
-        SeatDto seatDto1 = new SeatDto(subject0, 8, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto2 = new SeatDto(subject1, 7, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto3 = new SeatDto(subject2, 6, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto4 = new SeatDto(subject3, 5, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto5 = new SeatDto(subject4, 4, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto6 = new SeatDto(subject5, 3, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto7 = new SeatDto(subject6, 2, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto8 = new SeatDto(subject7, 1, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto9 = new SeatDto(subject8, 0, LocalDateTime.now(), ChangeStatus.OUT);
-        SeatDto seatDto10 = new SeatDto(subject9, 2, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto11 = new SeatDto(subject10, 1, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto1 = new SeatDto(subject0, 8, LocalDateTime.now());
+        SeatDto seatDto2 = new SeatDto(subject1, 7, LocalDateTime.now());
+        SeatDto seatDto3 = new SeatDto(subject2, 6, LocalDateTime.now());
+        SeatDto seatDto4 = new SeatDto(subject3, 5, LocalDateTime.now());
+        SeatDto seatDto5 = new SeatDto(subject4, 4, LocalDateTime.now());
+        SeatDto seatDto6 = new SeatDto(subject5, 3, LocalDateTime.now());
+        SeatDto seatDto7 = new SeatDto(subject6, 2, LocalDateTime.now());
+        SeatDto seatDto8 = new SeatDto(subject7, 1, LocalDateTime.now());
+        SeatDto seatDto9 = new SeatDto(subject8, 0, LocalDateTime.now());
+        SeatDto seatDto10 = new SeatDto(subject9, 2, LocalDateTime.now());
+        SeatDto seatDto11 = new SeatDto(subject10, 1, LocalDateTime.now());
         seatStorage.addAll(
             List.of(seatDto1, seatDto2, seatDto3, seatDto4, seatDto5, seatDto6, seatDto7, seatDto8, seatDto9, seatDto10,
                 seatDto11));
 
         // when
-        List<SeatDto> seats = seatStorage.getGeneralSeats();
+        List<SeatDto> seats = seatStorage.getGeneralSeats(5);
 
         // then
-        assertThat(seats).hasSize(6)
+        assertThat(seats).hasSize(5)
             .extracting(SeatDto::getSubject, SeatDto::getSeatCount)
             .containsExactly(
-                tuple(subject8, 0),
                 tuple(subject7, 1),
                 tuple(subject10, 1),
                 tuple(subject6, 2),
@@ -126,17 +125,17 @@ class SeatStorageTest {
         subjectRepository.saveAll(
             List.of(subject0, subject1, subject2, subject3, subject4, subject5, subject6, subject7, subject8, subject9,
                 subject10));
-        SeatDto seatDto1 = new SeatDto(subject0, 8, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto2 = new SeatDto(subject1, 7, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto3 = new SeatDto(subject2, 6, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto4 = new SeatDto(subject3, 5, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto5 = new SeatDto(subject4, 4, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto6 = new SeatDto(subject5, 3, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto7 = new SeatDto(subject6, 2, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto8 = new SeatDto(subject7, 1, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto9 = new SeatDto(subject8, 0, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto10 = new SeatDto(subject9, 2, LocalDateTime.now(), ChangeStatus.IN);
-        SeatDto seatDto11 = new SeatDto(subject10, 1, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto1 = new SeatDto(subject0, 8, LocalDateTime.now());
+        SeatDto seatDto2 = new SeatDto(subject1, 7, LocalDateTime.now());
+        SeatDto seatDto3 = new SeatDto(subject2, 6, LocalDateTime.now());
+        SeatDto seatDto4 = new SeatDto(subject3, 5, LocalDateTime.now());
+        SeatDto seatDto5 = new SeatDto(subject4, 4, LocalDateTime.now());
+        SeatDto seatDto6 = new SeatDto(subject5, 3, LocalDateTime.now());
+        SeatDto seatDto7 = new SeatDto(subject6, 2, LocalDateTime.now());
+        SeatDto seatDto8 = new SeatDto(subject7, 1, LocalDateTime.now());
+        SeatDto seatDto9 = new SeatDto(subject8, 0, LocalDateTime.now());
+        SeatDto seatDto10 = new SeatDto(subject9, 2, LocalDateTime.now());
+        SeatDto seatDto11 = new SeatDto(subject10, 1, LocalDateTime.now());
         seatStorage.addAll(
             List.of(seatDto1, seatDto2, seatDto3, seatDto4, seatDto5, seatDto6, seatDto7, seatDto8, seatDto9, seatDto10,
                 seatDto11));


### PR DESCRIPTION
## 작업 내용
여석을 변경지점만 주려다가 여러 사정 상 이번 서비스 기간에는 기존처럼 주게 되었습니다.
따라서 기존에 작성해두었던 변경 감지 로직을 삭제해야했습니다.
단순 롤백을 하기에는 서브모듈 작업도 이루어진 상태라, 롤백을 하진 않았고 다시 코드쳐서 구현했습니다.
크롤러에 `ChangeBuffer`말고 `AllSeatBuffer`를 도입하여 구현했습니다. 따라서 의존성이 AllSeatBuffer로 옮겨갔어용
정책 롤백에 따라 필요없어진 테스트가 있어서 주석처리한 것도 있습니다.
빠른 시일내에 다시 정책을 살릴 수도 있을 것 같아서...우선 남겨놨는데 지우고싶으면 추후 지워도 될듯...? 기간이 급하고 치명적인게 아니니...우선 냅다 주석처리했어요....
함께 페어마냥 했긴하지만 의아한지점이 있음 더 말씀해주세여