### PR TITLE
fix: 인증 정보 관련 어드민 API 검증 강화

### DIFF
--- a/src/main/java/kr/allcll/backend/session/dto/CredentialResponse.java
+++ b/src/main/java/kr/allcll/backend/session/dto/CredentialResponse.java
@@ -17,4 +17,13 @@ public record CredentialResponse(
             credential.getTokenL()
         );
     }
+
+    public static CredentialResponse ofInvalidCredential(String nullValue) {
+        return new CredentialResponse(
+            nullValue,
+            nullValue,
+            nullValue,
+            nullValue
+        );
+    }
 }


### PR DESCRIPTION
## 작업 내용
- 전반적으로 인증 정보에 대한 검증을 강화했습니다.
 1. 인증 정보 세팅 후, 만료 시간이 지나도 인증 정보 조회 API 호출 시 정상적으로 조회되는 문제가 있었습니다.
    이에 따라, 인증 정보가 유효한지 검사하는 메서드를 추가했습니다.
      - 학교 서버에 요청을 보내, 정상 응답이 온다면 true
      - 아니라면 예외가 발생하는데, 해당 예외를 catch하여 로깅 처리 및 false를 반환하도록 구현했습니다.
2. 인증 정보 세팅 시에도 문제가 있었습니다. 요청 필드값이 유효하지 않거나, 혹은 요청으로 들어온 인증 정보가 유효하지 않은 경우에도 정상적으로 저장되어 문제가 생겼습니다.
   이에 따라, 요청 및 인증 정보 유효성 검사를 실행하는 메서드를 추가적으로 구현했습니다.

---

포스트맨으로 위 시나리오에 대비한 정상 작동 확인했습니다.

## 고민 지점과 리뷰 포인트

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->