### PR TITLE
[TSK-56-144] 졸업인증 재분석 시 분석일자(createdAt) 미갱신 문제

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapper.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapper.java
@@ -114,7 +114,7 @@ public class GraduationCheckResponseMapper {
 
         return new GraduationCheckResponse(
             userId,
-            check.getCreatedAt(),
+            check.getUpdatedAt(),
             adjustedGraduatable,
             summary,
             adjustedCategories,

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/dto/GraduationCheckResponse.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/dto/GraduationCheckResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public record GraduationCheckResponse(
     Long checkId,
-    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
     Boolean isGraduatable,
     GraduationSummary summary,
     List<GraduationCategory> categories,

--- a/src/main/java/kr/allcll/backend/support/entity/BaseEntity.java
+++ b/src/main/java/kr/allcll/backend/support/entity/BaseEntity.java
@@ -3,13 +3,17 @@ package kr.allcll.backend.support.entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.web.bind.annotation.GetMapping;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(value = {BaseEntityListener.class})
 public abstract class BaseEntity {
 
     protected String semesterAt;
     protected LocalDateTime createdAt;
+    protected LocalDateTime updatedAt;
     protected LocalDateTime deletedAt;
     protected boolean isDeleted;
 
@@ -25,11 +29,7 @@ public abstract class BaseEntity {
         }
     }
 
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public boolean isDeleted() {
-        return isDeleted;
+    void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
     }
 }

--- a/src/main/java/kr/allcll/backend/support/entity/BaseEntityListener.java
+++ b/src/main/java/kr/allcll/backend/support/entity/BaseEntityListener.java
@@ -1,6 +1,7 @@
 package kr.allcll.backend.support.entity;
 
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import kr.allcll.backend.support.semester.Semester;
@@ -11,6 +12,12 @@ public class BaseEntityListener {
     public void initialize(BaseEntity entity) {
         entity.setSemesterAtIfAbsent(getCurrentSemester());
         entity.setCreatedAtIfAbsent(LocalDateTime.now());
+        entity.setUpdatedAt(LocalDateTime.now());
+    }
+
+    @PreUpdate
+    public void updateTimestamp(BaseEntity entity) {
+        entity.setUpdatedAt(LocalDateTime.now());
     }
 
     private String getCurrentSemester() {


### PR DESCRIPTION
## Summary
  졸업인증 재분석 시 분석 날짜가 갱신되도록 개선

  ## 변경 사항
  - BaseEntity에 `updatedAt` 필드 추가
  - JPA `@PreUpdate` 리스너로 엔티티 수정 시 자동 갱신
  - 응답 DTO에서 `updatedAt` 사용

  ## 문제 상황
  재분석을 수행해도 화면에 표시되는 분석 날짜가 갱신되지 않음
  - FE는 `createdAt`을 분석 날짜로 사용 중
  - 재분석 시 엔티티는 update되지만 `createdAt`은 변경되지 않음

  ## 해결 방법
  - 최초 생성 시점(`createdAt`)과 최신 수정 시점(`updatedAt`) 분리
  - 재분석 시 `updatedAt`만 자동 갱신
  - FE에 `updatedAt`을 분석 날짜로 전달