### PR TITLE
refactor: 관담 응답 포맷 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/basket/BasketService.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/BasketService.java
@@ -27,7 +27,7 @@ public class BasketService {
         String professorName,
         String subjectName
     ) {
-        Specification<Subject> condition = getCondition(departmentCode, professorName, subjectName);
+        Specification<Subject> condition = getCondition(departmentCode, professorName, subjectName, Semester.now());
         List<Subject> subjects = subjectRepository.findAll(condition);
         List<BasketsEachSubject> result = getBasketsEachSubject(subjects);
         return new BasketsResponse(result);
@@ -48,12 +48,15 @@ public class BasketService {
     private Specification<Subject> getCondition(
         String departmentCode,
         String professorName,
-        String subjectName
+        String subjectName,
+        String semesterAt
     ) {
         return Specification.where(
             SubjectSpecifications.hasDepartmentCode(departmentCode)
                 .and(SubjectSpecifications.hasProfessorName(professorName))
                 .and(SubjectSpecifications.hasSubjectName(subjectName))
+                .and(SubjectSpecifications.hasSemesterAt(semesterAt))
+                .and(SubjectSpecifications.isNotDeleted())
         );
     }
 

--- a/src/main/java/kr/allcll/backend/domain/basket/dto/BasketsEachSubject.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/dto/BasketsEachSubject.java
@@ -6,12 +6,6 @@ import kr.allcll.backend.domain.subject.Subject;
 
 public record BasketsEachSubject(
     Long subjectId,
-    String subjectName, //과목명
-    String departmentName, //개설학과
-    String departmentCode, //개설 학과코드
-    String subjectCode, // 학수번호
-    String classCode, //분반
-    String professorName, //교수명
     Integer totalCount //총 인원
 ) {
 
@@ -19,23 +13,11 @@ public record BasketsEachSubject(
         if (baskets.isEmpty()) {
             return new BasketsEachSubject(
                 subject.getId(),
-                subject.getCuriNm(),
-                subject.getManageDeptNm(),
-                subject.getDeptCd(),
-                subject.getCuriNo(),
-                subject.getClassName(),
-                subject.getLesnEmp(),
                 0
             );
         }
         return new BasketsEachSubject(
             subject.getId(),
-            subject.getCuriNm(),
-            subject.getManageDeptNm(),
-            subject.getDeptCd(),
-            subject.getCuriNo(),
-            subject.getClassName(),
-            subject.getLesnEmp(),
             baskets.getFirst().getTotRcnt()
         );
     }

--- a/src/main/java/kr/allcll/backend/domain/subject/SubjectRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/SubjectRepository.java
@@ -16,6 +16,9 @@ public interface SubjectRepository extends JpaRepository<Subject, Long>, JpaSpec
         """)
     List<Subject> findAllByDeptCd(String deptCd, String semesterAt);
 
+    @Query("select s from Subject s where s.isDeleted = false")
+    List<Subject> findAll();
+
     @Query("""
         select s from Subject s
         where s.id = :id

--- a/src/main/java/kr/allcll/backend/domain/subject/SubjectService.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/SubjectService.java
@@ -41,6 +41,7 @@ public class SubjectService {
             .and(SubjectSpecifications.hasSubjectCode(subjectCode))
             .and(SubjectSpecifications.hasClassCode(classCode))
             .and(SubjectSpecifications.hasProfessorName(professorName))
-            .and(SubjectSpecifications.hasSemesterAt(semesterAt));
+            .and(SubjectSpecifications.hasSemesterAt(semesterAt))
+            .and(SubjectSpecifications.isNotDeleted());
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/subject/SubjectSpecifications.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/SubjectSpecifications.java
@@ -38,4 +38,9 @@ public class SubjectSpecifications {
         return ((root, query, builder) ->
             semesterAt == null ? null : builder.equal(root.get("semesterAt"), semesterAt));
     }
+
+    public static Specification<Subject> isNotDeleted() {
+        return (root, query, builder) ->
+            builder.isFalse(root.get("isDeleted"));
+    }
 }

--- a/src/test/java/kr/allcll/backend/domain/basket/BasketApiTest.java
+++ b/src/test/java/kr/allcll/backend/domain/basket/BasketApiTest.java
@@ -36,12 +36,6 @@ public class BasketApiTest {
                 "baskets": [
                     {
                         "subjectId": 1,
-                        "subjectName": "컴퓨터구조",
-                        "departmentName": "전자정보공학과",
-                        "departmentCode": "3210",
-                        "subjectCode": "004310",
-                        "classCode": "001",
-                        "professorName": "김보예",
                         "totalCount": 14
                     }
                 ]
@@ -51,9 +45,7 @@ public class BasketApiTest {
         // when
         when(basketService.findBasketsByCondition(null, null, null)).thenReturn(
             new BasketsResponse(List.of(
-                new BasketsEachSubject(1L, "컴퓨터구조",
-                    "전자정보공학과", "3210",
-                    "004310", "001", "김보예", 14)
+                new BasketsEachSubject(1L, 14)
             ))
         );
         MvcResult result = mockMvc.perform(get("/api/baskets")).andExpect(status().isOk()).andReturn();

--- a/src/test/java/kr/allcll/backend/domain/basket/BasketServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/basket/BasketServiceTest.java
@@ -60,8 +60,8 @@ class BasketServiceTest {
             "김수민"
         );
         subjectRepository.saveAll(List.of(subjectA, subjectB));
-        basketRepository.save(createBasket(subjectA, "본교생", "전자정보통신공학과", 1));
-        basketRepository.save(createBasket(subjectB, "본교생", "에너지자원공학과", 1));
+        basketRepository.save(createBasket(subjectA, "본교생", "전자정보통신공학과", 1, 10));
+        basketRepository.save(createBasket(subjectB, "본교생", "에너지자원공학과", 2, 20));
         int expectedSize = 2;
 
         // when
@@ -70,15 +70,11 @@ class BasketServiceTest {
         // then
         assertThat(allSubjects.baskets()).hasSize(expectedSize)
             .extracting(
-                BasketsEachSubject::subjectName,
-                BasketsEachSubject::subjectCode,
-                BasketsEachSubject::classCode,
-                BasketsEachSubject::professorName,
-                BasketsEachSubject::departmentName,
-                BasketsEachSubject::departmentCode
+                BasketsEachSubject::subjectId,
+                BasketsEachSubject::totalCount
             ).containsExactly(
-                tuple("과목A", "001234", "001", "김수민", "전자정보통신공학과", "3210"),
-                tuple("과목B", "004321", "002", "김수민", "에너지자원공학과", "3211")
+                tuple(subjectA.getId(), 10),
+                tuple(subjectB.getId(), 20)
             );
     }
 
@@ -95,7 +91,7 @@ class BasketServiceTest {
             "김수민"
         );
         subjectRepository.save(subjectA);
-        basketRepository.save(createBasket(subjectA, "본교생", "전자정보통신공학과", 1));
+        basketRepository.save(createBasket(subjectA, "본교생", "전자정보통신공학과", 3, 10));
         int expectedSize = 1;
 
         // when
@@ -104,14 +100,10 @@ class BasketServiceTest {
         // then
         assertThat(allSubjects.baskets()).hasSize(expectedSize)
             .extracting(
-                BasketsEachSubject::subjectName,
-                BasketsEachSubject::subjectCode,
-                BasketsEachSubject::classCode,
-                BasketsEachSubject::professorName,
-                BasketsEachSubject::departmentName,
-                BasketsEachSubject::departmentCode
+                BasketsEachSubject::subjectId,
+                BasketsEachSubject::totalCount
             ).containsExactly(
-                tuple("과목A", "001234", "001", "김수민", "전자정보통신공학과", "3210")
+                tuple(subjectA.getId(), 10)
             );
     }
 
@@ -119,7 +111,52 @@ class BasketServiceTest {
     @DisplayName("학과 코드로 검색했을 시 관심 과목 조회를 확인한다.")
     void departmentCodeSelect() {
         // given
-        saveSubjectsAndBaskets();
+        Subject subjectA = createSubjectWithDepartmentInformation(
+            "컴공 과목A",
+            "컴퓨터공학과",
+            "3210",
+            "001234",
+            "001",
+            "김보예"
+        );
+
+        Subject subjectB = createSubjectWithDepartmentInformation(
+            "컴공 과목B",
+            "컴퓨터공학과",
+            "3210",
+            "004321",
+            "001",
+            "김보예"
+        );
+
+        Subject subjectC = createSubjectWithDepartmentInformation(
+            "소웨 과목C",
+            "소프트웨어학과",
+            "3211",
+            "004321",
+            "001",
+            "김수민"
+        );
+        subjectRepository.saveAll(
+            List.of(
+                subjectA,
+                subjectB,
+                subjectC
+            )
+        );
+        Basket basketA = createBasket(subjectA, "본교생", "컴공", 3, 10);
+        Basket basketB = createBasket(subjectA, "본교생", "전정통", 3, 10);
+        Basket basketC = createBasket(subjectB, "본교생", "컴공", 3, 4);
+        Basket basketD = createBasket(subjectC, "본교생", "전정통", 3, 5);
+        basketRepository.saveAll(
+            List.of(
+                basketA,
+                basketB,
+                basketC,
+                basketD
+            )
+        );
+
         int expectedSize = 2;
 
         // when
@@ -131,15 +168,11 @@ class BasketServiceTest {
         // then
         assertThat(basketsByCondition.baskets()).hasSize(expectedSize)
             .extracting(
-                BasketsEachSubject::subjectName,
-                BasketsEachSubject::subjectCode,
-                BasketsEachSubject::classCode,
-                BasketsEachSubject::professorName,
-                BasketsEachSubject::departmentName,
-                BasketsEachSubject::departmentCode
+                BasketsEachSubject::subjectId,
+                BasketsEachSubject::totalCount
             ).containsExactly(
-                tuple("컴공 과목A", "001234", "001", "김보예", "컴퓨터공학과", "3210"),
-                tuple("컴공 과목B", "004321", "001", "김보예", "컴퓨터공학과", "3210")
+                tuple(subjectA.getId(), 10),
+                tuple(subjectB.getId(), 4)
             );
     }
 
@@ -147,7 +180,65 @@ class BasketServiceTest {
     @DisplayName("교수명으로 검색했을 시 관심 과목 조회를 확인한다.")
     void professorSelect() {
         // given
-        saveSubjectsAndBaskets();
+        Subject subjectA = createSubjectWithDepartmentInformation(
+            "컴공 과목A",
+            "컴퓨터공학과",
+            "3210",
+            "001234",
+            "001",
+            "김보예"
+        );
+
+        Subject subjectB = createSubjectWithDepartmentInformation(
+            "컴공 과목B",
+            "컴퓨터공학과",
+            "3210",
+            "004321",
+            "001",
+            "김보예"
+        );
+
+        Subject subjectC = createSubjectWithDepartmentInformation(
+            "소웨 과목C",
+            "소프트웨어학과",
+            "3211",
+            "004321",
+            "001",
+            "김수민"
+        );
+
+        Subject subjectD = createSubjectWithDepartmentInformation(
+            "소웨 과목D",
+            "소프트웨어학과",
+            "3211",
+            "001234",
+            "001",
+            "김보예"
+        );
+
+        subjectRepository.saveAll(
+            List.of(
+                subjectA,
+                subjectB,
+                subjectC,
+                subjectD
+            )
+        );
+        Basket basketA = createBasket(subjectA, "본교생", "컴공", 3, 10);
+        Basket basketB = createBasket(subjectA, "본교생", "전정통", 3, 10);
+        Basket basketC = createBasket(subjectB, "본교생", "컴공", 3, 4);
+        Basket basketD = createBasket(subjectC, "본교생", "전정통", 3, 5);
+        Basket basketE = createBasket(subjectD, "본교생", "소웨", 3, 6);
+
+        basketRepository.saveAll(
+            List.of(
+                basketA,
+                basketB,
+                basketC,
+                basketD,
+                basketE
+            )
+        );
         int expectedSize = 3;
 
         // when
@@ -159,16 +250,12 @@ class BasketServiceTest {
         // then
         assertThat(basketsByCondition.baskets()).hasSize(expectedSize)
             .extracting(
-                BasketsEachSubject::subjectName,
-                BasketsEachSubject::subjectCode,
-                BasketsEachSubject::classCode,
-                BasketsEachSubject::professorName,
-                BasketsEachSubject::departmentName,
-                BasketsEachSubject::departmentCode
+                BasketsEachSubject::subjectId,
+                BasketsEachSubject::totalCount
             ).containsExactly(
-                tuple("컴공 과목A", "001234", "001", "김보예", "컴퓨터공학과", "3210"),
-                tuple("컴공 과목B", "004321", "001", "김보예", "컴퓨터공학과", "3210"),
-                tuple("소웨 과목D", "001234", "001", "김보예", "소프트웨어학과", "3211")
+                tuple(subjectA.getId(), 10),
+                tuple(subjectB.getId(), 4),
+                tuple(subjectD.getId(), 6)
             );
     }
 
@@ -176,7 +263,65 @@ class BasketServiceTest {
     @DisplayName("과목명으로 검색했을 시 관심 과목 조회를 확인한다.")
     void subjectNameSelect() {
         // given
-        saveSubjectsAndBaskets();
+        Subject subjectA = createSubjectWithDepartmentInformation(
+            "컴공 과목A",
+            "컴퓨터공학과",
+            "3210",
+            "001234",
+            "001",
+            "김보예"
+        );
+
+        Subject subjectB = createSubjectWithDepartmentInformation(
+            "컴공 과목B",
+            "컴퓨터공학과",
+            "3210",
+            "004321",
+            "001",
+            "김보예"
+        );
+
+        Subject subjectC = createSubjectWithDepartmentInformation(
+            "소웨 과목C",
+            "소프트웨어학과",
+            "3211",
+            "004321",
+            "001",
+            "김수민"
+        );
+
+        Subject subjectD = createSubjectWithDepartmentInformation(
+            "소웨 과목D",
+            "소프트웨어학과",
+            "3211",
+            "001234",
+            "001",
+            "김보예"
+        );
+
+        subjectRepository.saveAll(
+            List.of(
+                subjectA,
+                subjectB,
+                subjectC,
+                subjectD
+            )
+        );
+        Basket basketA = createBasket(subjectA, "본교생", "컴공", 3, 10);
+        Basket basketB = createBasket(subjectA, "본교생", "전정통", 3, 10);
+        Basket basketC = createBasket(subjectB, "본교생", "컴공", 3, 4);
+        Basket basketD = createBasket(subjectC, "본교생", "전정통", 3, 5);
+        Basket basketE = createBasket(subjectD, "본교생", "소웨", 3, 6);
+
+        basketRepository.saveAll(
+            List.of(
+                basketA,
+                basketB,
+                basketC,
+                basketD,
+                basketE
+            )
+        );
         int expectedSize = 1;
 
         // when
@@ -188,14 +333,10 @@ class BasketServiceTest {
         // then
         assertThat(basketsByCondition.baskets()).hasSize(expectedSize)
             .extracting(
-                BasketsEachSubject::subjectName,
-                BasketsEachSubject::subjectCode,
-                BasketsEachSubject::classCode,
-                BasketsEachSubject::professorName,
-                BasketsEachSubject::departmentName,
-                BasketsEachSubject::departmentCode
+                BasketsEachSubject::subjectId,
+                BasketsEachSubject::totalCount
             ).containsExactly(
-                tuple("컴공 과목A", "001234", "001", "김보예", "컴퓨터공학과", "3210")
+                tuple(subjectA.getId(), 10)
             );
     }
 
@@ -203,7 +344,65 @@ class BasketServiceTest {
     @DisplayName("과목명과 교수명으로 검색했을 시 관심 과목 조회를 확인한다.")
     void subjectNameAndProfessorSelect() {
         // given
-        saveSubjectsAndBaskets();
+        Subject subjectA = createSubjectWithDepartmentInformation(
+            "컴공 과목A",
+            "컴퓨터공학과",
+            "3210",
+            "001234",
+            "001",
+            "김보예"
+        );
+
+        Subject subjectB = createSubjectWithDepartmentInformation(
+            "컴공 과목B",
+            "컴퓨터공학과",
+            "3210",
+            "004321",
+            "001",
+            "김보예"
+        );
+
+        Subject subjectC = createSubjectWithDepartmentInformation(
+            "소웨 과목C",
+            "소프트웨어학과",
+            "3211",
+            "004321",
+            "001",
+            "김수민"
+        );
+
+        Subject subjectD = createSubjectWithDepartmentInformation(
+            "소웨 과목D",
+            "소프트웨어학과",
+            "3211",
+            "001234",
+            "001",
+            "김보예"
+        );
+
+        subjectRepository.saveAll(
+            List.of(
+                subjectA,
+                subjectB,
+                subjectC,
+                subjectD
+            )
+        );
+        Basket basketA = createBasket(subjectA, "본교생", "컴공", 1, 10);
+        Basket basketB = createBasket(subjectA, "본교생", "전정통", 2, 10);
+        Basket basketC = createBasket(subjectB, "본교생", "컴공", 3, 4);
+        Basket basketD = createBasket(subjectC, "본교생", "전정통", 4, 5);
+        Basket basketE = createBasket(subjectD, "본교생", "소웨", 8, 6);
+
+        basketRepository.saveAll(
+            List.of(
+                basketA,
+                basketB,
+                basketC,
+                basketD,
+                basketE
+            )
+        );
         int expectedSize = 1;
 
         // when
@@ -215,14 +414,10 @@ class BasketServiceTest {
         // then
         assertThat(basketsByCondition.baskets()).hasSize(expectedSize)
             .extracting(
-                BasketsEachSubject::subjectName,
-                BasketsEachSubject::subjectCode,
-                BasketsEachSubject::classCode,
-                BasketsEachSubject::professorName,
-                BasketsEachSubject::departmentName,
-                BasketsEachSubject::departmentCode
+                BasketsEachSubject::subjectId,
+                BasketsEachSubject::totalCount
             ).containsExactly(
-                tuple("컴공 과목A", "001234", "001", "김보예", "컴퓨터공학과", "3210")
+                tuple(subjectA.getId(), 10)
             );
     }
 
@@ -230,7 +425,65 @@ class BasketServiceTest {
     @DisplayName("과목명과 학과코드로 검색했을 시 관심 과목 조회를 확인한다.")
     void subjectNameAndDepartmentCodeSelect() {
         // given
-        saveSubjectsAndBaskets();
+        Subject subjectA = createSubjectWithDepartmentInformation(
+            "컴공 과목A",
+            "컴퓨터공학과",
+            "3210",
+            "001234",
+            "001",
+            "김보예"
+        );
+
+        Subject subjectB = createSubjectWithDepartmentInformation(
+            "컴공 과목B",
+            "컴퓨터공학과",
+            "3210",
+            "004321",
+            "001",
+            "김보예"
+        );
+
+        Subject subjectC = createSubjectWithDepartmentInformation(
+            "소웨 과목C",
+            "소프트웨어학과",
+            "3211",
+            "004321",
+            "001",
+            "김수민"
+        );
+
+        Subject subjectD = createSubjectWithDepartmentInformation(
+            "소웨 과목D",
+            "소프트웨어학과",
+            "3211",
+            "001234",
+            "001",
+            "김보예"
+        );
+
+        subjectRepository.saveAll(
+            List.of(
+                subjectA,
+                subjectB,
+                subjectC,
+                subjectD
+            )
+        );
+        Basket basketA = createBasket(subjectA, "본교생", "컴공", 1, 10);
+        Basket basketB = createBasket(subjectA, "본교생", "전정통", 2, 10);
+        Basket basketC = createBasket(subjectB, "본교생", "컴공", 3, 4);
+        Basket basketD = createBasket(subjectC, "본교생", "전정통", 4, 5);
+        Basket basketE = createBasket(subjectD, "본교생", "소웨", 8, 6);
+
+        basketRepository.saveAll(
+            List.of(
+                basketA,
+                basketB,
+                basketC,
+                basketD,
+                basketE
+            )
+        );
         int expectedSize = 1;
 
         // when
@@ -242,14 +495,10 @@ class BasketServiceTest {
         // then
         assertThat(basketsByCondition.baskets()).hasSize(expectedSize)
             .extracting(
-                BasketsEachSubject::subjectName,
-                BasketsEachSubject::subjectCode,
-                BasketsEachSubject::classCode,
-                BasketsEachSubject::professorName,
-                BasketsEachSubject::departmentName,
-                BasketsEachSubject::departmentCode
+                BasketsEachSubject::subjectId,
+                BasketsEachSubject::totalCount
             ).containsExactly(
-                tuple("컴공 과목A", "001234", "001", "김보예", "컴퓨터공학과", "3210")
+                tuple(subjectA.getId(), 10)
             );
     }
 
@@ -257,7 +506,53 @@ class BasketServiceTest {
     @DisplayName("과목명과 학과코드와 교수명으로 검색했을 시 관심 과목 조회를 확인한다.")
     void subjectNameAndDepartmentCodeAndProfessorNameSelect() {
         // given
-        saveSubjectsAndBaskets();
+        Subject subjectA = createSubjectWithDepartmentInformation(
+            "컴공 과목A",
+            "컴퓨터공학과",
+            "3210",
+            "001234",
+            "001",
+            "김보예"
+        );
+
+        Subject subjectB = createSubjectWithDepartmentInformation(
+            "컴공 과목B",
+            "컴퓨터공학과",
+            "3210",
+            "004321",
+            "001",
+            "김보예"
+        );
+
+        Subject subjectC = createSubjectWithDepartmentInformation(
+            "소웨 과목C",
+            "소프트웨어학과",
+            "3211",
+            "004321",
+            "001",
+            "김수민"
+        );
+
+        subjectRepository.saveAll(
+            List.of(
+                subjectA,
+                subjectB,
+                subjectC
+            )
+        );
+        Basket basketA = createBasket(subjectA, "본교생", "컴공", 1, 10);
+        Basket basketB = createBasket(subjectA, "본교생", "전정통", 2, 10);
+        Basket basketC = createBasket(subjectB, "본교생", "컴공", 3, 4);
+        Basket basketD = createBasket(subjectC, "본교생", "전정통", 4, 5);
+
+        basketRepository.saveAll(
+            List.of(
+                basketA,
+                basketB,
+                basketC,
+                basketD
+            )
+        );
         int expectedSize = 1;
 
         // when
@@ -269,14 +564,10 @@ class BasketServiceTest {
         // then
         assertThat(basketsByCondition.baskets()).hasSize(expectedSize)
             .extracting(
-                BasketsEachSubject::subjectName,
-                BasketsEachSubject::subjectCode,
-                BasketsEachSubject::classCode,
-                BasketsEachSubject::professorName,
-                BasketsEachSubject::departmentName,
-                BasketsEachSubject::departmentCode
+                BasketsEachSubject::subjectId,
+                BasketsEachSubject::totalCount
             ).containsExactly(
-                tuple("컴공 과목B", "004321", "001", "김보예", "컴퓨터공학과", "3210")
+                tuple(subjectB.getId(), 4)
             );
     }
 
@@ -303,8 +594,8 @@ class BasketServiceTest {
         // given
         Subject subjectA = createSubjectWithDepartmentCode("컴공 과목A", "001234", "001", "김보예", "3210");
         subjectRepository.save(subjectA);
-        Basket basketA = createBasket(subjectA, "본교생", "컴공", 10);
-        Basket basketB = createBasket(subjectA, "본교생", "전정통", 3);
+        Basket basketA = createBasket(subjectA, "본교생", "컴공", 10, 10);
+        Basket basketB = createBasket(subjectA, "본교생", "전정통", 3, 3);
         basketRepository.saveAll(List.of(basketA, basketB));
         int expected = 2;
 
@@ -331,13 +622,13 @@ class BasketServiceTest {
         // given
         Subject subjectA = createSubjectWithDepartmentCode("컴공 과목A", "001234", "001", "김보예", "3210");
         subjectRepository.save(subjectA);
-        Basket basketA = createBasket(subjectA, "본교생", "컴공", 10);
+        Basket basketA = createBasket(subjectA, "본교생", "컴공", 10, 10);
         basketRepository.save(basketA);
 
         // when
         SubjectBasketsResponse response = basketService.getEachSubjectBaskets(subjectA.getId());
 
-        // thene
+        // then
         assertThat(response.eachDepartmentRegisters()).hasSize(1)
             .extracting(
                 EachDepartmentBasket::studentBelong,
@@ -454,11 +745,11 @@ class BasketServiceTest {
                 subjectD
             )
         );
-        Basket basketA = createBasket(subjectA, "본교생", "컴공", 10);
-        Basket basketB = createBasket(subjectA, "본교생", "전정통", 3);
-        Basket basketC = createBasket(subjectB, "본교생", "컴공", 4);
-        Basket basketD = createBasket(subjectC, "본교생", "전정통", 5);
-        Basket basketE = createBasket(subjectD, "본교생", "소웨", 6);
+        Basket basketA = createBasket(subjectA, "본교생", "컴공", 3, 10);
+        Basket basketB = createBasket(subjectA, "본교생", "전정통", 4, 3);
+        Basket basketC = createBasket(subjectB, "본교생", "컴공", 5, 4);
+        Basket basketD = createBasket(subjectC, "본교생", "전정통", 6, 5);
+        Basket basketE = createBasket(subjectD, "본교생", "소웨", 7, 6);
 
         basketRepository.saveAll(
             List.of(
@@ -475,10 +766,11 @@ class BasketServiceTest {
         Subject subject,
         String studentBelong,
         String registerDepartment,
-        Integer eachCount
+        Integer eachCnt,
+        Integer totRcnt
     ) {
         return new Basket(subject, "", "", "", "", "", studentBelong,
             "", registerDepartment, "", "", 200, 0, 0,
-            0, 0, eachCount, 10);
+            0, 0, eachCnt, totRcnt);
     }
 }


### PR DESCRIPTION
## 작업 내용
Subject 요청에 기존 Basket의 응답 값들을 포함하도록 변경하였습니다.
따라서 Basket의 응답 dto 구성을 변경하였습니다.
이에 따라 테스트들도 재구성했습니다.
또한 이걸 1학기 때 이후에 처음 쓰는 api라서(계절 땐 관담 없음) subject 조회에 soft delete나 학기 조건이 안걸려있는 것 같더라구요? 그래서 이거 걸어줬습니다.

## 고민 지점과 리뷰 포인트
필터링 조건 적절한지 크로스체크 해주세요!! 무슨 말이냐면 학과 같은 경우에는 semester at은 조건 걸면 안되잖아요? 그래서 soft delete랑 학기 조건 추가한 것들이 적절한지 한번 더 크로스체크해달라는 의미입니당

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->