### PR TITLE
feat: 활성화된 pin 과목 조회 로직 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/seat/pin/PinRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/pin/PinRepository.java
@@ -17,6 +17,15 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
         """)
     List<Pin> findAllByToken(String tokenId, String semesterAt);
 
+
+    @Query(""" 
+        select p from Pin p
+        join fetch p.subject s
+        where s.isDeleted = false
+        and p.semesterAt = :semesterAt
+        """)
+    List<Pin> findAllBySemesterAt(String semesterAt);
+
     @Query(""" 
         select p from Pin p
         join p.subject s


### PR DESCRIPTION
## 작업 내용

백엔드 -> 크롤러 간에 크롤링 대상 핀 과목을 전송하는 로직을 개선했습니다. 

[1] 기존 방식
기존에는 활성화된 SSE 커넥션을 가져와서, 각 사용자 토큰으로 핀 과목을 조회했습니다. 

[2] 새로운 방식
현재 학기의 핀 과목을 한번에 모두 조회합니다. 활성화된 SSE 커넥션을 갖고와서, 전체 조회한 핀 과목 중 활성 유저의 핀과목만 걸러냅니다. 
이 방식에 문제가 될 수 있는 부분은, 현재 학기에 핀 데이터가 많다면 메모리를 많이 사용하고 새로운 병목 지점이 될 수 있습니다. 
이를 추적할 수 있는 지표 수집이 필요하지만, 이 pr에는 포함되어 있지 않습니다. 

## 작업한 이유

[1] 백엔드 -> 크롤러 간에 크롤링할 핀 과목을 전송하는 로직은 10초에 한 번씩 실행됩니다. 

```java
public class ExternalPreInvoker {

    private final ExternalService externalService;

    @Scheduled(fixedDelay = 1000 * 10)
    void sendPinnedSubjectsToExternal() {
        try {
            externalService.sendWantPinSubjectIdsToCrawler();
        } catch (Exception e) {
            log.error("[ExternalPreInvoker] 핀 과목 전달 중 오류 발생", e);
            throw e;
        }
        log.info("[ExternalPreInvoker] 핀 과목 전달 완료");
    }
    
    ...
}
```

[2] 기존 로직은 for문 내부에서 repository를 사용하여 DB 쿼리가 많이 발생하는 문제가 있었습니다. 

```java
public class ExternalService {

    private PinSubjectUpdateRequest getPinSubjects() {
        List<String> tokens = sseEmitterStorage.getUserTokens();
        Map<Subject, Integer> pinSubjects = new HashMap<>();
        for (String token : tokens) {
            List<Pin> pins = pinRepository.findAllByToken(token, Semester.now());
            for (Pin pin : pins) {
                Subject subject = pin.getSubject();
                pinSubjects.merge(subject, 1, Integer::sum);
            }
        }
        List<PinSubject> wantPinSubjects = getPinSubjectsWithPriority(pinSubjects);
        
        ...
        
}
```

SSE 연결한 사용자가 100명이라면, 100개의 token에 대해 for문을 순회합니다. 그럼 100번의 핀과목 조회 쿼리가 발생합니다. 

[3] DB 커넥션이 부족합니다. 
hikaricp를 사용하고 있는 프로젝트 구조에서, hikaricp는 기본 10개의 DB 커넥션을 사용합니다. 
10초 주기로 N개의 핀과목을 조회하는 쿼리가 발생합니다. 커넥션은 10개인데 100개의 쿼리를 실행하려면 병목이 생길 것으로 예상됩니다. 
예를 들어, 쿼리 처리 속도가 100ms라면 동시에 10개씩 100개를 처리하려면 100ms*10 = 1s의 시간이 걸립니다. 

백엔드 서버에서 발생하는 DB 쿼리는 위 로직에만 있는 것이 아닙니다. 
사용자가 핀 과목을 등록할 때에도, 여석을 크롤링한 후에 저장할 때에도 DB 쿼리는 발생합니다. 
위 로직이 오랫동안 DB 커넥션을 점유하고 있으면 여석을 크롤링해도 저장하지 못하는 문제가 있을 수 있고, 이 때문에 여석 크롤링이 밀릴 수 있습니다. 

[4] 정확한 지표로 검증하고 싶었으나, 현재는 증거 메트릭이 부족합니다. 
그래도 HikariCP 커넥션 풀을 보면 서비스 시간인 10-17시 사이에 커넥션 풀이 감소하는 것을 볼 수 있습니다. [데이터독](https://us5.datadoghq.com/dashboard/5q4-rfm-4w3?fromUser=false&fullscreen_end_ts=1755173727819&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_section=overview&fullscreen_start_ts=1754983397518&fullscreen_widget=8270680821744764&refresh_mode=sliding&from_ts=1755408132538&to_ts=1755411732538&live=true)

<img width="1530" height="652" alt="image" src="https://github.com/user-attachments/assets/ae38b72a-5aee-4a5c-a373-6a2419a4907b" />

## 고민 지점과 리뷰 포인트

수정한 로직을 테스트하는 코드가 없습니다. 이전에 존재했던 로직과 일치하는지 꼼꼼히 봐주시면 감사하겠습니다. 