### PR TITLE
[TSK-59] 핀과목 크롤링 방식을 Grace Period으로 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/config/ExternalPreInvoker.java
+++ b/src/main/java/kr/allcll/backend/config/ExternalPreInvoker.java
@@ -1,6 +1,7 @@
 package kr.allcll.backend.config;
 
 import kr.allcll.backend.client.ExternalService;
+import kr.allcll.backend.support.sse.SseEmitterStorage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class ExternalPreInvoker {
 
     private final ExternalService externalService;
+    private final SseEmitterStorage sseEmitterStorage;
 
     @Scheduled(fixedDelay = 1000 * 10)
     void sendPinnedSubjectsToExternal() {
@@ -22,5 +24,15 @@ public class ExternalPreInvoker {
             throw e;
         }
         log.info("[ExternalPreInvoker] 핀 과목 전달 완료");
+    }
+
+    @Scheduled(fixedDelay = 1000 * 60)
+    void cleanupExpiredSseActiveTimes() {
+        try {
+            sseEmitterStorage.cleanupExpiredActiveTimes();
+            log.debug("[ExternalPreInvoker] SSE 활성 시각 정리 완료");
+        } catch (Exception e) {
+            log.error("[ExternalPreInvoker] SSE 활성 시각 정리 중 오류 발생", e);
+        }
     }
 }

