### PR TITLE
feat: 과목 동기화 리포트 이메일 발송 로직 이동

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       DEV_URL: ${{ secrets.DEV_URL }}
       ADMIN_URL: ${{ secrets.ADMIN_URL }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
 
     defaults:
       run:
@@ -96,8 +97,10 @@ jobs:
           mkdir -p /home/ubuntu/app/logs
           
           echo "Starting new application..."
-          sudo nohup java -Dspring.profiles.active=dev \
+          sudo -E nohup java \
+          -Dspring.profiles.active=dev \
           -Dspring.config.location=/home/ubuntu/app/application-dev.yml \
           -Duser.timezone=Asia/Seoul \
           -Dlogging.file.path=/home/ubuntu/app/logs \
+          -DEMAIL_PASSWORD="${EMAIL_PASSWORD}" \
           -jar /home/ubuntu/app/server.jar & 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'io.micrometer:micrometer-registry-datadog'
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework:spring-aspects'

--- a/src/main/java/kr/allcll/backend/client/EmailProperties.java
+++ b/src/main/java/kr/allcll/backend/client/EmailProperties.java
@@ -1,0 +1,34 @@
+package kr.allcll.backend.client;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@Slf4j
+public class EmailProperties {
+
+    @Value("${spring.mail.host:smtp.gmail.com}")
+    private String host;
+
+    @Value("${spring.mail.port:587}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth:true}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable:true}")
+    private boolean starttlsEnable;
+
+    public EmailProperties() {
+        log.info("EmailProperties 접근");
+    }
+}

--- a/src/main/java/kr/allcll/backend/config/EmailConfig.java
+++ b/src/main/java/kr/allcll/backend/config/EmailConfig.java
@@ -1,0 +1,33 @@
+package kr.allcll.backend.config;
+
+import java.util.Properties;
+import kr.allcll.backend.client.EmailProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+@RequiredArgsConstructor
+public class EmailConfig {
+
+    private final EmailProperties emailProperties;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(emailProperties.getHost());
+        mailSender.setPort(emailProperties.getPort());
+        mailSender.setUsername(emailProperties.getUsername());
+        mailSender.setPassword(emailProperties.getPassword());
+        mailSender.setDefaultEncoding("UTF-8");
+
+        Properties props = new Properties();
+        props.put("mail.smtp.auth", String.valueOf(emailProperties.isAuth()));
+        props.put("mail.smtp.starttls.enable", String.valueOf(emailProperties.isStarttlsEnable()));
+
+        mailSender.setJavaMailProperties(props);
+        return mailSender;
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/subject/subjectReport/CrawlingMetaData.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/subjectReport/CrawlingMetaData.java
@@ -1,0 +1,22 @@
+package kr.allcll.backend.domain.subject.subjectReport;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+public record CrawlingMetaData(
+    LocalDateTime crawlingStartTime,
+    LocalDateTime crawlingEndTime
+) {
+
+    public String formattedDuration() {
+        Duration duration = crawlingDuration();
+        long minutes = duration.toMinutes();
+        long seconds = duration.minusMinutes(minutes).getSeconds();
+        return String.format("%d분 %d초", minutes, seconds);
+    }
+
+    private Duration crawlingDuration() {
+        return Duration.between(crawlingStartTime, crawlingEndTime);
+    }
+
+}

--- a/src/main/java/kr/allcll/backend/domain/subject/subjectReport/ReportTableBuilder.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/subjectReport/ReportTableBuilder.java
@@ -1,0 +1,139 @@
+package kr.allcll.backend.domain.subject.subjectReport;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import kr.allcll.crawler.subject.CrawlerSubject;
+import kr.allcll.crawler.subject.CrawlerSubjectDiffResult;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReportTableBuilder {
+
+    private String getTableStyle() {
+        return "style='border-collapse:collapse; margin-left:0; width:80%;'";
+    }
+
+    private String getThStyle() {
+        return "style='background-color:#f2f2f2; padding:8px; border:1px solid #ddd; text-align:center;'";
+    }
+
+    private String getTdStyle() {
+        return "style='padding:8px; border:1px solid #ddd; text-align:center;'";
+    }
+
+    public String buildSubjectChangeSummaryTable(int totalSubjectsCount, List<CrawlerSubject> insertSubjects,
+        List<CrawlerSubject> deleteSubjects, List<CrawlerSubject> updateSubjects) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<table ").append(getTableStyle()).append(">");
+        sb.append("<tr>")
+            .append("<th ").append(getThStyle()).append(">구분</th>")
+            .append("<th ").append(getThStyle()).append(">건수</th>")
+            .append("<th ").append(getThStyle()).append(">비고</th>")
+            .append("</tr>");
+
+        sb.append(buildSummaryRow("전체 과목 수", String.valueOf(totalSubjectsCount), "현재 동기화 기준 전체 과목 수"));
+        sb.append(buildSummaryRow("신규 추가 과목 수", String.valueOf(insertSubjects.size()), "DB에 없던 과목이 새로 추가됨"));
+        sb.append(buildSummaryRow("폐강 과목 수", String.valueOf(deleteSubjects.size()), "DB에서 isDeleted = true 로 처리됨"));
+        sb.append(buildSummaryRow("정보 변경 과목 수", String.valueOf(updateSubjects.size()), "과목명, 교수명, 강의실 등 주요 정보 수정"));
+
+        sb.append("</table>");
+        return sb.toString();
+    }
+
+    private String buildSummaryRow(String category, String count, String note) {
+        return "<tr>"
+            + "<td " + getTdStyle() + ">" + category + "</td>"
+            + "<td " + getTdStyle() + ">" + count + "</td>"
+            + "<td " + getTdStyle() + ">" + note + "</td>"
+            + "</tr>";
+    }
+
+    public String buildSubjectInfoTable(List<CrawlerSubject> subjects) {
+        if (subjects == null || subjects.isEmpty()) {
+            return "<p style='color:red;'>❌ 해당 데이터 없음 ❌</p>";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("<table ").append(getTableStyle()).append(">");
+        sb.append("<tr>")
+            .append("<th ").append(getThStyle()).append(">과목번호</th>")
+            .append("<th ").append(getThStyle()).append(">과목명</th>")
+            .append("<th ").append(getThStyle()).append(">강의실</th>")
+            .append("<th ").append(getThStyle()).append(">시간</th>")
+            .append("<th ").append(getThStyle()).append(">교수명</th>")
+            .append("</tr>");
+
+        for (CrawlerSubject subject : subjects) {
+            sb.append("<tr>")
+                .append("<td ").append(getTdStyle()).append(">").append(subject.getCuriNo()).append("</td>")
+                .append("<td ").append(getTdStyle()).append(">").append(subject.getCuriNm()).append("</td>")
+                .append("<td ").append(getTdStyle()).append(">").append(subject.getLesnRoom()).append("</td>")
+                .append("<td ").append(getTdStyle()).append(">").append(subject.getLesnTime()).append("</td>")
+                .append("<td ").append(getTdStyle()).append(">").append(subject.getLesnEmp()).append("</td>")
+                .append("</tr>");
+        }
+
+        sb.append("</table>");
+        return sb.toString();
+    }
+
+    public String buildSubjectDiffTable(List<CrawlerSubjectDiffResult> diffs) {
+        if (diffs == null || diffs.isEmpty()) {
+            return "<p style='color:red;'>❌ 해당 데이터 없음 ❌</p>";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("<table ").append(getTableStyle()).append(">");
+        sb.append("<tr>")
+            .append("<th ").append(getThStyle()).append(">id</th>")
+            .append("<th ").append(getThStyle()).append(">과목번호</th>")
+            .append("<th ").append(getThStyle()).append(">과목명</th>")
+            .append("<th ").append(getThStyle()).append(">강의실 변경</th>")
+            .append("<th ").append(getThStyle()).append(">시간 변경</th>")
+            .append("<th ").append(getThStyle()).append(">교수명 변경</th>")
+            .append("</tr>");
+
+        for (CrawlerSubjectDiffResult diff : diffs) {
+            sb.append("<tr>")
+                .append("<td ").append(getTdStyle()).append(">").append(diff.id()).append("</td>")
+                .append("<td ").append(getTdStyle()).append(">").append(diff.curiNo()).append("</td>")
+                .append("<td ").append(getTdStyle()).append(">").append(diff.curiNm()).append("</td>")
+                .append("<td ").append(getTdStyle()).append(">").append(diff.lesnRoom()).append("</td>")
+                .append("<td ").append(getTdStyle()).append(">").append(diff.lesnTime()).append("</td>")
+                .append("<td ").append(getTdStyle()).append(">").append(diff.lesnEmp()).append("</td>")
+                .append("</tr>");
+        }
+
+        sb.append("</table>");
+        return sb.toString();
+    }
+
+    public String buildSyncMetadataTable(CrawlingMetaData metaData) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<table ").append(getTableStyle()).append(">");
+        sb.append("<tr>")
+            .append("<th ").append(getThStyle()).append(">항목</th>")
+            .append("<th ").append(getThStyle()).append(">내용</th>")
+            .append("</tr>");
+
+        sb.append(buildSummaryRow("과목 동기화 실행 시각", formatDateTime(metaData.crawlingStartTime())));
+        sb.append(buildSummaryRow("과목 동기화 종료 시각", formatDateTime(metaData.crawlingEndTime())));
+        sb.append(buildSummaryRow("동기화 소요 시간", metaData.formattedDuration()));
+
+        sb.append("</table>");
+        return sb.toString();
+    }
+
+    private String buildSummaryRow(String category, String time) {
+        return "<tr>"
+            + "<td " + getTdStyle() + ">" + category + "</td>"
+            + "<td " + getTdStyle() + ">" + time + "</td>"
+            + "</tr>";
+    }
+
+    private String formatDateTime(LocalDateTime dateTime) {
+        return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
+}

--- a/src/main/java/kr/allcll/backend/domain/subject/subjectReport/SubjectReportService.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/subjectReport/SubjectReportService.java
@@ -1,0 +1,85 @@
+package kr.allcll.backend.domain.subject.subjectReport;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import kr.allcll.crawler.subject.CrawlerSubject;
+import kr.allcll.crawler.subject.CrawlerSubjectDiffResult;
+import kr.allcll.crawler.subject.CrawlerSubjectRepository;
+import kr.allcll.crawler.subject.SubjectSyncResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubjectReportService {
+
+    private final JavaMailSender emailSender;
+    private final ReportTableBuilder reportTableBuilder;
+    private final CrawlerSubjectRepository crawlerSubjectRepository;
+    private final String EMAIL_ADDRESS = "hynam1220@naver.com";
+
+    public void generateSubjectSyncReport(SubjectSyncResult syncResult, CrawlingMetaData metaData) {
+        List<CrawlerSubject> allSubjects = crawlerSubjectRepository.findAll();
+        int totalSubjectsCount = allSubjects.size();
+
+        sendSubjectReportToEmail(syncResult, metaData, totalSubjectsCount);
+    }
+
+    private void sendSubjectReportToEmail(SubjectSyncResult subjectSyncResult, CrawlingMetaData metaData,
+        int totalSubjectsCount) {
+        String dateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+        List<CrawlerSubject> insertSubjectReport = subjectSyncResult.subjectsToAdd();
+        List<CrawlerSubject> deleteSubjectReport = subjectSyncResult.subjectsToDelete();
+        List<CrawlerSubject> updateSubjectReport = subjectSyncResult.subjectsCanUpdate();
+        List<CrawlerSubjectDiffResult> updateSubjectDiffResults = subjectSyncResult.updateDiffs();
+
+        String title = "[ALLCLL] 과목 데이터 변경내역 (" + dateTime + ")";
+        String content = "<html>" +
+            "<body style='text-align:center; font-family:sans-serif;'>" +
+            "<h2>📊 과목 변경 집계 리포트 </h2>" +
+            reportTableBuilder.buildSubjectChangeSummaryTable(totalSubjectsCount, insertSubjectReport,
+                deleteSubjectReport, updateSubjectReport) +
+
+            "<br><hr><h2>🔎 과목 정보 변경 세부 집계 </h2>" +
+            "<h3>1) 추가된 과목</h3>" +
+            reportTableBuilder.buildSubjectInfoTable(insertSubjectReport) +
+            "<h3>2) 삭제된 과목</h3>" +
+            reportTableBuilder.buildSubjectInfoTable(deleteSubjectReport) +
+            "<h3>3) 수정된 과목</h3>" +
+            reportTableBuilder.buildSubjectDiffTable(updateSubjectDiffResults) +
+
+            "<br><hr><h2>⏰ 동기화 수행 정보</h2>" +
+            reportTableBuilder.buildSyncMetadataTable(metaData) +
+            "</body>" +
+            "</html>";
+        try {
+            sendMail(title, content);
+        } catch (MessagingException e) {
+            throw new RuntimeException("Unable to send email", e);
+        }
+    }
+
+    private void sendMail(String title, String content) throws MessagingException {
+        MimeMessage message = emailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, true);
+
+            helper.setTo(EMAIL_ADDRESS);
+            helper.setSubject(title);
+            helper.setText(content, true);
+
+            emailSender.send(message);
+        } catch (RuntimeException e) {
+            throw new RuntimeException("Unable to send email", e);
+        }
+    }
+
+}

--- a/src/main/java/kr/allcll/backend/domain/subject/subjectReport/SubjectReportService.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/subjectReport/SubjectReportService.java
@@ -23,7 +23,7 @@ public class SubjectReportService {
     private final JavaMailSender emailSender;
     private final ReportTableBuilder reportTableBuilder;
     private final CrawlerSubjectRepository crawlerSubjectRepository;
-    private final String EMAIL_ADDRESS = "hynam1220@naver.com";
+    private final String EMAIL_ADDRESS = "allclllclla@gmail.com";
 
     public void generateSubjectSyncReport(SubjectSyncResult syncResult, CrawlingMetaData metaData) {
         List<CrawlerSubject> allSubjects = crawlerSubjectRepository.findAll();

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,6 +3,14 @@ spring:
     driver-class-name: org.h2.Driver
     url: 'jdbc:h2:mem:test'
     username: sa
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: allclllclla@gmail.com
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
 
   h2:
     console:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     host: smtp.gmail.com
     port: 587
     username: allclllclla@gmail.com
-    password: ${EMAIL_PASSWORD}
+    password: test
     properties:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true


### PR DESCRIPTION
## 작업 내용
크롤러에서 작업했던 내용입니다.
기존에는 해당 작업이 크롤러 레포에서 진행되었습니다. 당시에는 admin API 작업 전이라, api, service 등 모든 비즈니스 로직이 크롤러 레포에 있었기 때문입니다.

하지만 admin API 작업 이후, API 클래스들을 모두 백엔드 레포로 이전했고, 크롤러 레포에는 최대한 크롤링 로직만 남기기로 하였습니다.
이에 따라 크롤러 pr #25에서 작성했던 로직 중 `과목 크롤링 시 과목 정보 변경 내역을 저장하는 기능`을 제외한 모든 로직을 백엔드 레포로 옮겼습니다.

아래는 크롤러 pr과 동일한 내용입니다
## 기존
저희 서비스에서 과목 데이터는 가장 핵심적인 정보 중 하나이기 때문에, 과목 변경 사항을 보다 철저히 관리해야합니다. 시간표가 처음 공개된 이후 수강신청 기간까지 과목 정보는 지속적으로 변경되는데, 지금까지는 저희가 직접 크롤링을 수동으로 실행하고 SQL로 변경된 과목 개수를 확인하는 방식으로 관리하고 있었습니다.

이미 과목 정합성을 맞추는 로직은 크롤러의 SubjectSyncProcessor 클래스 내부에 구현되어 있으며, 과목 추가(In), 삭제(Out), 정보 수정(Update)를 정확하게 판별할 수 있습니다.

## 구현 내용
과목 크롤링을 실행하면 변경 내역이 자동으로 allcll 메일로 전송되도록 기능을 추가하였습니다. 메일 본문에는 다음과 같은 내용이 포함됩니다.
1. 과목 변경 집계 리포트
  - 전체 과목 수
  - 신규 추가 과목 수
  - 폐강 과목 수
  - 정보 변경 과목 수
2. 과목 정보 변경 세부 집계
  - 추가된 과목 
  - 삭제된 과목
  - 수정된 과목 변경 내역
3. 동기화 수행 정보
  - 과목 동기화 실행 시각
  - 과목 동기화 종료 시각
  - 동기화 소요 시간

또한, 메일 본문에 표시될 표를 HTML 형식으로 만들어주는 로직은 `ReportTableBuilder` 클래스에서 담당하도록 분리하였습니다.

## 결과
📸 postman으로 로컬에서 테스트해보았을 때 잘 작동되는지 확인했습니다! 아래는 그 사진입니다
<img width="2168" height="1288" alt="image" src="https://github.com/user-attachments/assets/cae9100a-8657-47c1-991b-d800940c7d6b" />