### PR TITLE
[Draft] 아키텍처 및 알고리즘 개선 제안

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java
@@ -3,6 +3,7 @@ package kr.allcll.backend.domain.basket;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BasketRepository extends JpaRepository<Basket, Long> {
 
@@ -14,4 +15,14 @@ public interface BasketRepository extends JpaRepository<Basket, Long> {
         and s.semesterAt = :semesterAt
         """)
     List<Basket> findBySubjectId(Long id, String semesterAt);
+
+    // #1 N+1 제거: 여러 과목의 Basket을 한 번에 조회
+    @Query("""
+        select b from Basket b
+        join fetch b.subject s
+        where s.id in :ids
+        and s.isDeleted = false
+        and s.semesterAt = :semesterAt
+        """)
+    List<Basket> findBySubjectIds(@Param("ids") List<Long> ids, @Param("semesterAt") String semesterAt);
 }

--- a/src/main/java/kr/allcll/backend/domain/user/AuthService.java
+++ b/src/main/java/kr/allcll/backend/domain/user/AuthService.java
@@ -22,6 +22,9 @@ public class AuthService {
 
     private final LoginProperties properties;
 
+    // #2 OkHttpClient 재사용: ConnectionPool과 Dispatcher를 공유하는 공용 클라이언트
+    private final OkHttpClient sharedClient = new OkHttpClient();
+
     public OkHttpClient login(LoginRequest loginRequest) {
         try {
             String studentId = loginRequest.studentId();
@@ -30,7 +33,8 @@ public class AuthService {
             CookieManager cookieManager = new CookieManager();
             cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
 
-            OkHttpClient client = new OkHttpClient().newBuilder()
+            // #2 OkHttpClient 재사용: 공용 client에서 파생하여 connection pool 공유
+            OkHttpClient client = sharedClient.newBuilder()
                 .cookieJar(new JavaNetCookieJar(cookieManager))
                 .build();
 

--- a/src/main/java/kr/allcll/backend/support/sse/SseEmitterStorage.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseEmitterStorage.java
@@ -26,7 +26,8 @@ public class SseEmitterStorage {
 
     public void add(String token, SseEmitter sseEmitter) {
         emitters.put(token, sseEmitter);
-        log.info("[SSE] 새로운 연결이 추가되었습니다. 현재 연결 수: {}", emitters.size());
+        // #3 SSE 로그 레벨: 운영 환경에서 연결이 많을 때 info 로그 부담 방지
+        log.debug("[SSE] 새로운 연결이 추가되었습니다. 현재 연결 수: {}", emitters.size());
         sseEmitter.onTimeout(() -> {
             emitters.remove(token);
             log.debug("[SSE] 연결이 타임아웃으로 종료되었습니다. 현재 연결 수: {}", emitters.size());

--- a/src/main/java/kr/allcll/backend/support/sse/SseService.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseService.java
@@ -50,8 +50,9 @@ public class SseService {
         }
     }
 
+    // #3 중복 stream 제거: getUserTokens()가 이미 새 List를 반환하므로 재변환 불필요
     public List<String> getConnectedTokens() {
-        return sseEmitterStorage.getUserTokens().stream().toList();
+        return sseEmitterStorage.getUserTokens();
     }
 
     public SseStatusResponse isConnected(String token) {


### PR DESCRIPTION
## 작업 내용
**BasketService N+1 쿼리 제거, OkHttpClient ConnectionPool 재사용, SSE 로그 레벨 조정**

### 배경
안녕하세요. 저는 세종대학교를 졸업하고, 현재 미국에서 ML System Serving 및 Inference 최적화 연구 및 오픈소스 작업을 수행하고 있는 godmook입니다. 평소 오픈소스 생태계에 관심이 많았고, 그중에서도 모교 학생들이 유용하게 사용 중인 Allcll 시스템의 백엔드 아키텍처가 궁금해 전반적인 코드를 리뷰해 보았습니다.

코드를 점검하던 중, 시스템 로직 내에서 성능 저하(Latency) 및 리소스 오버헤드(Overhead)를 유발할 수 있는 병목(Bottleneck) 구간 3곳을 식별했습니다. 이를 해결하기 위해 기존 비즈니스 로직과 애플리케이션의 동작을 100% 유지하면서 처리 효율만 높일 수 있는 Zero-impact 기반의 리팩토링을 진행해 보았습니다.

과거 Full-stack 개발자로 근무한 경험이 있으나 현재는 System Engineer로서 주로 알고리즘 최적화, GPU 서빙 및 연산 가속화(Acceleration)에 집중하고 있다 보니, 이번 리팩토링 역시 백엔드의 전반적인 프레임워크보다는 시스템 엔지니어링 관점에서의 구조적 개선에 초점을 맞추었습니다. 오랜만에 다루는 Java 환경이라 직접적인 코드 구현보다는 아이디어를 바탕으로 로직을 수정하고, AI를 활용해 정적 검증(Static Verification)을 거치는 방식으로 작업했습니다.

따라서 현재 작성된 코드는 Unit Test나 Mocking Test가 완료되지 않은 Proof of Concept (PoC) 단계에 가깝습니다. 당장 프로덕션에 적용하기보다는, Allcll 시스템의 스케일업(Scale-up)과 리소스 효율화를 위한 '아키텍처 및 알고리즘 개선 제안' 정도로 가볍게 검토해 주시고 의미 있다고 판단되는 부분들을 차용해 주시면 좋겠습니다.

모교의 뜻깊은 서비스가 한 단계 더 발전하는 데 작은 보탬이 되기를 바랍니다. 관련하여 기술적인 피드백이나 논의는 언제든 환영하며, 훌륭한 프로젝트를 리드하고 있는 여러분의 경험에서도 많은 것을 배우고 싶습니다. Love to learn from you guys!

---

### 1. BasketService의 N+1 쿼리 문제

#### 문제
`BasketService.findBasketsByCondition()`에서 과목 목록을 조회한 뒤, **과목마다 개별적으로** `basketRepository.findBySubjectId()`를 호출하고 있었습니다.

```java
// 기존 코드 — BasketService.getBasketsEachSubject()
private List<BasketsEachSubject> getBasketsEachSubject(List<Subject> subjects) {
    List<BasketsEachSubject> result = new ArrayList<>();
    for (Subject subject : subjects) {
        List<Basket> baskets = basketRepository.findBySubjectId( // 과목마다 쿼리 1번 발생
            subject.getId(),
            Semester.getCurrentSemester()
        );
        result.add(BasketsEachSubject.from(subject, baskets));
    }
    return result;
}
```

이 경우 과목이 N개면 DB 호출이 **1(과목 조회) + N(과목별 장바구니 조회) = N+1번** 발생합니다. 예를 들어, 특정 학과의 과목이 80개라면 장바구니 조회 API 한 번에 **81번의 쿼리**가 실행되며, 과목 수가 많아질수록 응답 시간이 선형으로 증가하는 구조입니다.

#### 개선 방식
`BasketRepository`에 여러 과목 ID를 한 번에 조회하는 배치 메서드를 추가하고, 서비스에서는 한 번의 쿼리로 전체 Basket을 가져온 뒤 메모리에서 과목별로 그루핑하도록 변경했습니다.

**BasketRepository — 배치 조회 메서드 추가**
```java
@Query("""
    select b from Basket b
    join fetch b.subject s
    where s.id in :ids
    and s.isDeleted = false
    and s.semesterAt = :semesterAt
    """)
List<Basket> findBySubjectIds(@Param("ids") List<Long> ids, @Param("semesterAt") String semesterAt);
```
> 기존 `findBySubjectId`와 동일한 JPQL 구조에서 `s.id = :id`를 `s.id in :ids`로만 변경했습니다. `join fetch b.subject`도 그대로 유지하여 프록시 추가 조회를 방지합니다.

**BasketService — 배치 조회 + groupingBy 적용**
```java
private List<BasketsEachSubject> getBasketsEachSubject(List<Subject> subjects) {
    if (subjects.isEmpty()) {
        return List.of();
    }
    List<Long> subjectIds = subjects.stream().map(Subject::getId).toList();
    List<Basket> allBaskets = basketRepository.findBySubjectIds(subjectIds, Semester.getCurrentSemester());
    
    Map<Long, List<Basket>> basketsBySubjectId = allBaskets.stream()
        .collect(Collectors.groupingBy(basket -> basket.getSubject().getId()));

    return subjects.stream()
        .map(subject -> BasketsEachSubject.from(
            subject,
            basketsBySubjectId.getOrDefault(subject.getId(), Collections.emptyList())
        ))
        .toList();
}
```

| 항목 | 기존 | 개선 후 |
| --- | --- | --- |
| **과목 80개일 때 쿼리 수** | 81번 (1 + 80) | **2번** (1 + 1) |
| **시간복잡도** | O(N) DB 호출 | O(1) DB 호출 + O(N) 메모리 그루핑 |

**기존 기능 영향 여부 (없다고 추측)**
* `findBasketsByCondition()`의 반환 타입(`BasketsResponse`)은 동일합니다.
* 과목이 0개인 경우 `List.of()`를 반환하여 빈 리스트 처리가 유지됩니다.
* Basket이 없는 과목은 `getOrDefault`를 통해 빈 리스트가 전달되어, 기존과 동일하게 `totalCount = 0`으로 처리됩니다.
* 단건 과목 조회(`getEachSubjectBaskets`)는 기존 `findBySubjectId`를 그대로 사용하므로 변경 없습니다.

---

### 2. OkHttpClient의 ConnectionPool 미재사용 문제

#### 문제
`AuthService.login()`에서 로그인할 때마다 `new OkHttpClient().newBuilder()`로 완전히 새로운 인스턴스를 생성하고 있었습니다.

```java
// 기존 코드 — AuthService.login()
OkHttpClient client = new OkHttpClient().newBuilder()
    .cookieJar(new JavaNetCookieJar(cookieManager))
    .build();
```

`new OkHttpClient()`는 내부적으로 새 ConnectionPool과 Dispatcher(스레드풀)를 생성합니다. 로그인 요청이 올 때마다 스레드와 커넥션 풀이 새로 생성되고 폐기되는 구조라, 동시 로그인 사용자가 많아질 경우 불필요한 자원이 누적됩니다.

Reference 1: https://square.github.io/okhttp/5.x/okhttp/okhttp3/-ok-http-client/index.html
Reference 2: https://square.github.io/okhttp/3.x/okhttp/index.html?okhttp3/OkHttpClient.html#:~:text=OkHttp%20performs%20best%20when%20you,newCall(request).execute();

#### 개선 방식
앱 전체에서 하나의 공용 OkHttpClient를 두고, 로그인 시에는 `sharedClient.newBuilder()`로 CookieJar만 교체한 파생 클라이언트를 생성하도록 변경했습니다.

```java
@Service
@RequiredArgsConstructor
public class AuthService {

    private final LoginProperties properties;
    private final OkHttpClient sharedClient = new OkHttpClient(); // 공용 클라이언트

    public OkHttpClient login(LoginRequest loginRequest) {
        // ...
        OkHttpClient client = sharedClient.newBuilder()
            .cookieJar(new JavaNetCookieJar(cookieManager))
            .build();
        // ...
    }
}
```

| 항목 | 기존 | 개선 후 |
| --- | --- | --- |
| **ConnectionPool** | 로그인마다 새로 생성 | **앱 전체 1개 공유** |
| **Dispatcher** | 로그인마다 새로 생성 | **앱 전체 1개 공유** |
| **CookieJar** | 로그인마다 새로 생성 | 로그인마다 새로 생성 (유지) |
| **TCP 연결 재사용** | 불가능 | **동일 호스트 연결 재사용 가능** |

**기존 기능 영향 여부(없음 추청)**
* 부모 클라이언트의 자원을 참조하면서 CookieJar만 새로 설정되므로 세션 간 쿠키 격리는 기존처럼 안전하게 유지됩니다.
* `sharedClient`는 인라인으로 초기화되어 DI 생성자 파라미터에 영향을 주지 않습니다.

---

### 3. SSE 로그 레벨 조정 및 SseService 중복 stream 제거

#### 문제 및 개선
**A. 로그 레벨 조정**
`SseEmitterStorage.add()`에서 새 연결마다 `log.info()`를 남기고 있어, 접속자가 많아질 경우 디스크 I/O 부담과 가독성 저하가 우려되었습니다.
* **개선:** 기존 timeout/error 로그와 레벨을 맞추기 위해 `log.info` → `log.debug`로 변경했습니다.

Reference 3: https://logging.apache.org/log4j/2.x/manual/async.html
Reference 4: https://www.ibm.com/docs/en/ukofc/3.1.0?topic=server-apache-log4j2-configuration

**B. 중복 stream 변환 제거**
`SseEmitterStorage.getUserTokens()`가 이미 `stream().toList()`를 수행하여 새 List를 반환하는데, 호출부인 `SseService`에서 불필요하게 한 번 더 변환하고 있었습니다.
* **개선:** 중복 변환을 제거하고 반환값을 그대로 사용하도록 수정했습니다.

```java
// 개선된 코드 — SseService
public List<String> getConnectedTokens() {
    return sseEmitterStorage.getUserTokens(); // 중복된 .stream().toList() 제거
}
```

---

### 변경 파일 요약

| 파일 | 변경 내용 |
| --- | --- |
| `BasketRepository.java` | `findBySubjectIds()` 배치 조회 메서드 추가 |
| `BasketService.java` | N+1 루프 → 배치 조회 + groupingBy로 로직 변경 |
| `AuthService.java` | 공용 `OkHttpClient` 필드 추가 및 `sharedClient.newBuilder()` 사용 |
| `SseEmitterStorage.java` | 연결 추가 로그 레벨 변경 (`info` → `debug`) |
| `SseService.java` | `getConnectedTokens()` 중복 `stream().toList()` 제거 |

---

### 리뷰 포인트
1. **IN 절 사이즈:** `findBySubjectIds()`의 IN 절에 들어가는 과목 ID가 수천 건 이상일 경우 DB 벤더별 제한에 걸릴 수 있습니다. 현재는 Specification 조건 기반이라 대량 조회가 발생할 가능성이 낮다고 판단했습니다. 혹시 대량 조회 시나리오가 예상되신다면 chunk 분할을 추가하는 것이 좋다고 생각합니다.
2. **OkHttpClient 관리 위치:** `sharedClient`를 `AuthService` 내부 필드로 두었습니다. 현재는 이곳에서만 사용 중이나, 추후 다른 서비스에서도 OkHttp를 사용하게 된다면 `@Bean`으로 분리하여 Config에서 관리하는 것이 좋을지 방향성을 기반으로 작업하시는 것을 추천합니다.
3. 전반적인 코멘트 환영합니다!