### PR TITLE
[TSK-57] 실시간 여석 로직 개선 with Codex

### DIFF
--- a/src/main/java/kr/allcll/backend/support/sse/SseEmitterStorage.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseEmitterStorage.java
@@ -14,8 +14,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class SseEmitterStorage {
 
     /**
-     * token 당 단일 emitter를 저장한다.
-     * ConcurrentHashMap을 사용해 멀티 스레드 환경에서도 put/remove/get을 안전하게 처리한다.
+     * token 당 단일 emitter를 저장한다. ConcurrentHashMap을 사용해 멀티 스레드 환경에서도 put/remove/get을 안전하게 처리한다.
      */
     private final ConcurrentMap<String, SseEmitter> emitters;
 
@@ -33,7 +32,7 @@ public class SseEmitterStorage {
 
         if (previousEmitter != null) {
             log.debug("[SSE] 기존 연결을 교체합니다. token: {}", token);
-            previousEmitter.completeWithError(new IllegalStateException("SSE emitter replaced by newer connection."));
+            previousEmitter.complete();
         }
     }
 

--- a/src/main/java/kr/allcll/backend/support/sse/SseEmitterStorage.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseEmitterStorage.java
@@ -1,9 +1,10 @@
 package kr.allcll.backend.support.sse;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -12,48 +13,57 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Component
 public class SseEmitterStorage {
 
-    /*
-        ExecutorService로 변경이 필요할 수 있습니다.
+    /**
+     * token 당 단일 emitter를 저장한다.
+     * ConcurrentHashMap을 사용해 멀티 스레드 환경에서도 put/remove/get을 안전하게 처리한다.
      */
-    private final Map<String, SseEmitter> emitters;
+    private final ConcurrentMap<String, SseEmitter> emitters;
 
-    /*
-        동시성 문제로 자료구조 변경이 필요할 수 있습니다.
-     */
     public SseEmitterStorage() {
         this.emitters = new ConcurrentHashMap<>();
     }
 
     public void add(String token, SseEmitter sseEmitter) {
-        emitters.put(token, sseEmitter);
-        log.info("[SSE] 새로운 연결이 추가되었습니다. 현재 연결 수: {}", emitters.size());
-        sseEmitter.onTimeout(() -> {
-            emitters.remove(token);
-            log.debug("[SSE] 연결이 타임아웃으로 종료되었습니다. 현재 연결 수: {}", emitters.size());
-        });
-        sseEmitter.onError(e -> {
-            emitters.remove(token);
-        });
-        sseEmitter.onCompletion(() -> {
-            emitters.remove(token);
-        });
+        SseEmitter previousEmitter = emitters.put(token, sseEmitter);
+        log.debug("[SSE] 새로운 연결이 추가되었습니다. token: {}, 현재 연결 수: {}", token, emitters.size());
+
+        sseEmitter.onTimeout(() -> removeIfSameEmitter(token, sseEmitter, "timeout"));
+        sseEmitter.onError(error -> removeIfSameEmitter(token, sseEmitter, "error", error));
+        sseEmitter.onCompletion(() -> removeIfSameEmitter(token, sseEmitter, "completion"));
+
+        if (previousEmitter != null) {
+            log.debug("[SSE] 기존 연결을 교체합니다. token: {}", token);
+            previousEmitter.completeWithError(new IllegalStateException("SSE emitter replaced by newer connection."));
+        }
     }
 
-    /*
-        실제 객체를 전달하지 않으면 이미 완료된 SseEmitter에 대해 send() 호출이 발생한다.
-        Collections.unmodifiableList(), Stream.toList()를 사용하면 랩핑한 객체를 반환하기에 위 문제가 발생한다.
+    private void removeIfSameEmitter(String token, SseEmitter expectedEmitter, String reason) {
+        boolean removed = emitters.remove(token, expectedEmitter);
+        log.debug("[SSE] 연결 종료 콜백 처리. reason: {}, token: {}, removed: {}, 현재 연결 수: {}",
+            reason, token, removed, emitters.size());
+    }
+
+    private void removeIfSameEmitter(String token, SseEmitter expectedEmitter, String reason, Throwable throwable) {
+        removeIfSameEmitter(token, expectedEmitter, reason);
+        if (throwable != null) {
+            log.debug("[SSE] 종료 원인. token: {}, reason: {}, errorType: {}, message: {}",
+                token, reason, throwable.getClass().getSimpleName(), throwable.getMessage());
+        }
+    }
+
+    /**
+     * 순회 중 구조 변경(연결 추가/제거) 영향 최소화를 위해 스냅샷을 반환한다.
      */
     public List<SseEmitter> getEmitters() {
-        return emitters.values().stream().toList();
+        return new ArrayList<>(emitters.values());
     }
 
     public Optional<SseEmitter> getEmitter(String token) {
-        SseEmitter emitter = emitters.get(token);
-        return Optional.ofNullable(emitter);
+        return Optional.ofNullable(emitters.get(token));
     }
 
     public List<String> getUserTokens() {
-        return emitters.keySet().stream().toList();
+        return new ArrayList<>(emitters.keySet());
     }
 
     public int getActiveConnectionCount() {

--- a/src/test/java/kr/allcll/backend/support/sse/SseEmitterStorageTest.java
+++ b/src/test/java/kr/allcll/backend/support/sse/SseEmitterStorageTest.java
@@ -1,0 +1,107 @@
+package kr.allcll.backend.support.sse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class SseEmitterStorageTest {
+
+    private static final String TOKEN = "token";
+
+    @DisplayName("재연결 시 이전 emitter의 completion 콜백이 호출되어도 최신 emitter는 유지된다.")
+    @Test
+    void latestConnectionShouldRemainWhenPreviousCompletionCallbackRuns() {
+        SseEmitterStorage storage = new SseEmitterStorage();
+        TrackableSseEmitter previousEmitter = new TrackableSseEmitter();
+        TrackableSseEmitter latestEmitter = new TrackableSseEmitter();
+
+        storage.add(TOKEN, previousEmitter);
+        storage.add(TOKEN, latestEmitter);
+
+        previousEmitter.runCompletionCallback();
+
+        assertThat(storage.getEmitter(TOKEN)).contains(latestEmitter);
+        assertThat(previousEmitter.completeWithErrorCalled).isTrue();
+    }
+
+    @DisplayName("재연결 시 이전 emitter의 timeout 콜백이 호출되어도 최신 emitter는 유지된다.")
+    @Test
+    void latestConnectionShouldRemainWhenPreviousTimeoutCallbackRuns() {
+        SseEmitterStorage storage = new SseEmitterStorage();
+        TrackableSseEmitter previousEmitter = new TrackableSseEmitter();
+        TrackableSseEmitter latestEmitter = new TrackableSseEmitter();
+
+        storage.add(TOKEN, previousEmitter);
+        storage.add(TOKEN, latestEmitter);
+
+        previousEmitter.runTimeoutCallback();
+
+        assertThat(storage.getEmitter(TOKEN)).contains(latestEmitter);
+    }
+
+    @DisplayName("현재 emitter의 error 콜백이 호출되면 연결이 제거된다.")
+    @Test
+    void currentEmitterShouldBeRemovedWhenErrorCallbackRuns() {
+        SseEmitterStorage storage = new SseEmitterStorage();
+        TrackableSseEmitter emitter = new TrackableSseEmitter();
+
+        storage.add(TOKEN, emitter);
+        emitter.runErrorCallback(new IOException("broken pipe"));
+
+        assertThat(storage.getEmitter(TOKEN)).isEmpty();
+    }
+
+    private static class TrackableSseEmitter extends SseEmitter {
+
+        private boolean completeWithErrorCalled;
+        private Runnable timeoutCallback;
+        private Runnable completionCallback;
+        private Consumer<Throwable> errorCallback;
+
+        @Override
+        public synchronized void completeWithError(Throwable ex) {
+            completeWithErrorCalled = true;
+            super.completeWithError(ex);
+        }
+
+        @Override
+        public void onTimeout(Runnable callback) {
+            this.timeoutCallback = callback;
+            super.onTimeout(callback);
+        }
+
+        @Override
+        public void onCompletion(Runnable callback) {
+            this.completionCallback = callback;
+            super.onCompletion(callback);
+        }
+
+        @Override
+        public void onError(Consumer<Throwable> callback) {
+            this.errorCallback = callback;
+            super.onError(callback);
+        }
+
+        private void runTimeoutCallback() {
+            if (timeoutCallback != null) {
+                timeoutCallback.run();
+            }
+        }
+
+        private void runCompletionCallback() {
+            if (completionCallback != null) {
+                completionCallback.run();
+            }
+        }
+
+        private void runErrorCallback(Throwable throwable) {
+            if (errorCallback != null) {
+                errorCallback.accept(throwable);
+            }
+        }
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/sse/SseEmitterStorageTest.java
+++ b/src/test/java/kr/allcll/backend/support/sse/SseEmitterStorageTest.java
@@ -25,7 +25,7 @@ class SseEmitterStorageTest {
         previousEmitter.runCompletionCallback();
 
         assertThat(storage.getEmitter(TOKEN)).contains(latestEmitter);
-        assertThat(previousEmitter.completeWithErrorCalled).isTrue();
+        assertThat(previousEmitter.completeCalled).isTrue();
     }
 
     @DisplayName("재연결 시 이전 emitter의 timeout 콜백이 호출되어도 최신 emitter는 유지된다.")
@@ -57,15 +57,15 @@ class SseEmitterStorageTest {
 
     private static class TrackableSseEmitter extends SseEmitter {
 
-        private boolean completeWithErrorCalled;
+        private boolean completeCalled;
         private Runnable timeoutCallback;
         private Runnable completionCallback;
         private Consumer<Throwable> errorCallback;
 
         @Override
-        public synchronized void completeWithError(Throwable ex) {
-            completeWithErrorCalled = true;
-            super.completeWithError(ex);
+        public void complete() {
+            completeCalled = true;
+            super.complete();
         }
 
         @Override


### PR DESCRIPTION
## 변경사항

- 필드 타입을 `ConcurrentMap<String, SseEmitter>`로 변경하고, 실제 구현체로 `ConcurrentHashMap`을 유지하여 동시성 의도와 구현을 일치시켰습니다.
- 기존 TODO 형태의 주석을 제거하고, 다음 내용을 설명하는 구체적인 Javadoc을 추가했습니다.
  - `ConcurrentHashMap`을 사용하는 이유
  - `getEmitters()` / `getUserTokens()`가 스냅샷 `ArrayList` 복사본을 반환하는 이유
- 콜백 안전 제거를 위한 헬퍼(`removeIfSameEmitter(...)`)를 유지 및 연결하고,
  - emitter 교체/제거 시 로그를 통해 동작을 명확히 남기도록 했습니다.
- `getEmitter()`는 `Optional.ofNullable(emitters.get(token))` 형태로 단순화했습니다.
- `TrackableSseEmitter`를 활용한 `SseEmitterStorageTest`를 추가하여 다음을 검증합니다.
  - 이전 emitter의 콜백이 새 emitter를 제거하지 않음을 보장
  - 현재 emitter에서 발생한 error 콜백은 정상적으로 해당 emitter를 제거함을 보장

## 참고

- ai native 전환을 위한 초석으로, 웹 codex를 활용하여 코드 한 줄 입력하지 않고 PR을 올렸습니다. 
- PR 작성까지 codex가 해주는데 제목과 코멘트만 수정했습니다. 