### PR TITLE
[TSK-41] 사용자의 학과 코드 조회 시 학과 중복 조회 문제 해결

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/department/GraduationDepartmentInfoRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/department/GraduationDepartmentInfoRepository.java
@@ -2,8 +2,10 @@ package kr.allcll.backend.domain.graduation.department;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GraduationDepartmentInfoRepository extends JpaRepository<GraduationDepartmentInfo, Long> {
 
-    Optional<GraduationDepartmentInfo> findByDeptNm(String deptNm);
+    @Query("SELECT g FROM GraduationDepartmentInfo g WHERE g.admissionYear = :admissionYear AND g.deptNm = :deptNm")
+    Optional<GraduationDepartmentInfo> findByAdmissionYearAndDeptNm(int admissionYear, String deptNm);
 }

--- a/src/main/java/kr/allcll/backend/domain/user/UserService.java
+++ b/src/main/java/kr/allcll/backend/domain/user/UserService.java
@@ -28,13 +28,14 @@ public class UserService {
             .orElseGet(() -> save(userInfo));
     }
 
-    private User save(UserInfo info) {
-        GraduationDepartmentInfo departmentInfo = departmentInfoRepository.findByDeptNm(info.deptNm())
-            .orElseThrow(() -> new AllcllException(AllcllErrorCode.DEPARTMENT_NOT_FOUND, info.deptNm()));
+    private User save(UserInfo userInfo) {
+        int admissionYear = extractAdmissionYear(userInfo.studentId());
+        GraduationDepartmentInfo departmentInfo = departmentInfoRepository.findByAdmissionYearAndDeptNm(admissionYear, userInfo.deptNm())
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.DEPARTMENT_NOT_FOUND, userInfo.deptNm()));
         User user = new User(
-            info.studentId(),
-            info.name(),
-            extractAdmissionYear(info.studentId()),
+            userInfo.studentId(),
+            userInfo.name(),
+            extractAdmissionYear(userInfo.studentId()),
             MajorType.SINGLE,
             departmentInfo.getCollegeNm(),
             departmentInfo.getDeptNm(),
@@ -62,13 +63,13 @@ public class UserService {
         validateUserId(userId);
         User user = getById(userId);
         if (updateUserRequest.majorType() == MajorType.SINGLE) {
-            GraduationDepartmentInfo dept = departmentInfoRepository.findByDeptNm(updateUserRequest.deptNm())
+            GraduationDepartmentInfo dept = departmentInfoRepository.findByAdmissionYearAndDeptNm(user.getAdmissionYear(),updateUserRequest.deptNm())
                 .orElseThrow(
                     () -> new AllcllException(AllcllErrorCode.DEPARTMENT_NOT_FOUND, updateUserRequest.deptNm()));
             user.updateSingleMajorUser(updateUserRequest, dept);
             return;
         }
-        GraduationDepartmentInfo doubleDept = departmentInfoRepository.findByDeptNm(updateUserRequest.doubleDeptNm())
+        GraduationDepartmentInfo doubleDept = departmentInfoRepository.findByAdmissionYearAndDeptNm(user.getAdmissionYear(), updateUserRequest.doubleDeptNm())
             .orElseThrow(
                 () -> new AllcllException(AllcllErrorCode.DEPARTMENT_NOT_FOUND, updateUserRequest.doubleDeptNm()));
         user.updateDoubleMajorUser(updateUserRequest, doubleDept);


### PR DESCRIPTION
## 작업 배경
로그인 요청 시, 정상 로그인이 되지 않는 문제가 있었습니다.
현재 구현되어 있는 코드에서 로그인 API에 포함되어 있는 기능은 다음과 같습니다.

> 1. 대휴칼 로그인
> 2. 1로 불러온 정보를 이용해 [학과 정보 데이터]에서 학과 코드를 조회 후 학과 정보들을 저장합니다.
> 3. 졸업인증제도 여부를 불러와 저장합니다.
> 

2번에서, 학과명으로만 조회할 경우 다른 입학년도애도 동일한 학과의 이름이 존재하기 때문에 문제가 발생합니다. -> 로그인 정상 작동 X

## 작업 내용
따라서 학과 정보 조회 시, 입학년도 필터링 조건을 추가하여 문제를 해결했습니다!

## 검증
<img width="1526" height="71" alt="스크린샷 2026-02-08 오후 3 29 40" src="https://github.com/user-attachments/assets/301d2c5d-2254-4129-8efb-105933c4a61a" />

## 고민 지점과 리뷰 포인트
-

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->