### PR TITLE
[TSK-56-109] 복수 전공인 사용자 정보 수정 시 주전공 수정도 가능하도록 개선

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/user/User.java
+++ b/src/main/java/kr/allcll/backend/domain/user/User.java
@@ -62,18 +62,25 @@ public class User extends BaseEntity {
         this.doubleDeptCd = doubleDeptCd;
     }
 
-    public void updateSingleMajorUser(UpdateUserRequest updateUserRequest, GraduationDepartmentInfo dept) {
+    public void updateSingleMajorUser(UpdateUserRequest updateUserRequest, GraduationDepartmentInfo primaryDept) {
         this.majorType = updateUserRequest.majorType();
-        this.collegeNm = dept.getCollegeNm();
-        this.deptNm = dept.getDeptNm();
-        this.deptCd = dept.getDeptCd();
+        this.collegeNm = primaryDept.getCollegeNm();
+        this.deptNm = primaryDept.getDeptNm();
+        this.deptCd = primaryDept.getDeptCd();
         this.doubleCollegeNm = null;
         this.doubleDeptNm = null;
         this.doubleDeptCd = null;
     }
 
-    public void updateDoubleMajorUser(UpdateUserRequest updateUserRequest, GraduationDepartmentInfo doubleDept) {
+    public void updateDoubleMajorUser(
+        UpdateUserRequest updateUserRequest,
+        GraduationDepartmentInfo primaryDept,
+        GraduationDepartmentInfo doubleDept
+    ) {
         this.majorType = updateUserRequest.majorType();
+        this.collegeNm = primaryDept.getCollegeNm();
+        this.deptNm = primaryDept.getDeptNm();
+        this.deptCd = primaryDept.getDeptCd();
         this.doubleCollegeNm = doubleDept.getCollegeNm();
         this.doubleDeptNm = doubleDept.getDeptNm();
         this.doubleDeptCd = doubleDept.getDeptCd();


### PR DESCRIPTION
## 이슈
사용자 정보 수정 API에서, 복수 전공일 경우 주전공 학과 정보가 수정이 안 되는 이슈가 있습니다.

## 작업 내용
[기존] 사용자 정보 수정 시 다음과 같은 케이스가 존재했습니다.
1. 단일 전공인 경우, 주전공의 학과 정보를 수정합니다.
2. 복수 전공의 경우, 복수전공의 학과 정보를 수정합니다.

[개선]
기존 기능에 복수 전공의 경우 주전공 학과 정보도 수정 가능하도록 개선하였습니다.

## 고민 지점과 리뷰 포인트
-

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->