### PR TITLE
fix: 사용자 정보 조회 응답 형태 변경

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/user/dto/UserResponse.java
+++ b/src/main/java/kr/allcll/backend/domain/user/dto/UserResponse.java
@@ -6,10 +6,15 @@ import kr.allcll.backend.domain.user.User;
 public record UserResponse(
     Long id,
     String studentId,
-    String studentName,
+    String name,
+    int admissionYear,
+    MajorType majorType,
+    String collegeName,
     String deptName,
-    String deptCd,
-    MajorType majorType
+    String deptCode,
+    String doubleCollegeName,
+    String doubleDeptName,
+    String doubleDeptCode
 ) {
 
     public static UserResponse from(User user) {
@@ -17,9 +22,14 @@ public record UserResponse(
             user.getId(),
             user.getStudentId(),
             user.getName(),
+            user.getAdmissionYear(),
+            user.getMajorType(),
+            user.getCollegeNm(),
             user.getDeptNm(),
             user.getDeptCd(),
-            user.getMajorType()
+            user.getDoubleCollegeNm(),
+            user.getDoubleDeptNm(),
+            user.getDoubleDeptCd()
         );
     }
 }


### PR DESCRIPTION
## 작업 내용
(범위가 아주 작은 내용이라 따로 taskid를 파서 작업을 진행하지는 않았는데, 필요해보인다면 말씀해주세요!)

1차 배포 목표를 단일 전공 기준으로만 생각하여, 사용자 정보를 조회하는 로직(Get /api/auth/me)의 응답에 사용자의 주전공에 대한 정보만 포함됩니다. 
하지만 1차 배포 때 복수전공까지 고려하기로하여, 응답을 더욱 구체화하고자 해당 작업을 진행하였습니다.

### 1. 단일전공기준

- 기존 응답
    
    ```json
    {
        "id": 1,
        "studentId": "21012345",
        "studentName": "남올클",
        "deptName": "데이터사이언스학과",
        "deptCd": "3225",
        "majorType": "SINGLE"
    }
    ```
    
- 변경 응답
    
    ```
    {
        "id": 1,
        "studentId": "21012345",
        "name": "남올클",
        "admissionYear": 2021,
        "majorType": "SINGLE",
        "collegeName": "소프트웨어융합대학",
        "deptName": "데이터사이언스학과",
        "deptCode": "3225",
        "doubleCollegeName": null,
        "doubleDeptName": null,
        "doubleDeptCode": null
    }
    ```

### 2. 복수전공기준

- 기존 응답
    
    ```json
    {
        "id": 2,
        "studentId": "22012345",
        "studentName": "안올클",
        "deptName": "인공지능데이터사이언스학과",
        "deptCd": "3516",
        "majorType": "DOUBLE"
    }
    ```
    
- 변경 응답
    
    ```json
    {
        "id": 2,
        "studentId": "22012345",
        "name": "안올클",
        "admissionYear": 2024,
        "majorType": "DOUBLE",
        "collegeName": "인공지능융합대학",
        "deptName": "인공지능데이터사이언스학과",
        "deptCode": "3516",
        "doubleCollegeName": "인공지능융합대학",
        "doubleDeptName": "정보보호학과",
        "doubleDeptCode": "3514"
    }
    ```

## 고민 지점과 리뷰 포인트
User DB에 있는 정보를 거의 다 보내주고있는데, 추가로 보내주어야할 것 같은 정보가있다면 말씀해주세요!

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->