### PR TITLE
refactor: seat report에 isDeleted 칼럼 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/subject/subjectReport/ReportTableBuilder.java
+++ b/src/main/java/kr/allcll/backend/domain/subject/subjectReport/ReportTableBuilder.java
@@ -92,6 +92,7 @@ public class ReportTableBuilder {
             .append("<th ").append(getThStyle()).append(">강의실 변경</th>")
             .append("<th ").append(getThStyle()).append(">시간 변경</th>")
             .append("<th ").append(getThStyle()).append(">교수명 변경</th>")
+            .append("<th ").append(getThStyle()).append(">isDeleted</th>")
             .append("</tr>");
 
         for (CrawlerSubjectDiffResult diff : diffs) {
@@ -102,6 +103,7 @@ public class ReportTableBuilder {
                 .append("<td ").append(getTdStyle()).append(">").append(diff.lesnRoom()).append("</td>")
                 .append("<td ").append(getTdStyle()).append(">").append(diff.lesnTime()).append("</td>")
                 .append("<td ").append(getTdStyle()).append(">").append(diff.lesnEmp()).append("</td>")
+                .append("<td ").append(getTdStyle()).append(">").append(diff.isDeleted()).append("</td>")
                 .append("</tr>");
         }
 


### PR DESCRIPTION
## 작업 내용
1. 리포트에 softdeleted 여부를 확인하는 칼럼을 추가했습니다
isDeleted 여부를 확인하는 로직은 크롤러 36번 pr 참고해주세요!
<img width="986" height="120" alt="스크린샷 2025-08-12 오후 3 32 59" src="https://github.com/user-attachments/assets/a5ef3882-afdc-4aa6-9e53-69e70eb1afa8" />
  (⚠️상태변경말고 isDeleted로 칼럼명 설정하였습니다!)

2. `-` -> `new`(=삭제되었다가 생김) 와 `-`(before와 after가 동일해 변경내역 없음) 가 헷갈려서 before과 after가 동일해 변경사항 없는 경우에는 점으로 표시됩니다! 
  해당 로직 자체는 크롤러에 있습니다

## 고민 지점과 리뷰 포인트

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->