### PR TITLE
feat: 여석 크롤링 실행 상태 확인 API 구현

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/AdminSeatApi.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminSeatApi.java
@@ -2,6 +2,7 @@ package kr.allcll.backend.admin;
 
 import jakarta.servlet.http.HttpServletRequest;
 import kr.allcll.crawler.seat.CrawlerSeatService;
+import kr.allcll.crawler.seat.SeatStatusResponse;
 import kr.allcll.crawler.seat.TargetSubjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -38,6 +39,15 @@ public class AdminSeatApi {
         targetSubjectService.loadAllSubjects();
         crawlerSeatService.getSeasonSeatPeriodically(userId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/admin/seat/check")
+    public ResponseEntity<SeatStatusResponse> getSeatStatus(HttpServletRequest request) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
+        SeatStatusResponse seatStatusResponse = crawlerSeatService.getSeatCrawlerStatus();
+        return ResponseEntity.ok(seatStatusResponse);
     }
 
     @PostMapping("/api/admin/seat/cancel")


### PR DESCRIPTION
## 작업 내용
크롤러 SeatService에 구현한 메서드를 활용하여, 여석 전송 실행 상태를 확인하는 api를 구현했습니다.
자세한 로직은 크롤러 pr을 참고해주세요!

포스트맨으로 정상 작동 확인했습니다.

1. 여석 크롤링 시작 시, 정상적으로 로그가 찍힙니다.
<img width="2504" height="624" alt="image" src="https://github.com/user-attachments/assets/55ba17e0-d0e6-4844-a4cc-9189c7c2f86d" />

포스트맨에서도, SSE로 잘 전달됩니다.
<img width="2508" height="1522" alt="image" src="https://github.com/user-attachments/assets/5ea16ff0-d8ce-4ce8-8aea-ac5e40ec7752" />


2. 데이터베이스에도 정상적으로 데이터가 담기는 것을 확인했습니다. 보안 상의 이유로 해당 캡쳐본은 첨부하지 않겠습니다.

3. 여석 크롤링 중이므로, 해당 요청 응답값이 true로 반환됩니다.
<img width="2568" height="1052" alt="image" src="https://github.com/user-attachments/assets/7f849b9d-963d-4d0a-8b65-7debbb3f2154" />

4. 여석 크롤링 중단 후, 구현한 여석 전송 실행 상태 확인 api를 호출하면 정상적으로 false가 반환됩니다.
<img width="2526" height="994" alt="image" src="https://github.com/user-attachments/assets/8aab0c3b-fe83-47c8-97b2-6d7fdc81452e" />


## 고민 지점과 리뷰 포인트
-
<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->