### PR TITLE
feat: SSE 상태 판별 어드민 API 추가 구현

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/AdminRequestValidator.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminRequestValidator.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class AdminRequestValidator {
 
     private static final String AUTH_HEADER = "X-ADMIN-TOKEN";
-    private static final long REQUEST_INTERVAL_SECONDS = 5;
+    private static final long REQUEST_INTERVAL_SECONDS = 3;
 
     private final Map<String, Long> lastRequestTimeByIp = new ConcurrentHashMap<>();
 

--- a/src/main/java/kr/allcll/backend/admin/AdminSseApi.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminSseApi.java
@@ -2,7 +2,9 @@ package kr.allcll.backend.admin;
 
 import jakarta.servlet.http.HttpServletRequest;
 import kr.allcll.backend.support.scheduler.SchedulerService;
+import kr.allcll.backend.support.scheduler.dto.SeatSchedulerStatusResponse;
 import kr.allcll.backend.support.sse.SseService;
+import kr.allcll.backend.support.sse.dto.SseStatusResponse;
 import kr.allcll.backend.support.web.ThreadLocalHolder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -32,7 +34,17 @@ public class AdminSseApi {
             .body(emitter);
     }
 
-    @PostMapping("/api/admin/scheduler/start")
+    @GetMapping("/api/admin/sse/check")
+    public ResponseEntity<SseStatusResponse> getSseConnectedStatus(HttpServletRequest request) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
+        String token = ThreadLocalHolder.SHARED_TOKEN.get();
+        SseStatusResponse sseStatusResponse = sseService.isConnected(token);
+        return ResponseEntity.ok().body(sseStatusResponse);
+    }
+
+    @PostMapping("/api/admin/seat-scheduler/start")
     public ResponseEntity<Void> startScheduling(HttpServletRequest request) {
         if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
             return ResponseEntity.status(401).build();
@@ -41,12 +53,21 @@ public class AdminSseApi {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/api/admin/scheduler/cancel")
+    @PostMapping("/api/admin/seat-scheduler/cancel")
     public ResponseEntity<Void> cancelScheduling(HttpServletRequest request) {
         if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
             return ResponseEntity.status(401).build();
         }
         schedulerService.cancelScheduling();
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/admin/seat-scheduler/check")
+    public ResponseEntity<SeatSchedulerStatusResponse> checkSchedulerStatus(HttpServletRequest request) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
+        SeatSchedulerStatusResponse seatSchedulerStatusResponse = schedulerService.getSeatSchedulerStatus();
+        return ResponseEntity.ok(seatSchedulerStatusResponse);
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
@@ -40,7 +40,7 @@ public class GeneralSeatSender {
         scheduledTaskHandler.scheduleAtFixedRate(getGeneralSeatTask(), SENDING_PERIOD);
     }
 
-    private boolean hasActiveSchedule() {
+    public boolean hasActiveSchedule() {
         return scheduledTaskHandler.getTaskCount() > 0;
     }
 

--- a/src/main/java/kr/allcll/backend/domain/seat/PinSeatSender.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/PinSeatSender.java
@@ -38,7 +38,7 @@ public class PinSeatSender {
         scheduledTaskHandler.scheduleAtFixedRate(getPinSeatTask(), SENDING_PERIOD);
     }
 
-    private boolean hasActiveSchedule() {
+    public boolean hasActiveSchedule() {
         return scheduledTaskHandler.getTaskCount() > 0;
     }
 

--- a/src/main/java/kr/allcll/backend/support/scheduler/SchedulerService.java
+++ b/src/main/java/kr/allcll/backend/support/scheduler/SchedulerService.java
@@ -2,6 +2,7 @@ package kr.allcll.backend.support.scheduler;
 
 import kr.allcll.backend.domain.seat.GeneralSeatSender;
 import kr.allcll.backend.domain.seat.PinSeatSender;
+import kr.allcll.backend.support.scheduler.dto.SeatSchedulerStatusResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,5 +21,10 @@ public class SchedulerService {
     public void cancelScheduling() {
         generalSeatSender.cancel();
         pinSeatSender.cancel();
+    }
+
+    public SeatSchedulerStatusResponse getSeatSchedulerStatus() {
+        boolean isActive = generalSeatSender.hasActiveSchedule() && pinSeatSender.hasActiveSchedule();
+        return SeatSchedulerStatusResponse.of(isActive);
     }
 }

--- a/src/main/java/kr/allcll/backend/support/scheduler/SchedulerService.java
+++ b/src/main/java/kr/allcll/backend/support/scheduler/SchedulerService.java
@@ -24,7 +24,7 @@ public class SchedulerService {
     }
 
     public SeatSchedulerStatusResponse getSeatSchedulerStatus() {
-        boolean isActive = generalSeatSender.hasActiveSchedule() && pinSeatSender.hasActiveSchedule();
-        return SeatSchedulerStatusResponse.of(isActive);
+        boolean isSending = generalSeatSender.hasActiveSchedule() && pinSeatSender.hasActiveSchedule();
+        return SeatSchedulerStatusResponse.of(isSending);
     }
 }

--- a/src/main/java/kr/allcll/backend/support/scheduler/dto/SeatSchedulerStatusResponse.java
+++ b/src/main/java/kr/allcll/backend/support/scheduler/dto/SeatSchedulerStatusResponse.java
@@ -1,0 +1,10 @@
+package kr.allcll.backend.support.scheduler.dto;
+
+public record SeatSchedulerStatusResponse(
+    boolean isActive
+) {
+
+    public static SeatSchedulerStatusResponse of(boolean isActive) {
+        return new SeatSchedulerStatusResponse(isActive);
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/scheduler/dto/SeatSchedulerStatusResponse.java
+++ b/src/main/java/kr/allcll/backend/support/scheduler/dto/SeatSchedulerStatusResponse.java
@@ -1,10 +1,10 @@
 package kr.allcll.backend.support.scheduler.dto;
 
 public record SeatSchedulerStatusResponse(
-    boolean isActive
+    boolean isSending
 ) {
 
-    public static SeatSchedulerStatusResponse of(boolean isActive) {
-        return new SeatSchedulerStatusResponse(isActive);
+    public static SeatSchedulerStatusResponse of(boolean isSending) {
+        return new SeatSchedulerStatusResponse(isSending);
     }
 }

--- a/src/main/java/kr/allcll/backend/support/sse/SseService.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseService.java
@@ -2,6 +2,7 @@ package kr.allcll.backend.support.sse;
 
 import java.io.IOException;
 import java.util.List;
+import kr.allcll.backend.support.sse.dto.SseStatusResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -45,11 +46,17 @@ public class SseService {
         try {
             sseEmitter.send(eventBuilder);
         } catch (IOException e) {
+            log.warn("전송 실패 - SSE 연결이 끊겼습니다.: {}", e.getMessage());
             SseErrorHandler.handle(e);
         }
     }
 
     public List<String> getConnectedTokens() {
         return sseEmitterStorage.getUserTokens().stream().toList();
+    }
+
+    public SseStatusResponse isConnected(String token) {
+        boolean isConnected = sseEmitterStorage.getEmitter(token).isPresent();
+        return SseStatusResponse.of(isConnected);
     }
 }

--- a/src/main/java/kr/allcll/backend/support/sse/dto/SseStatusResponse.java
+++ b/src/main/java/kr/allcll/backend/support/sse/dto/SseStatusResponse.java
@@ -1,0 +1,9 @@
+package kr.allcll.backend.support.sse.dto;
+
+public record SseStatusResponse(
+    boolean isConnected
+) {
+    public static SseStatusResponse of(boolean isConnected) {
+        return new SseStatusResponse(isConnected);
+    }
+}


### PR DESCRIPTION
## 작업 내용
기존에 존재하던 SSE 관련 API는 다음과 같습니다.

> 1. SSE 연결을 허용한다.
> 2. SSE로 여석 정보를 전달한다.
> 3. SSE 여석 정보 전달을 중단한다.

---

새로 구현한 API는 다음과 같습니다.

> 1. SSE 연결 상태를 확인한다. - true/false
> 2. SSE 여석 데이터 전송 여부를 확인한다. - true/false

새로 구현한 API가 나온 배경을 설명드리겠습니다.
최근 회의에서, 어드민 페이지를 만드는 목적에 대한 논의가 이루어졌습니다.
두 가지 방향성이 언급되었습니다.

> 1. Action에 대한 자동화
> 2. 모니터링 한 곳으로 모으는 역할

- 기존 운영 과정에서 포스트맨으로 수동 입력 + 프로세스대로 요청을 보내는 등의 불편함이 있었습니다. 
   ex) header / 인증정보를 설정하는 부분이 번거로움.

2번 방향성으로 갈 경우, 포스트맨을 사용하는 것과 크게 다르지 않다는 의견이 나왔습니다.
따라서, 관리자가 편리하게 운영하고 대시보드를 통해 현재 운영 상황을 모니터링 하는 방향성으로 논의되었습니다.
자세한 내용은 회의록을 참고해주세요.

---
포스트맨으로 검증 완료했습니다.
해당 시나리오와 캡쳐본은 추후 추가하도록 하겠습니다.

## 고민 지점과 리뷰 포인트
1.**요청 간격 변수값 논의 필요**
어드민 API에서는 요청 IP를 기준으로 요청 간격과 토큰 유효성을 검사해 요청을 제한하거나 허용하도록 설계돼 있습니다. 기존에는 여석 전송과 여석 전송 중단 두 개의 API만 존재했고, 이 둘은 일반적으로 순차적으로 호출되기 때문에 요청 간 간격이 짧지 않았습니다. 그래서 요청이 너무 빠르게 반복되는 경우에만 차단하는 방식으로 동작했습니다!

하지만 어드민 API가 추가됨에 따라, 여러 요청이 빠르게 연속적으로 호출되는 경우가 많아졌고, 기존 설정이었던 5초 제한은 이런 정상적인 흐름에도 401 오류를 발생시키는 문제가 있었습니다. 그래서 현재는 간격 제한 값을 3초로 줄인 상태입니다.

요청 간격 제한은 요청이 짧은 시간에 너무 자주 발생하는 경우를 차단해 보안을 강화하기 위한 목적이라는 점은 이해가 됩니다. 다만 지금처럼 정상적인 어드민 사용 과정에서도 제한에 걸려 불편을 겪는 상황이라면, 이 기준값을 더 완화하는 것은 어떨까 합니다!
  이에 대한 의견 주시면 감사하겠습니다~
  (해당 불편함은 포스트맨에서 검증하는 과정에서 겪었습니다.)

2.**SSE 연결 중단 API 구현에 대하여**
기존에는 SSE 연결하는 API만 구현되어 있던걸로 알고 있습니다. SSE 연결을 중단하는 API도 필요할까요?
필요하다면 어느 시점에 호출이 필요할까요?

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->