### PR TITLE
[TSK-56-145] 교선 학점에 포함되지 않는 교양 카테고리 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/check/excel/CompletedCourseDto.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/excel/CompletedCourseDto.java
@@ -81,6 +81,7 @@ public record CompletedCourseDto(
             case "균필" -> CategoryType.BALANCE_REQUIRED;
             case "기교", "기필" -> CategoryType.ACADEMIC_BASIC;
             case "교선", "교선1", "교선2" -> CategoryType.GENERAL_ELECTIVE;
+            case "교양" -> CategoryType.GENERAL;
             case "전필", "복필" -> CategoryType.MAJOR_REQUIRED;
             case "전선", "복선" -> CategoryType.MAJOR_ELECTIVE;
             case "전기" -> CategoryType.MAJOR_BASIC;

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/CategoryType.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/CategoryType.java
@@ -8,6 +8,7 @@ public enum CategoryType { // 이수구분
     BALANCE_REQUIRED,      // 균형교양
     ACADEMIC_BASIC,        // 학문기초교양
     GENERAL_ELECTIVE,      // 교양선택
+    GENERAL,               // 교양
     MAJOR_REQUIRED,        // 전공필수
     MAJOR_ELECTIVE,        // 전공선택
     MAJOR_BASIC,           // 전공기초


### PR DESCRIPTION
## 이슈
사용자 기이수 과목 조회 시, 이수구분에 null로 응답이 오는 이슈가 있었습니다.

기이수 성적표에는 교선 이외에도 [교양]이라는 카테고리가 존재합니다.

> [교선]으로 인정이 안 되는 교과목인 경우, [교양]으로 표시됩니다.
> 즉, [교선] 이수구분에 포함되지 않고 [전체 이수 학점]에는 포함되는 것이죠.

원인은 해당 [교양] 카테고리를 의미하는 ENUM이 존재하지 않아, 매핑에 실패하여 null로 들어오는 것이었습니다.

## 작업 내용
[교양] 카테고리를 의미하는 `GENERAL` ENUM을 새롭게 추가하고,
사용자 기이수 성적표 이수구분에 "교양"으로 들어오게 되면 `GENERAL`로 매핑해주는 로직을 추가하였습니다.

## 검증
[현재 오류 시나리오 재현 - 19학번 현우님 기이수 성적표]
<img width="720" height="374" alt="image" src="https://github.com/user-attachments/assets/53c65fd6-f8e4-4534-a156-59070763c699" />

[개선 후 응답 ]
<img width="720" height="378" alt="image" src="https://github.com/user-attachments/assets/9d22f44d-2ccb-4770-a5ef-ef848cf26afc" />
null로 들어오지 않고 `GENERAL`로 잘 매핑되어 반환되는 것을 확인하였습니다!

## 고민 지점과 리뷰 포인트
- 다른 엣지 케이스가 있을까용?

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->