### PR TITLE
[TSK-56-130] 영어 인증 충족 여부 검사 시, 대체 과목 이수 여부 확인 로직 오류 해결

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/CertificationChecker.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/CertificationChecker.java
@@ -58,12 +58,11 @@ public class CertificationChecker {
         }
 
         EnglishCertCriterion englishCertCriterion = englishCertCriterionOpt.get();
-        String altCuriNo = englishCertCriterion.getAltCuriNo();
         for (CompletedCourseDto completedCourse : completedCourses) {
             if (!completedCourse.isCreditEarned()) {
                 continue;
             }
-            if (englishCertCriterion.matchesAltCourse(altCuriNo)) {
+            if (englishCertCriterion.matchesAltCourse(completedCourse.curiNo())) {
                 return true;
             }
         }


### PR DESCRIPTION
## 이슈
졸업인증 제도 중 영어인증 영역에서, 

> 1. 영어 인증 기준 미달
> 2. 영어 인증 대체 과목 미이수

인 경우에도 영어인증 이수 처리가 되는 이슈가 있었습니다.

## 원인
영어인증 대체과목 검사 로직에서, 사용자 기이수성적표에 존재하는 학수번호가 아닌 영어인증 기준 데이터의 학수번호로 검사가 되고 있었기 때문에 발생한 이슈입니다.

## 작업 내용
사용자 기이수성적표에 존재하는 학수번호로 대체과목 이수 여부를 확인하고 최종 영어인증 충족여부에 반영되도록 수정하였습니다.

## 검증
### 영어인증 미이수 사용자

**[기존 코드 응답 결과]**
<img width="220" height="94" alt="스크린샷 2026-02-18 오후 12 46 25" src="https://github.com/user-attachments/assets/4f037e1d-a416-4df7-bcd2-581ae90782f6" />

**[개선 코드 응답 결과]**
<img width="244" height="108" alt="스크린샷 2026-02-18 오후 12 44 00" src="https://github.com/user-attachments/assets/5627edb1-64a2-4a1c-9e42-ce1fc518f087" />

## 고민 지점과 리뷰 포인트
-

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->