### PR TITLE
refactor: 세션 갱신 실행 여부 판별 로직 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/session/SessionService.java
+++ b/src/main/java/kr/allcll/backend/session/SessionService.java
@@ -1,8 +1,6 @@
 package kr.allcll.backend.session;
 
 import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import kr.allcll.backend.session.dto.CredentialResponse;
 import kr.allcll.backend.session.dto.SessionStatusResponse;
 import kr.allcll.backend.session.dto.SetCredentialRequest;
@@ -19,8 +17,6 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class SessionService {
-
-    private final Map<String, String> userTaskMap = new ConcurrentHashMap<>();
 
     private final Credentials credentials;
     private final CrawlerScheduledTaskHandler threadPoolTaskScheduler;
@@ -44,7 +40,7 @@ public class SessionService {
         Credential credential = credentials.findByUserId(userId);
         Runnable resetSessionTask = () -> sessionClient.execute(credential, new EmptyPayload());
 
-        String taskId = threadPoolTaskScheduler.scheduleAtFixedRate(userId, resetSessionTask, Duration.ofSeconds(10));
+        threadPoolTaskScheduler.scheduleAtFixedRate(userId, resetSessionTask, Duration.ofSeconds(10));
     }
 
     public SessionStatusResponse getSessionStatus(String userId) {
@@ -55,6 +51,5 @@ public class SessionService {
     public void cancelSessionScheduling() {
         threadPoolTaskScheduler.cancelAll();
         credentials.deleteAll();
-        userTaskMap.clear();
     }
 }

--- a/src/main/java/kr/allcll/backend/session/SessionService.java
+++ b/src/main/java/kr/allcll/backend/session/SessionService.java
@@ -37,25 +37,18 @@ public class SessionService {
     }
 
     public void startSession(String userId) {
-        if (userTaskMap.containsKey(userId) && threadPoolTaskScheduler.isRunning(userTaskMap.get(userId))) {
+        if(threadPoolTaskScheduler.isRunning(userId)) {
             log.info("이미 해당 인증 정보로 세션 갱신 중입니다: {}", userId);
             return;
         }
         Credential credential = credentials.findByUserId(userId);
         Runnable resetSessionTask = () -> sessionClient.execute(credential, new EmptyPayload());
 
-        String taskId = threadPoolTaskScheduler.scheduleAtFixedRate(resetSessionTask, Duration.ofSeconds(10));
-        userTaskMap.put(userId, taskId);
+        String taskId = threadPoolTaskScheduler.scheduleAtFixedRate(userId, resetSessionTask, Duration.ofSeconds(10));
     }
 
     public SessionStatusResponse getSessionStatus(String userId) {
-        String taskId = userTaskMap.get(userId);
-
-        boolean isActive = false;
-        if (taskId != null) {
-            isActive = threadPoolTaskScheduler.isRunning(taskId);
-        }
-
+        boolean isActive = threadPoolTaskScheduler.isRunning(userId);
         return SessionStatusResponse.of(isActive);
     }
 


### PR DESCRIPTION
## 작업 내용
세션 갱신 실행 여부를 판별하는 로직을 수정했습니다.
기존에는 크롤러 - 스케줄러 핸들러의 내의 메서드를 사용하기 위해 taskId와 userId를 매핑하여 구현하였습니다.
taskId를 userId로 대체하여 Map 자료형을 쓰지 않고 좀 더 간편화 시키는 방향으로 수정했습니다.

기존, 크롤러 스케줄러를 관리하는 핸들러는 
1. Session 갱신 요청을 보내는 클래스와,
2. Seat 정보를 얻어오는 클래스
두 곳에서 쓰였습니다. 
하지만, 이는 config 클래스에서 각 스케줄러가 따로 관리되도록 설정되어 있으므로, 하나의 도메인에서 실행되는 스케줄러가 다른 도메인에서 실행되는 스케줄러에 영향을 주지 않습니다. 
따라서, taskId를 userId로 대체하여 쓰는 방식에서 문제가 생길 일은 없다고 판단했습니다.
---

포스트맨으로 정상 동작 확인했습니다.
나중에, 세션 갱신과 여석 정보 크롤링을 같이 실행할 때도 한 번 검증해보면 좋을 것 같아요.

## 고민 지점과 리뷰 포인트

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->