### PR TITLE
refactor: 크롤러 의존도 낮추기 위한 basket 클래스 백엔드 코드로 이동

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/basket/AdminBasketApi.java
+++ b/src/main/java/kr/allcll/backend/admin/basket/AdminBasketApi.java
@@ -1,5 +1,6 @@
 package kr.allcll.backend.admin.basket;
 
+import jakarta.servlet.http.HttpServletRequest;
 import kr.allcll.backend.admin.AdminRequestValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +16,11 @@ public class AdminBasketApi {
     private final AdminRequestValidator validator;
 
     @PostMapping("/api/admin/basket/fetch")
-    public ResponseEntity<Void> getSubjects(@RequestParam String userId) {
+    public ResponseEntity<Void> getSubjects(HttpServletRequest request,
+        @RequestParam String userId) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
         adminBasketService.fetchAndSaveBaskets(userId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kr/allcll/backend/admin/basket/AdminBasketApi.java
+++ b/src/main/java/kr/allcll/backend/admin/basket/AdminBasketApi.java
@@ -1,0 +1,22 @@
+package kr.allcll.backend.admin.basket;
+
+import kr.allcll.backend.admin.AdminRequestValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminBasketApi {
+
+    private final AdminBasketService adminBasketService;
+    private final AdminRequestValidator validator;
+
+    @PostMapping("/api/admin/basket/fetch")
+    public ResponseEntity<Void> getSubjects(@RequestParam String userId) {
+        adminBasketService.fetchAndSaveBaskets(userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/kr/allcll/backend/admin/basket/AdminBasketService.java
+++ b/src/main/java/kr/allcll/backend/admin/basket/AdminBasketService.java
@@ -1,0 +1,70 @@
+package kr.allcll.backend.admin.basket;
+
+import java.util.List;
+import kr.allcll.crawler.basket.CrawlerBasket;
+import kr.allcll.crawler.basket.CrawlerBasketRepository;
+import kr.allcll.crawler.client.BasketClient;
+import kr.allcll.crawler.client.payload.BasketPayload;
+import kr.allcll.crawler.common.entity.CrawlerSemester;
+import kr.allcll.crawler.credential.Credential;
+import kr.allcll.crawler.credential.Credentials;
+import kr.allcll.crawler.subject.CrawlerSubject;
+import kr.allcll.crawler.subject.CrawlerSubjectRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminBasketService {
+
+    private final Credentials credentials;
+    private final BasketClient basketClient;
+    private final CrawlerBasketRepository crawlerBasketRepository;
+    private final CrawlerSubjectRepository crawlerSubjectRepository;
+
+    public void fetchAndSaveBaskets(String userId) {
+        Credential credential = credentials.findByUserId(userId);
+        List<CrawlerSubject> crawlerSubjects = crawlerSubjectRepository.findAllBySemesterAt(CrawlerSemester.now());
+        for (CrawlerSubject crawlerSubject : crawlerSubjects) {
+            List<CrawlerBasket> notDuplicatedCrawlerBaskets = fetchBaskets(crawlerSubject, credential);
+            crawlerBasketRepository.saveAll(notDuplicatedCrawlerBaskets);
+            wait(1000);
+        }
+    }
+
+    private List<CrawlerBasket> fetchBaskets(CrawlerSubject crawlerSubject, Credential credential) {
+        BasketPayload requestPayload = BasketPayload.from(crawlerSubject);
+        List<CrawlerBasket> crawlerBaskets = basketClient.execute(credential, requestPayload).toBaskets(crawlerSubject);
+        return filterDuplicatedBaskets(crawlerBaskets);
+    }
+
+    private List<CrawlerBasket> filterDuplicatedBaskets(List<CrawlerBasket> crawlerBaskets) {
+        return crawlerBaskets.stream()
+            .filter(this::doesNotDuplicatedBasket)
+            .toList();
+    }
+
+    /*
+    중복된 Basket 기준은 다음과 같다.
+    1. 한 과목에는 여러 개의 Basket이 존재할 수 있다. (subjectId)
+    2. 위 조건을 만족하는 여러 개의 Basket 중에서는 학생 학과 코드로 구분한다. (studentDeptCd)
+    3. 위 두 조건을 만족해도 여러 학기에 걸쳐 중복되는 Basket이 존재할 수 있다. 이것은 학기로 구분한다. (semesterAt)
+    4. 하지만 3번 조건은 무시해도 된다. subjectId에 이미 semesterAt이 포함되어 있기 때문이다.
+     */
+    private boolean doesNotDuplicatedBasket(CrawlerBasket crawlerBasket) {
+        return !crawlerBasketRepository.existsBySubjectIdAndStudentDeptCd(
+            crawlerBasket.getSubjectId(),
+            crawlerBasket.getStudentDeptCd()
+        );
+    }
+
+    private void wait(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            log.error("Thread sleep error", e);
+        }
+    }
+}


### PR DESCRIPTION
# 작업 내용

크롤러 의존도를 낮추기 위해 basket 관련 클래스들을 백엔드 코드로 이동합니다.

이동 대상이 되는 클래스들은 다음과 같습니다.

- `CrawlerBasketService`
- `CrawlerBasketApi`

기존 백엔드 코드의 domain > basket 패키지에도 BasketApi, BasketService가 있습니다. 이들은 관심과목 검색(GET - `/api/baskets?param=value`), 관심과목 정보 상세조회(GET - `/api/baskets/{subjectId}`)에 관한 로직입니다. 

해당 로직은 직접 관심과목 정보를 크롤링 하는 로직이므로 domain의 basket보다는 admin api로 이동하여 요청을 시도할 때 토큰 인증을 하고 하는것이 보안상 맞다고 판단되어 아래와 같이 작업하였습니다.

해당 로직은 직접 관심과목 정보를 크롤링하는 로직이므로, `domain > basket`보다는 admin API로 이동하여 요청 시 토큰 인증을 거치는 것이 보안상 더 적절하다고 판단했습니다.
이에 따라 아래와 같이 작업을 진행했습니다.

- admin > basket 패키지 생성
- `CrawlerBasektService` → `AdminBasketService` 이름 변경
- `CrawlerBasketApi` → `AdminBasketApi` 이름 변경
- Admin 토큰 검증 로직 추가

---

# 고민 사항

해당 로직을 Admin으로 관리하는 것에대해 적절한지, 더 나은 방법이 있는지 의견있으면 코멘트 부탁드립니다!