### PR TITLE
올클 prod CD 워크플로우 수정

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -14,6 +14,8 @@ jobs:
       DEV_URL: ${{ secrets.DEV_URL }}
       ADMIN_URL: ${{ secrets.ADMIN_URL }}
       EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
+      GOOGLE_ACCOUNT_JSON: ${{ secrets.GOOGLE_ACCOUNT_JSON }}
+      GOOGLE_SHEETS_CREDENTIALS_LOCATION: file:/opt/secrets/google-service-account.json
 
     defaults:
       run:
@@ -43,6 +45,14 @@ jobs:
         run: |
           mkdir -p ${{ secrets.APP_DIR }}
           cp config/application-prod.yml ${{ secrets.APP_DIR }}/application-prod.yml
+
+      - name: Create Google Service Account json on EC2
+        run: |
+          sudo mkdir -p /opt/secrets
+          echo "${GOOGLE_ACCOUNT_JSON}" | sudo tee /opt/secrets/google-service-account.json > /dev/null
+          sudo chmod 600 /opt/secrets/google-service-account.json
+          sudo chown ubuntu:ubuntu /opt/secrets/google-service-account.json
+          ls -al /opt/secrets/google-service-account.json
 
       - name: CheckOut with submodule
         uses: actions/checkout@v4


### PR DESCRIPTION
## 작업 내용
`Google Service Account JSON`을 시크릿으로 관리하도록 변경했습니다.
`secrets.GOOGLE_ACCOUNT_JSON` 값으로 EC2에 서비스 계정 키 파일을 생성하고,
생성된 키 파일의 경로를 환경변수로 주입해, 애플리케이션이 해당 키 파일을 읽어 인증하도록 구성했습니다!

## 고민 지점과 리뷰 포인트

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->