### PR TITLE
feat: 학과 정보 관리 어드민 API 구현

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/AdminDepartmentApi.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminDepartmentApi.java
@@ -1,5 +1,6 @@
 package kr.allcll.backend.admin;
 
+import jakarta.servlet.http.HttpServletRequest;
 import kr.allcll.backend.domain.department.DepartmentService;
 import kr.allcll.backend.domain.department.dto.DepartmentsResponse;
 import kr.allcll.crawler.department.CrawlerDepartmentService;
@@ -16,18 +17,26 @@ public class AdminDepartmentApi {
 
     private final CrawlerDepartmentService crawlerDepartmentService;
     private final DepartmentService departmentService;
+    private final AdminRequestValidator validator;
 
     @PostMapping("/api/admin/departments")
-    public void fetchAndSaveDepartments(
+    public ResponseEntity<Void> fetchAndSaveDepartments(HttpServletRequest request,
         @RequestParam String userId,
         @RequestParam String year,
         @RequestParam String semesterCode
     ) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
         crawlerDepartmentService.fetchAndSaveDepartments(userId, year, semesterCode);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/api/admin/departments")
-    public ResponseEntity<DepartmentsResponse> getAllDepartments() {
+    public ResponseEntity<DepartmentsResponse> getAllDepartments(HttpServletRequest request) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
         DepartmentsResponse response = departmentService.retrieveAllDepartment();
         return ResponseEntity.ok(response);
     }


### PR DESCRIPTION
## 작업 내용
학과 크롤링 정보 관리 어드민 API를 구현했습니다.
1. 전체 학과 데이터를 크롤링하는 api
  - 크롤러의 학과 크롤링 api를 가져왔습니다.
  - 관련 service나 repository등의 클래스들은 크롤러 pr에 작성했듯이, 변경 지점이 너무 커서 추후 리팩토링 사항으로 남겨놓고 일단 controller만 옮겼습니다.
2. 전체 학과 크롤링 데이터를 조회하는 api
  - `DepartmentApi`의 `retrieveAllDepartment` 로직과 동일합니다
<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->

api 주소는 `/api/departments/fetch` 에서 `/api/departments`로 변경했는데 너무 모호하진않은지 의견주시면 감사하겠습니당