### PR TITLE
refactor: 2025 동계 계절학기에 맞게 코드 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
@@ -37,7 +37,7 @@ public class GeneralSeatSender {
         if (hasActiveSchedule()) {
             return;
         }
-        scheduledTaskHandler.scheduleAtFixedRate(getGeneralSeatTaskAtSeasonSemester(), SENDING_PERIOD);
+        scheduledTaskHandler.scheduleAtFixedRate(getAllSeatTaskAtSeasonSemester(), SENDING_PERIOD);
     }
 
     public boolean hasActiveSchedule() {
@@ -51,10 +51,10 @@ public class GeneralSeatSender {
         };
     }
 
-    private Runnable getGeneralSeatTaskAtSeasonSemester() {
+    private Runnable getAllSeatTaskAtSeasonSemester() {
         return () -> {
-            List<SeatDto> generalSeats = seatStorage.getGeneralSeatsAtSeasonSemester(SEASON_SEMESTER_QUERY_LIMIT);
-            sseService.propagate(EVENT_NAME, SeatsResponse.from(generalSeats));
+            List<SeatDto> allSeat = seatStorage.getAllSeatsAtSeasonSemester(SEASON_SEMESTER_QUERY_LIMIT);
+            sseService.propagate(EVENT_NAME, SeatsResponse.from(allSeat));
         };
     }
 

--- a/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/SeatStorage.java
@@ -33,7 +33,7 @@ public class SeatStorage {
             .toList();
     }
 
-    public List<SeatDto> getGeneralSeatsAtSeasonSemester(int limit) {
+    public List<SeatDto> getAllSeatsAtSeasonSemester(int limit) {
         Collection<SeatDto> seatsValue = seats.values();
         return seatsValue.stream()
                 .filter(seat -> seat.getSeatCount() > 0)


### PR DESCRIPTION
## 작업 내용
저희 어드민에서 호출하는 엔드포인트는 계절학기거 이미 분리된 것으로 알고있습니다(맞지요? 답변부탁주스 ㅎㅎ)
그래서 프론트에 전달해주는 과목 개수만 늘려주는 작업 했습니다!
`/api/admin/seat-scheduler/start` 호출 -> `schedulerService.startScheduling();`가 호출 -> `generalSeatSender.send();`호출 -> SSE 전송 스케줄러에 등록하여 스케줄링 시작(1초마다 보냄)
이 순서자나요? 
1. **Runnable 반환 메서드(이하 스케줄) 계절 전용 추가**
  이전에는 generalSeatSender.send()에서 호출하는 스케줄의 QUERY_LIMIT 숫자를 갈아끼워줬었습니다. 메서드를 추가함으로써 호출하는 스케줄을 갈아끼우도록 수정했습니다.
2. **SeatStorage 전체 과목 반환 메서드 계절 전용 추가**
  보통은 교양 과목을 전달하는데, 이젠 전체 과목을 전달할거잖아요? 1번의 스케줄에서 호출하는 SeatStorage의 nonMajor 필터링을 제외한 메서드를 추가해줬습니다.
 
> 1번과 2번의 추가로, 이제 계절마다 메서드를 수정하던 것을, 메서드를 갈아끼우는 형태로 변경했습니다. 개선의 여지는 아직 있지만...(SEASON_SEMESTER_QUERY_LIMIT 계절때마다 변수 수정해야함) 우선 내일부터 서비스니까요.... 우선 이정도만 개선했습니다. 계절 서비스 끝나고 추후 더 작업하겠습니다.

3. **SEASON_SEMESTER_QUERY_LIMIT는 40으로 수정했습니다.**
`select * from subjects where semester_at = '2025-겨울' and curi_no not in('010418','010419','010420');` 요 쿼리 실행해서 창의학기제 제외한 숫자 세보니까 40이더라고요

## 고민 지점과 리뷰 포인트
저 뭐 놓친거있는지 흐름 점검 해주심 감사하겠습니다! "프론트에게 SSE 전달하는 흐름"과, "저희의 어드민 호출로 general 과목 세팅해두는 흐름"이 있을 것 같아여(맞죠? 끊임없이의심해)
- 기존 학기와 달리 계절학기 전용 `/api/admin/season-seat/start`호출로, 계절학기때 general queue는 전체 과목으로 세팅.
- 프론트에게 전송하는 SSE 전달 숫자 늘림. SSE 전송 스케줄러 1초마다 돌아가며 전체 과목 전송해줌.

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->