### PR TITLE
refactor: preseat로직 패키지 분리

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/AdminPreSeatApi.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminPreSeatApi.java
@@ -1,0 +1,27 @@
+package kr.allcll.backend.admin;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kr.allcll.crawler.seat.preseat.CrawlerPreSeatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminPreSeatApi {
+
+    private final CrawlerPreSeatService crawlerPreSeatService;
+    private final AdminRequestValidator validator;
+
+    @PostMapping("/api/admin/pre-seat/fetch")
+    public ResponseEntity<Void> getAllPreSeats(HttpServletRequest request,
+        @RequestParam(required = false) String userId) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
+        crawlerPreSeatService.getAllPreSeat(userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/kr/allcll/backend/admin/AdminSeatApi.java
+++ b/src/main/java/kr/allcll/backend/admin/AdminSeatApi.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import kr.allcll.crawler.seat.CrawlerSeatService;
 import kr.allcll.crawler.seat.SeatStatusResponse;
 import kr.allcll.crawler.seat.TargetSubjectService;
+import kr.allcll.crawler.seat.preseat.CrawlerPreSeatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminSeatApi {
 
     private final CrawlerSeatService crawlerSeatService;
+    private final CrawlerPreSeatService crawlerPreSeatService;
     private final TargetSubjectService targetSubjectService;
     private final AdminRequestValidator validator;
 
@@ -56,16 +58,6 @@ public class AdminSeatApi {
             return ResponseEntity.status(401).build();
         }
         crawlerSeatService.cancelSeatScheduling();
-        return ResponseEntity.ok().build();
-    }
-
-    @PostMapping("/api/admin/pre-seat/fetch")
-    public ResponseEntity<Void> getAllPreSeats(HttpServletRequest request,
-        @RequestParam(required = false) String userId) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
-        crawlerSeatService.getAllPreSeat(userId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatService.java
@@ -1,31 +1,20 @@
 package kr.allcll.backend.domain.seat;
 
 import java.util.List;
-import kr.allcll.backend.domain.seat.dto.PreSeatsResponse;
 import kr.allcll.backend.domain.seat.dto.SeatDto;
 import kr.allcll.backend.domain.seat.pin.Pin;
 import kr.allcll.backend.domain.seat.pin.PinRepository;
 import kr.allcll.backend.domain.subject.Subject;
 import kr.allcll.backend.support.semester.Semester;
-import kr.allcll.crawler.seat.AllPreSeatBuffer;
-import kr.allcll.crawler.seat.PreSeatResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SeatService {
 
     private final PinRepository pinRepository;
     private final SeatStorage seatStorage;
-    private final AllPreSeatBuffer allPreSeatBuffer;
-
-    public PreSeatsResponse getAllPreSeats() {
-        List<PreSeatResponse> preSeats = allPreSeatBuffer.getAllAndFlush();
-        return PreSeatsResponse.from(preSeats);
-    }
 
     public List<SeatDto> getPinSeats(String token) {
         List<Pin> pins = pinRepository.findAllByToken(token, Semester.now());

--- a/src/main/java/kr/allcll/backend/domain/seat/preseat/PreSeatApi.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/preseat/PreSeatApi.java
@@ -1,6 +1,6 @@
-package kr.allcll.backend.domain.seat;
+package kr.allcll.backend.domain.seat.preseat;
 
-import kr.allcll.backend.domain.seat.dto.PreSeatsResponse;
+import kr.allcll.backend.domain.seat.preseat.dto.PreSeatsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,13 +8,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class SeatApi {
+public class PreSeatApi {
 
-    private final SeatService seatService;
+    private final PreSeatService preSeatService;
 
     @GetMapping("/api/pre-seat")
     public ResponseEntity<PreSeatsResponse> getAllPreSeats() {
-        PreSeatsResponse response = seatService.getAllPreSeats();
+        PreSeatsResponse response = preSeatService.getAllPreSeats();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/preseat/PreSeatService.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/preseat/PreSeatService.java
@@ -1,0 +1,20 @@
+package kr.allcll.backend.domain.seat.preseat;
+
+import java.util.List;
+import kr.allcll.backend.domain.seat.preseat.dto.PreSeatsResponse;
+import kr.allcll.crawler.seat.preseat.AllPreSeatBuffer;
+import kr.allcll.crawler.seat.preseat.PreSeatResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PreSeatService {
+
+    private final AllPreSeatBuffer allPreSeatBuffer;
+
+    public PreSeatsResponse getAllPreSeats() {
+        List<PreSeatResponse> preSeats = allPreSeatBuffer.getAllAndFlush();
+        return PreSeatsResponse.from(preSeats);
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/seat/preseat/dto/PreSeatsResponse.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/preseat/dto/PreSeatsResponse.java
@@ -1,7 +1,7 @@
-package kr.allcll.backend.domain.seat.dto;
+package kr.allcll.backend.domain.seat.preseat.dto;
 
 import java.util.List;
-import kr.allcll.crawler.seat.PreSeatResponse;
+import kr.allcll.crawler.seat.preseat.PreSeatResponse;
 
 public record PreSeatsResponse(
     List<PreSeatResponse> preSeats


### PR DESCRIPTION
## 작업 내용
- seat 패키지 내 preseat 패키지를 만들어 두 로직을 분리하였습니다.
- 기존에 AdminSeatApi에 seat과 preseat로직이 함께 있었기에,  preseat관련 로직은 AdminPreSeatApi로 분리했습니다.
- SeatService내의 preseat관련 메서드 또한 분리하였습니다

postman으로 정상작동 확인하였습니다.
<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->