### PR TITLE
feat: 변경 감지 정책 도입

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/seat/AdminSeatApi.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/AdminSeatApi.java
@@ -3,6 +3,7 @@ package kr.allcll.backend.admin.seat;
 import jakarta.servlet.http.HttpServletRequest;
 import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.admin.seat.dto.SeatStatusResponse;
+import kr.allcll.backend.admin.subject.TargetSubjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/kr/allcll/backend/admin/seat/AllSeatBuffer.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/AllSeatBuffer.java
@@ -8,6 +8,10 @@ import kr.allcll.backend.admin.seat.dto.ChangeSubjectsResponse;
 import kr.allcll.crawler.common.properties.SjptProperties;
 import org.springframework.stereotype.Component;
 
+/**
+ * deprecated : 변경감지로 정책 변경에 따라 해당 클래스를 사용하지 않습니다.
+ */
+
 @Component
 public class AllSeatBuffer {
 

--- a/src/main/java/kr/allcll/backend/admin/seat/ChangeDetector.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/ChangeDetector.java
@@ -1,5 +1,7 @@
 package kr.allcll.backend.admin.seat;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import kr.allcll.backend.admin.seat.dto.ChangeSubjectsResponse;
@@ -20,7 +22,9 @@ public class ChangeDetector {
     private final SjptProperties sjptProperties;
 
     public boolean isRemainSeatChanged(CrawlerSubject crawlerSubject, CrawlerSeat renewedCrawlerSeat) {
-        Optional<CrawlerSeat> previousSeat = crawlerSeatRepository.findByCrawlerSubject(crawlerSubject);
+        LocalDate today = LocalDate.now();
+
+        Optional<CrawlerSeat> previousSeat = crawlerSeatRepository.findByCrawlerSubjectAndCreatedDate(crawlerSubject, today);
         if (previousSeat.isEmpty()) {
             return true;
         }
@@ -41,7 +45,7 @@ public class ChangeDetector {
         } else {
             changedSubjectBuffer.add(
                 ChangeSubjectsResponse.of(crawlerSubject.getId(), ChangeStatus.UPDATE, SeatUtils.getRemainSeat(
-                    renewedCrawlerSeat)));
+                    renewedCrawlerSeat), LocalDateTime.now()));
         }
     }
 

