### PR TITLE
feat: 여석 관리 어드민 API 구현

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/AdminSeatApi.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminSeatApi.java
@@ -1,0 +1,65 @@
+package kr.allcll.backend.admin;
+
+import java.util.List;
+import kr.allcll.crawler.seat.CrawlerSeatService;
+import kr.allcll.crawler.seat.PinSubjectUpdateRequest;
+import kr.allcll.crawler.seat.SubjectSummaryResponse;
+import kr.allcll.crawler.seat.TargetSubjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminSeatApi {
+
+    private final CrawlerSeatService crawlerSeatService;
+    private final TargetSubjectService targetSubjectService;
+
+    @GetMapping("/api/seat/start")
+    public ResponseEntity<Void> getSeatPeriodically(@RequestParam(required = false) String userId) {
+        targetSubjectService.loadGeneralSubjects();
+        crawlerSeatService.getAllSeatPeriodically(userId);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/season-seat/start")
+    public ResponseEntity<Void> seasonSeatStart(@RequestParam(required = false) String userId) {
+        targetSubjectService.loadAllSubjects();
+        crawlerSeatService.getSeasonSeatPeriodically(userId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/api/seat/cancel")
+    public ResponseEntity<Void> cancelSeatScheduling() {
+        crawlerSeatService.cancelSeatScheduling();
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * deprecated: 백엔드와의 통신이 크롤러의 서브모듈화로 필요 없어 졌습니다. 따라서 해당 api를 통해 loadPinSubject를 하는 것이 아닌, 백엔드 서버에서 직접
+     * loadPinSubjects를 호출합니다.
+     */
+    @PutMapping("/api/pin")
+    public ResponseEntity<Void> pinSubject(@RequestBody PinSubjectUpdateRequest request) {
+        targetSubjectService.loadPinSubjects(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/admin/target-subjects")
+    public ResponseEntity<List<SubjectSummaryResponse>> getTargetSubjects() {
+        List<SubjectSummaryResponse> response = targetSubjectService.getAllTargetSubjects();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/api/admin/target-general-subjects")
+    public ResponseEntity<List<SubjectSummaryResponse>> getTargetGeneralSubjects() {
+        List<SubjectSummaryResponse> response = targetSubjectService.getAllTargetGeneralSubjects();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/kr/allcll/backend/admin/AdminSeatApi.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminSeatApi.java
@@ -1,16 +1,12 @@
 package kr.allcll.backend.admin;
 
-import java.util.List;
+import jakarta.servlet.http.HttpServletRequest;
 import kr.allcll.crawler.seat.CrawlerSeatService;
-import kr.allcll.crawler.seat.PinSubjectUpdateRequest;
-import kr.allcll.crawler.seat.SubjectSummaryResponse;
 import kr.allcll.crawler.seat.TargetSubjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,46 +16,36 @@ public class AdminSeatApi {
 
     private final CrawlerSeatService crawlerSeatService;
     private final TargetSubjectService targetSubjectService;
+    private final AdminRequestValidator validator;
 
-    @GetMapping("/api/seat/start")
-    public ResponseEntity<Void> getSeatPeriodically(@RequestParam(required = false) String userId) {
+    @GetMapping("/api/admin/seat/start")
+    public ResponseEntity<Void> getSeatPeriodically(HttpServletRequest request,
+        @RequestParam(required = false) String userId) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
         targetSubjectService.loadGeneralSubjects();
         crawlerSeatService.getAllSeatPeriodically(userId);
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/api/season-seat/start")
-    public ResponseEntity<Void> seasonSeatStart(@RequestParam(required = false) String userId) {
+    @GetMapping("/api/admin/season-seat/start")
+    public ResponseEntity<Void> seasonSeatStart(HttpServletRequest request,
+        @RequestParam(required = false) String userId) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
         targetSubjectService.loadAllSubjects();
         crawlerSeatService.getSeasonSeatPeriodically(userId);
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/api/seat/cancel")
-    public ResponseEntity<Void> cancelSeatScheduling() {
+    @PostMapping("/api/admin/seat/cancel")
+    public ResponseEntity<Void> cancelSeatScheduling(HttpServletRequest request) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
         crawlerSeatService.cancelSeatScheduling();
         return ResponseEntity.ok().build();
-    }
-
-    /**
-     * deprecated: 백엔드와의 통신이 크롤러의 서브모듈화로 필요 없어 졌습니다. 따라서 해당 api를 통해 loadPinSubject를 하는 것이 아닌, 백엔드 서버에서 직접
-     * loadPinSubjects를 호출합니다.
-     */
-    @PutMapping("/api/pin")
-    public ResponseEntity<Void> pinSubject(@RequestBody PinSubjectUpdateRequest request) {
-        targetSubjectService.loadPinSubjects(request);
-        return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/api/admin/target-subjects")
-    public ResponseEntity<List<SubjectSummaryResponse>> getTargetSubjects() {
-        List<SubjectSummaryResponse> response = targetSubjectService.getAllTargetSubjects();
-        return ResponseEntity.ok(response);
-    }
-
-    @GetMapping("/api/admin/target-general-subjects")
-    public ResponseEntity<List<SubjectSummaryResponse>> getTargetGeneralSubjects() {
-        List<SubjectSummaryResponse> response = targetSubjectService.getAllTargetGeneralSubjects();
-        return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## 작업 내용
학과 크롤링 정보 관리 어드민 API를 구현했습니다.

크롤러의 여석 크롤링 api 중 admin 페이지에 사용되는 메서드들만 이동하였습니다.
- 일반 학기 여석 크롤링
- 계절 학기 여석 크롤링
- 여석 크롤링 종료

### 추후 구현해야하는 로직
`여석 크롤링 상태에 대한 확인 로직`을 추가해야하는데 관련 내용이 `크롤러 레포 31번 PR`에 있어요. (링크를 첨부해도 되는지 모르겠어 따로 첨부는 하지 않았습니다)
방법 함께 의논해보고 따로 pr파서 구현하도록하겠습니다!
<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->