### PR TITLE
fix: 과목 조회 쿼리에 폐강된 과목도 조회하도록 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/subject/SubjectService.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/SubjectService.java
@@ -41,7 +41,6 @@ public class SubjectService {
             .and(SubjectSpecifications.hasSubjectCode(subjectCode))
             .and(SubjectSpecifications.hasClassCode(classCode))
             .and(SubjectSpecifications.hasProfessorName(professorName))
-            .and(SubjectSpecifications.hasSemesterAt(semesterAt))
-            .and(SubjectSpecifications.isNotDeleted());
+            .and(SubjectSpecifications.hasSemesterAt(semesterAt));
     }
 }


### PR DESCRIPTION
## 작업 내용

프론트의 요청으로 과목 조회 api에 폐강된 과목도 조회하도록 수정했습니다. 
프론트에서도 과목 폐강 여부를 알아야 합니다. 

## 고민 지점과 리뷰 포인트

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->