--- a/src/main/java/kr/allcll/backend/support/sse/SseConnection.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseConnection.java
@@ -1,0 +1,39 @@
+package kr.allcll.backend.support.sse;
+
+import java.time.LocalDateTime;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+final class SseConnection {
+
+    private SseEmitter emitter;
+    private final LocalDateTime lastActiveAt;
+
+    SseConnection(SseEmitter emitter, LocalDateTime lastActiveAt) {
+        this.emitter = emitter;
+        this.lastActiveAt = lastActiveAt;
+    }
+
+    static SseConnection of(SseEmitter emitter) {
+        return new SseConnection(emitter, LocalDateTime.now());
+    }
+
+    SseEmitter getEmitter() {
+        return emitter;
+    }
+
+    boolean isConnected() {
+        return emitter != null;
+    }
+
+    boolean isExpired(LocalDateTime threshold) {
+        return lastActiveAt.isBefore(threshold);
+    }
+
+    boolean shouldCleanup(LocalDateTime threshold) {
+        return isExpired(threshold) && !isConnected();
+    }
+
+    void disconnect() {
+        this.emitter = null;
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/sse/SseEmitterStorage.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseEmitterStorage.java
@@ -1,5 +1,7 @@
 package kr.allcll.backend.support.sse;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -12,20 +14,29 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Component
 public class SseEmitterStorage {
 
+    private static final Duration GRACE_PERIOD = Duration.ofSeconds(30);
+
     /*
         ExecutorService로 변경이 필요할 수 있습니다.
      */
     private final Map<String, SseEmitter> emitters;
 
     /*
+        SSE 연결이 끊긴 후에도 일정 시간 동안 크롤링 대상으로 유지하기 위한 마지막 활성 시각
+     */
+    private final Map<String, LocalDateTime> lastActiveTimes;
+
+    /*
         동시성 문제로 자료구조 변경이 필요할 수 있습니다.
      */
     public SseEmitterStorage() {
         this.emitters = new ConcurrentHashMap<>();
+        this.lastActiveTimes = new ConcurrentHashMap<>();
     }
 
     public void add(String token, SseEmitter sseEmitter) {
         emitters.put(token, sseEmitter);
+        lastActiveTimes.put(token, LocalDateTime.now());
         log.info("[SSE] 새로운 연결이 추가되었습니다. 현재 연결 수: {}", emitters.size());
         sseEmitter.onTimeout(() -> {
             emitters.remove(token);
@@ -53,7 +64,36 @@ public class SseEmitterStorage {
     }
 
     public List<String> getUserTokens() {
-        return emitters.keySet().stream().toList();
+        return getUserTokensWithinGracePeriod();
+    }
+
+    /**
+     * Grace Period 내에 활성화된 적이 있는 사용자 토큰 목록을 반환합니다.
+     * 현재 연결된 사용자와 최근 GRACE_PERIOD 이내에 연결이 끊긴 사용자를 포함합니다.
+     */
+    private List<String> getUserTokensWithinGracePeriod() {
+        LocalDateTime gracePeriodThreshold = LocalDateTime.now().minus(GRACE_PERIOD);
+
+        return lastActiveTimes.entrySet().stream()
+            .filter(entry -> entry.getValue().isAfter(gracePeriodThreshold))
+            .map(Map.Entry::getKey)
+            .toList();
+    }
+
+    /**
+     * Grace Period를 초과한 오래된 lastActiveTimes 엔트리를 정리합니다.
+     * 주기적으로 호출되어 메모리 누수를 방지합니다.
+     */
+    public void cleanupExpiredActiveTimes() {
+        LocalDateTime cleanupThreshold = LocalDateTime.now().minus(GRACE_PERIOD);
+
+        lastActiveTimes.entrySet().removeIf(entry -> {
+            boolean shouldRemove = entry.getValue().isBefore(cleanupThreshold);
+            if (shouldRemove) {
+                log.debug("[SSE] Grace Period 초과로 토큰 정리: {}", entry.getKey());
+            }
+            return shouldRemove;
+        });
     }
 
     public int getActiveConnectionCount() {

--- a/src/main/java/kr/allcll/backend/support/sse/SseEmitterStorage.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseEmitterStorage.java
@@ -29,17 +29,18 @@ public class SseEmitterStorage {
         log.info("[SSE] 새로운 연결이 추가되었습니다. 현재 연결 수: {}", getActiveConnectionCount());
 
         sseEmitter.onTimeout(() -> {
-            disconnectToken(token);
+            disconnectToken(token, sseEmitter);
             log.debug("[SSE] 연결이 타임아웃으로 종료되었습니다. 현재 연결 수: {}", getActiveConnectionCount());
         });
-        sseEmitter.onError(e -> disconnectToken(token));
-        sseEmitter.onCompletion(() -> disconnectToken(token));
+        sseEmitter.onError(e -> disconnectToken(token, sseEmitter));
+        sseEmitter.onCompletion(() -> disconnectToken(token, sseEmitter));
     }
 
-    private void disconnectToken(String token) {
+    private void disconnectToken(String token, SseEmitter sseEmitter) {
         SseConnection connection = connections.get(token);
-        if (connection != null) {
+        if (connection != null && connection.getEmitter() == sseEmitter) {
             connection.disconnect();
+            connections.remove(token);
         }
     }
 

--- a/src/test/java/kr/allcll/backend/support/sse/SseEmitterStorageTest.java
+++ b/src/test/java/kr/allcll/backend/support/sse/SseEmitterStorageTest.java
@@ -72,7 +72,7 @@ class SseEmitterStorageTest {
         // when
         storage.cleanupExpiredActiveTimes();
 
-        // then - Grace Period 내이므로 여전히 존재
+        // then
         List<String> tokens = storage.getUserTokens();
         assertThat(tokens).contains(token);
     }
@@ -113,32 +113,30 @@ class SseEmitterStorageTest {
         assertThat(storage.getEmitter("non-existent")).isEmpty();
     }
 
-    @DisplayName("[버그 재현] 30초 이상 유지되는 정상 SSE 연결이 비활성으로 처리된다")
+    @DisplayName("30초 이상 유지되는 정상 SSE 연결이 활성으로 처리되어야 한다")
     @Test
     void getUserTokens_shouldNotExcludeLongLivedActiveConnections() throws Exception {
-        // given - SSE 연결을 생성하고 추가
+        // given
         String token = "long-lived-connection";
-        SseEmitter emitter = new SseEmitter(60000L); // 60초 타임아웃
+        SseEmitter emitter = new SseEmitter(60000L);
         storage.add(token, emitter);
 
-        // when - 초기 상태 확인 (연결이 활성 상태여야 함)
-        assertThat(storage.getUserTokens()).contains(token);
-        assertThat(storage.getActiveConnectionCount()).isEqualTo(1);
-        assertThat(storage.getEmitter(token)).isPresent();
+        // when
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(storage.getUserTokens()).contains(token);
+            softly.assertThat(storage.getActiveConnectionCount()).isEqualTo(1);
+            softly.assertThat(storage.getEmitter(token)).isPresent();
+        });
 
-        // lastActiveTime을 31초 전으로 설정 (리플렉션 사용)
         setLastActiveTime(token, LocalDateTime.now().minusSeconds(31));
 
-        // then - 31초 후에도 연결이 여전히 살아있음 (emitters에 존재)
+        // then
         assertThat(storage.getActiveConnectionCount()).isEqualTo(1);
         assertThat(storage.getEmitter(token)).isPresent();
 
-        // 하지만 getUserTokens()는 해당 토큰을 반환하지 않음 (버그!)
         List<String> activeTokens = storage.getUserTokens();
 
-        // 현재 구현으로는 이 assertion이 실패함 - 버그 재현!
         assertThat(activeTokens)
-            .as("30초 이상 유지되는 정상 SSE 연결도 활성 목록에 포함되어야 함")
             .contains(token);
     }
 
@@ -156,8 +154,6 @@ class SseEmitterStorageTest {
 
         // oldToken의 lastActiveTime을 31초 전으로 설정
         setLastActiveTime(oldToken, LocalDateTime.now().minusSeconds(31));
-
-        // 새로운 연결 추가
         storage.add(newToken, newEmitter);
 
         // when
@@ -165,11 +161,9 @@ class SseEmitterStorageTest {
         int activeCount = storage.getActiveConnectionCount();
 
         // then
-        assertThat(activeCount).isEqualTo(2); // 두 연결 모두 살아있음
+        assertThat(activeCount).isEqualTo(2);
 
-        // 하지만 getUserTokens는 최근 30초 이내 연결만 반환 (버그!)
         assertThat(activeTokens)
-            .as("emitters에 존재하는 모든 연결은 getUserTokens에 포함되어야 함")
             .containsExactlyInAnyOrder(oldToken, newToken);
     }
 
@@ -181,8 +175,7 @@ class SseEmitterStorageTest {
         SseEmitter emitter = new SseEmitter();
         storage.add(token, emitter);
 
-        // when - 연결 종료 시뮬레이션 (onCompletion 콜백을 수동으로 실행)
-        // 실제 HTTP 연결 없는 테스트 환경에서는 complete() 호출이 콜백을 트리거하지 않음
+        // when
         removeFromEmitters(token);
 
         SoftAssertions.assertSoftly(softly -> {
@@ -193,7 +186,6 @@ class SseEmitterStorageTest {
 
         setLastActiveTime(token, LocalDateTime.now().minusSeconds(31));
 
-        // 31초 후에는 제외됨
         assertThat(storage.getUserTokens()).doesNotContain(token);
     }
 
@@ -211,7 +203,7 @@ class SseEmitterStorageTest {
         SseEmitter expiredEmitter = new SseEmitter();
         storage.add(expiredToken, expiredEmitter);
         removeFromEmitters(expiredToken);
-        setLastActiveTime(expiredToken, LocalDateTime.now().minusSeconds(31));  // 31초 전으로 설정
+        setLastActiveTime(expiredToken, LocalDateTime.now().minusSeconds(31));
 
         // when
         storage.cleanupExpiredActiveTimes();
@@ -243,6 +235,10 @@ class SseEmitterStorageTest {
         }
     }
 
+    /**
+     - 연결 종료 시뮬레이션 (onCompletion 콜백을 수동으로 실행)
+     - 실제 HTTP 연결 없는 테스트 환경에서는 complete() 호출이 콜백을 트리거하지 않음
+     **/
     @SuppressWarnings("unchecked")
     private void removeFromEmitters(String token) throws Exception {
         Field connectionsField = SseEmitterStorage.class.getDeclaredField("connections");

--- a/src/test/java/kr/allcll/backend/support/sse/SseEmitterStorageTest.java
+++ b/src/test/java/kr/allcll/backend/support/sse/SseEmitterStorageTest.java
@@ -1,0 +1,109 @@
+package kr.allcll.backend.support.sse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class SseEmitterStorageTest {
+
+    private SseEmitterStorage storage;
+
+    @BeforeEach
+    void setUp() {
+        storage = new SseEmitterStorage();
+    }
+
+    @DisplayName("SSE 연결 추가 시 getUserTokens에서 토큰이 조회된다")
+    @Test
+    void add_shouldRecordLastActiveTime() {
+        // given
+        String token = "test-token";
+        SseEmitter emitter = new SseEmitter();
+
+        // when
+        storage.add(token, emitter);
+
+        // then
+        List<String> tokens = storage.getUserTokens();
+        assertThat(tokens).contains(token);
+    }
+
+    @DisplayName("여러 연결이 있을 때 모두 토큰으로 조회된다")
+    @Test
+    void getUserTokens_shouldReturnAllTokens() {
+        // given
+        String token1 = "token1";
+        String token2 = "token2";
+        String token3 = "token3";
+
+        SseEmitter emitter1 = new SseEmitter();
+        SseEmitter emitter2 = new SseEmitter();
+        SseEmitter emitter3 = new SseEmitter();
+
+        storage.add(token1, emitter1);
+        storage.add(token2, emitter2);
+        storage.add(token3, emitter3);
+
+        // when
+        List<String> tokens = storage.getUserTokens();
+
+        // then
+        assertThat(tokens).containsExactlyInAnyOrder(token1, token2, token3);
+    }
+
+    @DisplayName("정리 작업 실행 시 최근 토큰은 제거되지 않는다")
+    @Test
+    void cleanupExpiredActiveTimes_shouldNotRemoveRecentTokens() {
+        // given
+        String token = "test-token";
+        SseEmitter emitter = new SseEmitter();
+        storage.add(token, emitter);
+
+        // when
+        storage.cleanupExpiredActiveTimes();
+
+        // then - Grace Period 내이므로 여전히 존재
+        List<String> tokens = storage.getUserTokens();
+        assertThat(tokens).contains(token);
+    }
+
+    @DisplayName("활성 연결 수는 실제 emitters 수와 동일하다")
+    @Test
+    void getActiveConnectionCount_shouldReturnEmittersSize() {
+        // given
+        String token1 = "token1";
+        String token2 = "token2";
+
+        SseEmitter emitter1 = new SseEmitter();
+        SseEmitter emitter2 = new SseEmitter();
+
+        storage.add(token1, emitter1);
+        storage.add(token2, emitter2);
+
+        // when & then
+        assertThat(storage.getActiveConnectionCount()).isEqualTo(2);
+    }
+
+    @DisplayName("Emitter를 정상적으로 가져올 수 있다")
+    @Test
+    void getEmitter_shouldReturnCorrectEmitter() {
+        // given
+        String token = "test-token";
+        SseEmitter emitter = new SseEmitter();
+        storage.add(token, emitter);
+
+        // when & then
+        assertThat(storage.getEmitter(token)).isPresent();
+    }
+
+    @DisplayName("존재하지 않는 토큰으로 조회 시 빈 Optional을 반환한다")
+    @Test
+    void getEmitter_shouldReturnEmptyForNonExistentToken() {
+        // when & then
+        assertThat(storage.getEmitter("non-existent")).isEmpty();
+    }
+}


### PR DESCRIPTION
# Grace Period 기반 SSE 크롤링 대상 유지 로직 구현


### 기존 동작 메커니즘 (AS-IS)

```
T+0초:  사용자가 과목에 핀 고정 (DB 저장), SSE 연결 활성화
T+5초:  탭 전환 또는 일시적 연결 끊김
         → onCompletion 호출
         → emitters에서 제거
T+10초: ExternalPreInvoker 실행 (크롤링 대상 선정)
         → sseEmitterStorage.getUserTokens() 호출
         → 해당 토큰이 emitters에 없음
         → 핀 크롤링 대상에서 제외
```

**결과**: 사용자는 핀을 고정했지만 크롤링이 안 되어 알림을 받지 못함

### 새로운 동작 메커니즘 (TO-BE)

```
T+0초:  SSE 연결
         → emitters에 추가
         → lastActiveTimes에 현재시각 기록

T+5초:  탭 전환
         → onCompletion
         → emitters에서만 제거 (lastActiveTimes는 유지)

T+10초: 크롤링 대상 선정
         → lastActiveTimes에서 Grace Period(30초) 내 토큰 조회
         → 있음
         → 크롤링 O

T+15초: 사용자 복귀
         → 브라우저 자동 재연결
         → 새 SseEmitter 생성 및 lastActiveTimes 갱신

T+40초: cleanup 실행
         → Grace Period 초과한 토큰 정리
```

## 구현 내용

### 1. SseEmitterStorage 개선

**새로운 필드 추가**
```java
private static final Duration GRACE_PERIOD = Duration.ofSeconds(30);
private final Map<String, LocalDateTime> lastActiveTimes;
```

**주요 메서드**
- `getUserTokens()`: Grace Period 내 활성화된 토큰 반환 (기존 인터페이스 유지)
- `getUserTokensWithinGracePeriod()`: Grace Period 로직 구현
- `cleanupExpiredActiveTimes()`: 오래된 엔트리 정리

### 2. ExternalPreInvoker 개선

**주기적 정리 스케줄러 추가**
```java
@Scheduled(fixedDelay = 1000 * 60)  // 1분마다
void cleanupExpiredSseActiveTimes()
```

메모리 누수 방지를 위한 주기적 정리 작업

### 3. 테스트 코드 작성

`SseEmitterStorageTest.java` - 6개의 단위 테스트
- SSE 연결 추가 및 토큰 조회 검증
- 여러 연결 관리 검증
- 정리 작업 동작 검증

## 기대 효과

1. **핀 알림 누락 방지**: 탭 전환 등 일시적 연결 끊김 시에도 크롤링 대상 유지
2. **사용자 경험 개선**: 안정적인 실시간 알림 수신
3. **시스템 안정성**: 죽은 객체를 즉시 제거하여 메모리/예외 안전성 확보

