### PR TITLE
revert: "hotfix: 쿼리 타임 백엔드로 롤백"

### DIFF
--- a/src/main/java/kr/allcll/backend/client/ExternalClient.java
+++ b/src/main/java/kr/allcll/backend/client/ExternalClient.java
@@ -45,7 +45,7 @@ public class ExternalClient {
             seatStorage.add(
                 new SeatDto(subject,
                     eachChange.remainSeat(),
-                    LocalDateTime.now()
+                    eachChange.createdAt()
 //                    eachChange.changeStatus()
                 )
             );


### PR DESCRIPTION
## 작업한 내용

사용자에게는 항상 크롤링한 시간을 보여야 합니다. 롤백되었던 로직(31640a07e7ae0f4177557f3f3ca5c329cc6b288c)을 다시 롤백합니다. 
관련해서 [크롤러 작업](https://github.com/allcll/allcll-crawler/pull/44)도 진행했습니다. 
