### PR TITLE
fix: 기존 SSE 연결 api 롤백

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/AdminSseApi.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminSseApi.java
@@ -22,28 +22,6 @@ public class AdminSseApi {
     private final SchedulerService schedulerService;
     private final AdminRequestValidator validator;
 
-    @GetMapping(value = "/api/admin/sse-connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> getServerSentEventConnection(HttpServletRequest request) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
-        String token = ThreadLocalHolder.SHARED_TOKEN.get();
-        SseEmitter emitter = sseService.connect(token);
-        return ResponseEntity.ok()
-            .header("X-Accel-Buffering", "no")
-            .body(emitter);
-    }
-
-    @GetMapping("/api/admin/sse/check")
-    public ResponseEntity<SseStatusResponse> getSseConnectedStatus(HttpServletRequest request) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
-        String token = ThreadLocalHolder.SHARED_TOKEN.get();
-        SseStatusResponse sseStatusResponse = sseService.isConnected(token);
-        return ResponseEntity.ok().body(sseStatusResponse);
-    }
-
     @PostMapping("/api/admin/seat-scheduler/start")
     public ResponseEntity<Void> startScheduling(HttpServletRequest request) {
         if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {

--- a/src/main/java/kr/allcll/backend/support/sse/SseApi.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseApi.java
@@ -1,0 +1,25 @@
+package kr.allcll.backend.support.sse;
+
+import kr.allcll.backend.support.web.ThreadLocalHolder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+public class SseApi {
+
+    private final SseService sseService;
+
+    @GetMapping(value = "/api/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> getServerSentEventConnection() {
+        String token = ThreadLocalHolder.SHARED_TOKEN.get();
+        SseEmitter emitter = sseService.connect(token);
+        return ResponseEntity.ok()
+            .header("X-Accel-Buffering", "no")
+            .body(emitter);
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/sse/SseApiTest.java
+++ b/src/test/java/kr/allcll/backend/support/sse/SseApiTest.java
@@ -3,10 +3,7 @@ package kr.allcll.backend.support.sse;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import kr.allcll.backend.admin.AdminRequestValidator;
-import kr.allcll.backend.admin.AdminSseApi;
 import kr.allcll.backend.domain.seat.PinSeatSender;
-import kr.allcll.backend.support.scheduler.SchedulerService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(AdminSseApi.class)
+@WebMvcTest(SseApi.class)
 class SseApiTest {
 
     @Autowired
@@ -25,19 +22,13 @@ class SseApiTest {
     private SseService sseService;
 
     @MockitoBean
-    private SchedulerService schedulerService;
-
-    @MockitoBean
     private PinSeatSender pinSeatSender;
-
-    @MockitoBean
-    private AdminRequestValidator validator;
 
     @DisplayName("Server Sent Event를 연결한다.")
     @Test
     void getServerSentEventConnection() throws Exception {
         // when, then
-        mockMvc.perform(get("/api/admin/sse-connect")
+        mockMvc.perform(get("/api/connect")
                 .accept(MediaType.TEXT_EVENT_STREAM_VALUE))
             .andExpect(status().isOk());
     }

--- a/src/test/java/kr/allcll/backend/support/sse/SseServiceTest.java
+++ b/src/test/java/kr/allcll/backend/support/sse/SseServiceTest.java
@@ -7,16 +7,13 @@ import io.restassured.response.Response;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
-import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.domain.seat.PinSeatSender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -27,14 +24,8 @@ class SseServiceTest {
 
     private static final Logger log = LoggerFactory.getLogger(SseServiceTest.class);
 
-    @Value("${admin.token}")
-    private String adminToken;
-
     @Autowired
     private SseService sseService;
-
-    @MockitoBean
-    private AdminRequestValidator validator;
 
     @MockitoBean
     private PinSeatSender pinSeatSender;
@@ -51,14 +42,10 @@ class SseServiceTest {
     @Test
     void sseConnectionTest() {
         // when
-        Mockito.when(validator.isUnauthorized(Mockito.any())).thenReturn(false);
-        Mockito.when(validator.isRateLimited(Mockito.any())).thenReturn(false);
-
         Response response = RestAssured.given()
             .accept("text/event-stream")
-            .header("X-ADMIN-TOKEN", adminToken)
             .when()
-            .get("/api/admin/sse-connect")
+            .get("/api/connect")
             .then()
             .statusCode(200)
             .extract()
@@ -72,14 +59,10 @@ class SseServiceTest {
     @Test
     void ssePropagationTest() {
         // given
-        Mockito.when(validator.isUnauthorized(Mockito.any())).thenReturn(false);
-        Mockito.when(validator.isRateLimited(Mockito.any())).thenReturn(false);
-
         Response response1 = RestAssured.given()
             .accept("text/event-stream")
-            .header("X-ADMIN-TOKEN", adminToken)
             .when()
-            .get("/api/admin/sse-connect")
+            .get("/api/connect")
             .then()
             .statusCode(200)
             .extract()
@@ -87,9 +70,8 @@ class SseServiceTest {
 
         Response response2 = RestAssured.given()
             .accept("text/event-stream")
-            .header("X-ADMIN-TOKEN", adminToken)
             .when()
-            .get("/api/admin/sse-connect")
+            .get("/api/connect")
             .then()
             .statusCode(200)
             .extract()


### PR DESCRIPTION
## 작업 내용
- SSE 연결 허용 및 차단 api 에 대한 컨텍스트 이해가 부족한 상태로 구현된 어드민 api 를 삭제하고, 클라이언트가 SSE 연결 시에 요청하는 api를 롤백했습니다.

## 고민 지점과 리뷰 포인트

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->
추후 구현이 필요한 SSE 관련 API에 대해서 정리해보겠습니다.
1. SSE 연결을 허용하는 어드민 api
- 수강신청 기간 때에는 클라이언트가 SSE 연결을 맺을 수 있도록 허용한다.
2. SSE 연결을 차단하는 어드민 api
- 수강신청 기간이 아닐 때 SSE 연결이 자동으로 이루어지는 것을 방지한다.
3.  SSE 연결 상태를 확인하는 어드민 api
- 현재 SSE 연결을 허용하고 있는지 차단 중인지 확인한다.

해당 api 구현은 후순위로 두고, 시간적 여유가 생기면 그 때 진행하도록 합니다.