--- a/src/main/java/kr/allcll/backend/admin/seat/LiveBoards.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/LiveBoards.java
@@ -1,5 +1,6 @@
 package kr.allcll.backend.admin.seat;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,7 @@ public class LiveBoards {
     public List<ChangeSubjectsResponse> checkStatus(CrawlerSubject crawlerSubject, Integer remainSeat) {
         if (canOnlyIn(crawlerSubject, remainSeat)) {
             liveBoardSubjects.put(crawlerSubject, remainSeat);
-            return List.of(ChangeSubjectsResponse.of(crawlerSubject.getId(), ChangeStatus.IN, remainSeat));
+            return List.of(ChangeSubjectsResponse.of(crawlerSubject.getId(), ChangeStatus.IN, remainSeat, LocalDateTime.now()));
         }
         CrawlerSubject maxCrawlerSubject = findMaxRemainSeatSubject();
         Integer maxSubjectRemainSeat = liveBoardSubjects.get(maxCrawlerSubject);
@@ -35,17 +36,17 @@ public class LiveBoards {
             liveBoardSubjects.put(crawlerSubject, remainSeat);
             liveBoardSubjects.remove(maxCrawlerSubject);
             return List.of(
-                ChangeSubjectsResponse.of(crawlerSubject.getId(), ChangeStatus.IN, remainSeat),
-                ChangeSubjectsResponse.of(maxCrawlerSubject.getId(), ChangeStatus.OUT, maxSubjectRemainSeat)
+                ChangeSubjectsResponse.of(crawlerSubject.getId(), ChangeStatus.IN, remainSeat, LocalDateTime.now()),
+                ChangeSubjectsResponse.of(maxCrawlerSubject.getId(), ChangeStatus.OUT, maxSubjectRemainSeat, LocalDateTime.now())
             );
         }
         if (canOut(crawlerSubject, remainSeat)) {
             liveBoardSubjects.remove(crawlerSubject);
-            return List.of(ChangeSubjectsResponse.of(crawlerSubject.getId(), ChangeStatus.OUT, remainSeat));
+            return List.of(ChangeSubjectsResponse.of(crawlerSubject.getId(), ChangeStatus.OUT, remainSeat, LocalDateTime.now()));
         }
         if (canUpdate(crawlerSubject, remainSeat)) {
             liveBoardSubjects.put(crawlerSubject, remainSeat);
-            return List.of(ChangeSubjectsResponse.of(crawlerSubject.getId(), ChangeStatus.UPDATE, remainSeat));
+            return List.of(ChangeSubjectsResponse.of(crawlerSubject.getId(), ChangeStatus.UPDATE, remainSeat, LocalDateTime.now()));
         }
         return Collections.emptyList();
     }

--- a/src/main/java/kr/allcll/backend/admin/seat/SeatPersistenceService.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/SeatPersistenceService.java
@@ -1,5 +1,7 @@
 package kr.allcll.backend.admin.seat;
 
+import java.time.LocalDate;
+import java.util.Optional;
 import kr.allcll.crawler.seat.CrawlerSeat;
 import kr.allcll.crawler.seat.CrawlerSeatRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,17 @@ public class SeatPersistenceService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveSeat(CrawlerSeat crawlerSeat) {
-        crawlerSeatRepository.save(crawlerSeat);
+        LocalDate today = LocalDate.now();
+
+        Optional<CrawlerSeat> existingSeatOpt = crawlerSeatRepository.findByCrawlerSubjectAndCreatedDate(
+            crawlerSeat.getCrawlerSubject(),
+            today
+        );
+        if (existingSeatOpt.isPresent()) {
+            CrawlerSeat existingCrawlerSeat = existingSeatOpt.get();
+            existingCrawlerSeat.merge(crawlerSeat);
+        } else {
+            crawlerSeatRepository.save(crawlerSeat);
+        }
     }
 }

--- a/src/main/java/kr/allcll/backend/admin/subject/TargetSubjectService.java
+++ b/src/main/java/kr/allcll/backend/admin/subject/TargetSubjectService.java
@@ -1,4 +1,4 @@
-package kr.allcll.backend.admin.seat;
+package kr.allcll.backend.admin.subject;
 
 import java.util.List;
 import java.util.Map;
@@ -8,7 +8,6 @@ import kr.allcll.backend.admin.seat.dto.PinSubjectUpdateRequest.PinSubject;
 import kr.allcll.crawler.common.exception.CrawlerAllcllException;
 import kr.allcll.crawler.subject.CrawlerSubject;
 import kr.allcll.crawler.subject.CrawlerSubjectRepository;
-import kr.allcll.backend.admin.subject.SubjectFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/kr/allcll/backend/admin/subject/TargetSubjectStorage.java
+++ b/src/main/java/kr/allcll/backend/admin/subject/TargetSubjectStorage.java
@@ -1,4 +1,4 @@
-package kr.allcll.backend.admin.seat;
+package kr.allcll.backend.admin.subject;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/kr/allcll/backend/client/ExternalClient.java
+++ b/src/main/java/kr/allcll/backend/client/ExternalClient.java
@@ -1,8 +1,8 @@
 package kr.allcll.backend.client;
 
 import java.util.List;
-import kr.allcll.backend.admin.seat.AllSeatBuffer;
-import kr.allcll.backend.admin.seat.TargetSubjectService;
+import kr.allcll.backend.admin.seat.ChangedSubjectBuffer;
+import kr.allcll.backend.admin.subject.TargetSubjectService;
 import kr.allcll.backend.admin.seat.dto.ChangeSubjectsResponse;
 import kr.allcll.backend.admin.seat.dto.PinSubjectUpdateRequest;
 import kr.allcll.backend.domain.seat.SeatStorage;
