### PR TITLE
refactor: Sse 관련 어드민 API 패키지 경로 변경

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/sse/AdminSseApi.java
+++ b/src/main/java/kr/allcll/backend/admin/sse/AdminSseApi.java
@@ -1,24 +1,19 @@
-package kr.allcll.backend.admin;
+package kr.allcll.backend.admin.sse;
 
 import jakarta.servlet.http.HttpServletRequest;
+import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.support.scheduler.SchedulerService;
 import kr.allcll.backend.support.scheduler.dto.SeatSchedulerStatusResponse;
-import kr.allcll.backend.support.sse.SseService;
-import kr.allcll.backend.support.sse.dto.SseStatusResponse;
-import kr.allcll.backend.support.web.ThreadLocalHolder;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequiredArgsConstructor
 public class AdminSseApi {
 
-    private final SseService sseService;
     private final SchedulerService schedulerService;
     private final AdminRequestValidator validator;
 


### PR DESCRIPTION
## 작업 내용
admin 하위에 sse 패키지 생성 후 `AdminSseApi`를 이동하였습니다.
해당 Api는 총 세 가지입니다.

> 1. Sse 전송을 시작하는 API
> 2. Sse 전송을 중단하는 API
> 3. Sse 전송 여부를 확인하는 API

`AdminSseApi` 에서 사용하는 `SchedulerService`는 admin>sse 로 이동하지 않았습니다.
기존, support > schduler 패키지 하위에 두는 것이 역할 분리 측면에서 맞다고 판단하였습니다.

## 고민 지점과 리뷰 포인트
다른 패키지 분리 방안이 있다면 공유해주세요!

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->