### PR TITLE
reactor: SubjectResponse에 필드 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/subject/dto/SubjectResponse.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/dto/SubjectResponse.java
@@ -13,7 +13,11 @@ public record SubjectResponse(
     String studentYear,
     String lesnTime,
     String lesnRoom,
-    String tmNum
+    String tmNum,
+    String remark,
+    String curiTypeCdNm,
+    String curiLangNm,
+    Boolean isDeleted
 ) {
 
     public static SubjectResponse from(Subject subject) {
@@ -28,7 +32,11 @@ public record SubjectResponse(
             subject.getStudentYear(),
             subject.getLesnTime(),
             subject.getLesnRoom(),
-            subject.getTmNum()
+            subject.getTmNum(),
+            subject.getRemark(),
+            subject.getCuriTypeCdNm(),
+            subject.getCuriLangNm(),
+            subject.isDeleted()
         );
     }
 }

--- a/src/main/java/kr/allcll/backend/support/entity/BaseEntity.java
+++ b/src/main/java/kr/allcll/backend/support/entity/BaseEntity.java
@@ -24,4 +24,8 @@ public abstract class BaseEntity {
             this.createdAt = createdAt;
         }
     }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
 }


### PR DESCRIPTION
## 작업 내용
프론트 요청으로 `SubjectResponse`에 아래 4개의 필드를 추가했습니다
- remark: 외국인대상강좌, 컴공대상강좌, 등등 여부
- curiTypeCdNm: 이수구분
- curiLangNm: 강의 언어
- isDeleted:  삭제여부 

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->