@@ -25,8 +25,8 @@ public class ExternalClient {
 
     // 외부 의존성
     private final TargetSubjectService targetSubjectService;
-    //    private final ChangedSubjectBuffer changedSubjectBuffer;
-    private final AllSeatBuffer allSeatBuffer;
+    private final ChangedSubjectBuffer changedSubjectBuffer;
+    // private final AllSeatBuffer allSeatBuffer;
 
     private final SeatStorage seatStorage;
     private final SubjectRepository subjectRepository;
@@ -36,7 +36,7 @@ public class ExternalClient {
     }
 
     public void getAllTargetSubjects() {
-        List<ChangeSubjectsResponse> allChangedSubject = allSeatBuffer.getAllAndFlush();
+        List<ChangeSubjectsResponse> allChangedSubject = changedSubjectBuffer.getAllAndFlush();
         for (ChangeSubjectsResponse eachChange : allChangedSubject) {
             Long subjectId = eachChange.subjectId();
             Subject subject = subjectRepository.findById(subjectId, Semester.now())
@@ -44,8 +44,8 @@ public class ExternalClient {
             seatStorage.add(
                 new SeatDto(subject,
                     eachChange.remainSeat(),
-                    eachChange.createdAt()
-//                    eachChange.changeStatus()
+                    eachChange.createdAt(),
+                    eachChange.changeStatus()
                 )
             );
         }

--- a/src/main/java/kr/allcll/backend/domain/seat/DeprecatedSeatApi.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/DeprecatedSeatApi.java
@@ -1,7 +1,7 @@
 package kr.allcll.backend.domain.seat;
 
 import java.util.List;
-import kr.allcll.backend.admin.seat.TargetSubjectService;
+import kr.allcll.backend.admin.subject.TargetSubjectService;
 import kr.allcll.backend.admin.seat.dto.PinSubjectUpdateRequest;
 import kr.allcll.backend.domain.seat.dto.DeprecatedSubjectSummaryResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/allcll/backend/domain/seat/DeprecatedSeatService.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/DeprecatedSeatService.java
@@ -1,7 +1,7 @@
 package kr.allcll.backend.domain.seat;
 
 import java.util.List;
-import kr.allcll.backend.admin.seat.TargetSubjectStorage;
+import kr.allcll.backend.admin.subject.TargetSubjectStorage;
 import kr.allcll.backend.domain.seat.dto.DeprecatedSubjectSummaryResponse;
 import kr.allcll.crawler.subject.CrawlerSubject;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
@@ -46,7 +46,7 @@ public class GeneralSeatSender {
 
     private Runnable getGeneralSeatTask() {
         return () -> {
-            List<SeatDto> generalSeats = seatStorage.getGeneralSeats(QUERY_LIMIT);
+            List<SeatDto> generalSeats = seatStorage.getGeneralSeats();
             sseService.propagate(EVENT_NAME, SeatsResponse.from(generalSeats));
         };
     }

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
@@ -26,11 +26,13 @@ public class SeatStorage {
     }
 
     public List<SeatDto> getGeneralSeats() {
+        LocalDateTime now = LocalDateTime.now();
+
         Collection<SeatDto> seatsValue = seats.values();
         return seatsValue.stream()
             .filter(seat -> seat.getSubject().isNonMajor())
             .filter(seat ->
-                Duration.between(seat.getQueryTime(), LocalDateTime.now()).getSeconds() <= LIMIT_QUERY_TIME)
+                Duration.between(seat.getQueryTime(), now).getSeconds() <= LIMIT_QUERY_TIME)
             .sorted(Comparator.comparingInt(SeatDto::getSeatCount))
             .toList();
     }

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
@@ -1,5 +1,7 @@
 package kr.allcll.backend.domain.seat;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -23,13 +25,13 @@ public class SeatStorage {
         this.seats = new ConcurrentHashMap<>();
     }
 
-    public List<SeatDto> getGeneralSeats(int limit) {
+    public List<SeatDto> getGeneralSeats() {
         Collection<SeatDto> seatsValue = seats.values();
         return seatsValue.stream()
             .filter(seat -> seat.getSubject().isNonMajor())
-            .filter(seat -> seat.getSeatCount() > 0)
+            .filter(seat ->
+                Duration.between(seat.getQueryTime(), LocalDateTime.now()).getSeconds() <= LIMIT_QUERY_TIME)
             .sorted(Comparator.comparingInt(SeatDto::getSeatCount))
-            .limit(limit)
             .toList();
     }
 

--- a/src/main/java/kr/allcll/backend/domain/seat/dto/SeatDto.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/dto/SeatDto.java
@@ -1,6 +1,7 @@
 package kr.allcll.backend.domain.seat.dto;
 
 import java.time.LocalDateTime;
+import kr.allcll.backend.admin.seat.ChangeStatus;
 import kr.allcll.backend.domain.subject.Subject;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,5 +13,5 @@ public class SeatDto {
     private Subject subject;
     private int seatCount;
     private LocalDateTime queryTime;
-//    private ChangeStatus changeStatus;
+    private ChangeStatus changeStatus;
 }

--- a/src/main/java/kr/allcll/backend/domain/seat/dto/SeatResponse.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/dto/SeatResponse.java
@@ -1,18 +1,21 @@
 package kr.allcll.backend.domain.seat.dto;
 
 import java.time.LocalDateTime;
+import kr.allcll.backend.admin.seat.ChangeStatus;
 
 public record SeatResponse(
     Long subjectId,
     Integer seatCount,
-    LocalDateTime queryTime
+    LocalDateTime queryTime,
+    ChangeStatus changeStatus
 ) {
 
     public static SeatResponse from(SeatDto seatDto) {
         return new SeatResponse(
             seatDto.getSubject().getId(),
             seatDto.getSeatCount(),
-            seatDto.getQueryTime()
+            seatDto.getQueryTime(),
+            seatDto.getChangeStatus()
         );
     }
 }

--- a/src/test/java/kr/allcll/backend/client/ExternalClientTest.java
+++ b/src/test/java/kr/allcll/backend/client/ExternalClientTest.java
@@ -1,14 +1,19 @@
 package kr.allcll.backend.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import kr.allcll.backend.AllcllBackendApplication;
+import kr.allcll.backend.admin.seat.ChangeStatus;
 import kr.allcll.backend.admin.seat.ChangedSubjectBuffer;
-import kr.allcll.backend.admin.seat.TargetSubjectStorage;
+import kr.allcll.backend.admin.subject.TargetSubjectStorage;
+import kr.allcll.backend.admin.seat.dto.ChangeSubjectsResponse;
 import kr.allcll.backend.admin.seat.dto.PinSubjectUpdateRequest;
 import kr.allcll.backend.admin.seat.dto.PinSubjectUpdateRequest.PinSubject;
 import kr.allcll.backend.domain.seat.SeatStorage;
+import kr.allcll.backend.domain.seat.dto.SeatDto;
 import kr.allcll.backend.domain.subject.Subject;
 import kr.allcll.backend.domain.subject.SubjectRepository;
 import kr.allcll.backend.fixture.SubjectFixture;
@@ -68,28 +73,28 @@ class ExternalClientTest {
                 subjectB.getId()
             );
     }
-//
-//    @Test
-//    @DisplayName("변경 감지 과목들의 정상 수신을 확인한다.")
-//    void getAllTargetSubjects() {
-//        // given
-//        Subject subjectA = subjectRepository
-//            .save(SubjectFixture.createNonMajorSubject("차와문화", "123456", "001", "김보예"));
-//        Subject subjectB = subjectRepository
-//            .save(SubjectFixture.createNonMajorSubject("차와문화", "123456", "002", "김보예"));
-//        changedSubjectBuffer.add(new ChangeSubjectsResponse(subjectA.getId(), ChangeStatus.IN, 10));
-//        changedSubjectBuffer.add(new ChangeSubjectsResponse(subjectB.getId(), ChangeStatus.IN, 15));
-//
-//        // when
-//        externalClient.getAllTargetSubjects();
-//        List<SeatDto> allSeatDtos = seatStorage.getAll();
-//
-//        // then
-//        assertThat(allSeatDtos).hasSize(2)
-//            .extracting(SeatDto::getSubject, SeatDto::getSeatCount)
-//            .containsExactly(
-//                tuple(subjectA, 10),
-//                tuple(subjectB, 15)
-//            );
-//    }
+
+    @Test
+    @DisplayName("변경 감지 과목들의 정상 수신을 확인한다.")
+    void getAllTargetSubjects() {
+        // given
+        Subject subjectA = subjectRepository
+            .save(SubjectFixture.createNonMajorSubject("차와문화", "123456", "001", "김보예"));
+        Subject subjectB = subjectRepository
+            .save(SubjectFixture.createNonMajorSubject("차와문화", "123456", "002", "김보예"));
+        changedSubjectBuffer.add(new ChangeSubjectsResponse(subjectA.getId(), ChangeStatus.IN, 10, LocalDateTime.now()));
+        changedSubjectBuffer.add(new ChangeSubjectsResponse(subjectB.getId(), ChangeStatus.IN, 15, LocalDateTime.now()));
+
+        // when
+        externalClient.getAllTargetSubjects();
+        List<SeatDto> allSeatDtos = seatStorage.getAll();
+
+        // then
+        assertThat(allSeatDtos).hasSize(2)
+            .extracting(SeatDto::getSubject, SeatDto::getSeatCount)
+            .containsExactly(
+                tuple(subjectA, 10),
+                tuple(subjectB, 15)
+            );
+    }
 }

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import kr.allcll.backend.admin.seat.ChangeStatus;
 import kr.allcll.backend.domain.seat.dto.SeatDto;
 import kr.allcll.backend.domain.seat.pin.Pin;
 import kr.allcll.backend.domain.seat.pin.PinRepository;
@@ -68,11 +69,11 @@ class SeatServiceTest {
         pinRepository.saveAll(List.of(pin1, pin2, pin3, pin4, pin5));
 
         LocalDateTime now = LocalDateTime.now();
-        SeatDto seat1 = new SeatDto(subject1, 1, now);
-        SeatDto seat2 = new SeatDto(subject2, 2, now);
-        SeatDto seat3 = new SeatDto(subject3, 3, now);
-        SeatDto seat4 = new SeatDto(subject4, 4, now);
-        SeatDto seat5 = new SeatDto(subject5, 5, now);
+        SeatDto seat1 = new SeatDto(subject1, 1, now, ChangeStatus.IN);
+        SeatDto seat2 = new SeatDto(subject2, 2, now, ChangeStatus.IN);
+        SeatDto seat3 = new SeatDto(subject3, 3, now, ChangeStatus.IN);
+        SeatDto seat4 = new SeatDto(subject4, 4, now, ChangeStatus.IN);
+        SeatDto seat5 = new SeatDto(subject5, 5, now, ChangeStatus.IN);
         seatStorage.addAll(List.of(seat1, seat2, seat3, seat4, seat5));
 
         // when

--- a/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
+++ b/src/test/java/kr/allcll/backend/domain/seat/SeatStorageTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import kr.allcll.backend.admin.seat.ChangeStatus;
 import kr.allcll.backend.domain.seat.dto.SeatDto;
 import kr.allcll.backend.domain.subject.Subject;
 import kr.allcll.backend.domain.subject.SubjectRepository;
@@ -40,9 +41,9 @@ class SeatStorageTest {
         subjectRepository.save(subject);
 
         // when
-        SeatDto previousSeatDto = new SeatDto(subject, 10, LocalDateTime.now());
+        SeatDto previousSeatDto = new SeatDto(subject, 10, LocalDateTime.now(), ChangeStatus.IN);
         seatStorage.add(previousSeatDto);
-        SeatDto updatedSeatDto = new SeatDto(subject, 5, LocalDateTime.now());
+        SeatDto updatedSeatDto = new SeatDto(subject, 5, LocalDateTime.now(), ChangeStatus.UPDATE);
         seatStorage.add(updatedSeatDto);
 
         // then
@@ -76,28 +77,29 @@ class SeatStorageTest {
         subjectRepository.saveAll(
             List.of(subject0, subject1, subject2, subject3, subject4, subject5, subject6, subject7, subject8, subject9,
                 subject10));
-        SeatDto seatDto1 = new SeatDto(subject0, 8, LocalDateTime.now());
-        SeatDto seatDto2 = new SeatDto(subject1, 7, LocalDateTime.now());
-        SeatDto seatDto3 = new SeatDto(subject2, 6, LocalDateTime.now());
-        SeatDto seatDto4 = new SeatDto(subject3, 5, LocalDateTime.now());
-        SeatDto seatDto5 = new SeatDto(subject4, 4, LocalDateTime.now());
-        SeatDto seatDto6 = new SeatDto(subject5, 3, LocalDateTime.now());
-        SeatDto seatDto7 = new SeatDto(subject6, 2, LocalDateTime.now());
-        SeatDto seatDto8 = new SeatDto(subject7, 1, LocalDateTime.now());
-        SeatDto seatDto9 = new SeatDto(subject8, 0, LocalDateTime.now());
-        SeatDto seatDto10 = new SeatDto(subject9, 2, LocalDateTime.now());
-        SeatDto seatDto11 = new SeatDto(subject10, 1, LocalDateTime.now());
+        SeatDto seatDto1 = new SeatDto(subject0, 8, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto2 = new SeatDto(subject1, 7, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto3 = new SeatDto(subject2, 6, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto4 = new SeatDto(subject3, 5, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto5 = new SeatDto(subject4, 4, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto6 = new SeatDto(subject5, 3, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto7 = new SeatDto(subject6, 2, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto8 = new SeatDto(subject7, 1, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto9 = new SeatDto(subject8, 0, LocalDateTime.now(), ChangeStatus.OUT);
+        SeatDto seatDto10 = new SeatDto(subject9, 2, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto11 = new SeatDto(subject10, 1, LocalDateTime.now(), ChangeStatus.IN);
         seatStorage.addAll(
             List.of(seatDto1, seatDto2, seatDto3, seatDto4, seatDto5, seatDto6, seatDto7, seatDto8, seatDto9, seatDto10,
                 seatDto11));
 
         // when
-        List<SeatDto> seats = seatStorage.getGeneralSeats(5);
+        List<SeatDto> seats = seatStorage.getGeneralSeats();
 
         // then
-        assertThat(seats).hasSize(5)
+        assertThat(seats).hasSize(6)
             .extracting(SeatDto::getSubject, SeatDto::getSeatCount)
             .containsExactly(
+                tuple(subject8, 0),
                 tuple(subject7, 1),
                 tuple(subject10, 1),
                 tuple(subject6, 2),
@@ -124,17 +126,17 @@ class SeatStorageTest {
         subjectRepository.saveAll(
             List.of(subject0, subject1, subject2, subject3, subject4, subject5, subject6, subject7, subject8, subject9,
                 subject10));
-        SeatDto seatDto1 = new SeatDto(subject0, 8, LocalDateTime.now());
-        SeatDto seatDto2 = new SeatDto(subject1, 7, LocalDateTime.now());
-        SeatDto seatDto3 = new SeatDto(subject2, 6, LocalDateTime.now());
-        SeatDto seatDto4 = new SeatDto(subject3, 5, LocalDateTime.now());
-        SeatDto seatDto5 = new SeatDto(subject4, 4, LocalDateTime.now());
-        SeatDto seatDto6 = new SeatDto(subject5, 3, LocalDateTime.now());
-        SeatDto seatDto7 = new SeatDto(subject6, 2, LocalDateTime.now());
-        SeatDto seatDto8 = new SeatDto(subject7, 1, LocalDateTime.now());
-        SeatDto seatDto9 = new SeatDto(subject8, 0, LocalDateTime.now());
-        SeatDto seatDto10 = new SeatDto(subject9, 2, LocalDateTime.now());
-        SeatDto seatDto11 = new SeatDto(subject10, 1, LocalDateTime.now());
+        SeatDto seatDto1 = new SeatDto(subject0, 8, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto2 = new SeatDto(subject1, 7, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto3 = new SeatDto(subject2, 6, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto4 = new SeatDto(subject3, 5, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto5 = new SeatDto(subject4, 4, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto6 = new SeatDto(subject5, 3, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto7 = new SeatDto(subject6, 2, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto8 = new SeatDto(subject7, 1, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto9 = new SeatDto(subject8, 0, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto10 = new SeatDto(subject9, 2, LocalDateTime.now(), ChangeStatus.IN);
+        SeatDto seatDto11 = new SeatDto(subject10, 1, LocalDateTime.now(), ChangeStatus.IN);
         seatStorage.addAll(
             List.of(seatDto1, seatDto2, seatDto3, seatDto4, seatDto5, seatDto6, seatDto7, seatDto8, seatDto9, seatDto10,
                 seatDto11));


### PR DESCRIPTION
## 작업 내용
여석 전송 로직을 변경했습니다. 
- 기존: 조회한 모든 여석 정보를 SSE로 보냅니다.
- 변경 후: 변경된 여석 정보만 SSE로 보냅니다. 여석의 변경 상태는 총 세가지입니다. (IN, OUT, UPDATE)

기존에 보예님께서 작업하셨던 내용을 롤백한 것이므로, 작성하셨던 PR을 기반으로 이야기하겠습니다.

---
** <[crawler - #7](https://github.com/allcll/allcll-crawler/pull/7) PR>의 내용 기반으로 수정한 내용입니다. **

백엔드와 서버가 단일화 되어 더이상 SSE로 여석을 전송해주던 로직은 필요 없게 되었습니다.
따라서 SSE를 사용하는 것이 아닌 자료구조에 저장하는 방식으로 변경했습니다.
백엔드는 여석 크롤링 후 저장해둔 자료구조를 통해 여석 정보를 가져오게 될 것입니다. 여석을 저장할 자료구조의 이름은 `ChangedSubjectBuffer`입니다. 
변경된 여석 정보들이 담겨 있는 `ChangedSubjectBuffer`의 `getAllAndFlush()`를 통해 버퍼에 저장된 것을 싹 가져가서 클라이언트에게 전송해줍니다. 그리고 전송한 과목들은 버퍼에서 내보냅니다.
또한 data transfer 비용 문제로 변경 지점만 클라이언트에게 여석 전송을 하도록 합의했었습니다.
따라서 크롤러에서 변경지점이 있을 때에만 버퍼에 저장하고, DB 저장도 변경이 있을 때에만 update하도록 수정했습니다.

추가된 각 클래스의 역할은 다음과 같습니다.

`ChangeDetector`
- 이름 그대로 변경을 감지합니다.
- `isRemainSeatChanged` 메서드를 통해 여석의 변경을 감지합니다.
- `saveChangeToBuffer`를 통해 변경 지점을 버퍼에 저장해줍니다.
- 교양이라면 `LiveBoard`에게 상태 판별을 한번 맡기고, 교양이 아닌 핀 과목이라면 무조건 UPDATE로 버퍼에 저장해줍니다.

`ChangeSubjectsResponse`
- subjectId와 ChangeStatus와 여석정보를 담고 있습니다.
- 클라이언트에게 전송할 데이터의 구조입니다.

`ChangedSubjectBuffer`
- 여석이 변경 되어 클라이언트에게 전송할 과목들을 저장해두는 자료구조 입니다.
  - 따라서 `ChangeSubjectsResponse`들을 가지고 있습니다.
- 동시성 제어를 위해 ConcurrentLinkedQueue를 사용합니다.
- 백엔드에서는 해당 클래스의 getAllAndFlush() 메서드를 통해 버퍼를 싹 비워서 가져가게 됩니다.

`LiveBoard`
- 전광판의 상태를 관리합니다.
- 전광판에 진입할 과목의 status(in,out,update)를 판별하고 반환해줍니다.
- 상태 판별은 아래 조건을 상정하여 진행 했습니다.
<img width="524" height="525" alt="스크린샷 2025-08-30 오전 10 48 18" src="https://github.com/user-attachments/assets/3c7f8a60-b82e-4086-96af-055072f2c20b" />

## 고민 지점과 리뷰 포인트
**1. 여석 정보 DB 저장 방안에 대한 논의가 필요합니다.**

- 기존: 조회한 모든 여석 정보를 DB에 저장했습니다. 

   ### 해당 방식 채택 근거

> 1.  크롤링된 모든 데이터를 저장하기에 디버깅이 쉽다.
>     
>     로깅하는 대신에 DB에 저장한다고 생각하면 돼요. 특정 과목이 언제언제 크롤링됐는지 쿼리로 볼 수 있으니까, 로그로 눈 빠지게 보는 것보다 훨씬 편할거라 생각됩니다.
>     
> 3. 나중에 추가될 기능(여석 변동 추이 제공하는 기능)에서 반드시 필요하다.
>     
>     해당 기능을 구현하기 위해서는 크롤링할 때마다 여석을 저장해야 해요.
>     
> 4.  데이터 용량이 크지 않다.
>     
>     여석 테이블의 한 레코드는 240byte 정도 용량을 차지합니다.
>     
>     하루 7시간 동안 크롤링했을 때 필요한 용량을 계산해보면 240byte * 15(초당 15회크롤링) * 3600(1시간) * 7(하루 7시간 크롤링) = `90MB` 인데 RDS가 20GB 까지 무료이기 때문에 괜찮다고 판단된다.
> 

- 변경: 해당 과목에 대한 여석이 존재하면 update, 존재하지 않으면 insert 합니다.

    ### 해당 방식으로 변경한 이유

> 기존 방식대로 한다면, 
> ```
> public boolean isRemainSeatChanged(CrawlerSubject crawlerSubject, CrawlerSeat renewedCrawlerSeat) {
>         LocalDate today = LocalDate.now();
> 
>         Optional<CrawlerSeat> previousSeat = crawlerSeatRepository.findByCrawlerSubjectAndCreatedDate(crawlerSubject, today);
>         if (previousSeat.isEmpty()) {
>             return true;
>         }
>         Integer previousRemainSeat = SeatUtils.getRemainSeat(previousSeat.get());
>         Integer nowRemainSeat = SeatUtils.getRemainSeat(renewedCrawlerSeat);
>         return !previousRemainSeat.equals(nowRemainSeat);
>     }
> ```
> -> 과목으로 해당 여석을 조회할 때, 여러 개가 반환된다면 오류가 발생합니다.
> 이를 해결하기 위해 기존 방식대로 돌려놓았습니다.
> 
> 하지만, 이 방식은 단순 save 하는 방식보다 성능 측면에서 좋지 않습니다. 
> 저장하거나 업데이트 하기 전 읽기 작업을 한 번 더 수행하기 때문입니다.
> 최근 DB 커넥션 문제로 여석이 밀리는 현상이 발생했기에, 더욱 신경써야할 부분이라고 생각해요.
> 

**2. 여석 조회 시점의 데이터 정합성에 대해 논의가 필요합니다.**
- 기존 정책
  - 여석 크롤링 -> 현재 시간 저장의 흐름이었기에 사용자들에게 실제 여석 조회 시점을 보여줄 수 있었습니다.
- 변경 감지 정책
  -  여석 크롤링 -> 변경 여부 확인 -> 변경 상태 확인 -> 현재 시간 저장의 흐름입니다.
  - depth가 기존 방식에 비해 조금 더 깊어졌습니다. 이렇게 된다면, 저장되는 시간과 실제 여석 조회 시점과의 시간차가 발생할 수 있을 것 같아요. 거의 무시 가능한 수준이라고 생각은 들지만, 그래도 이 부분에 대해 의견 공유하고 싶어서 언급드립니다! 
<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->