### PR TITLE
[TSK-56-149] 고전독서인증 여부 확인 기준 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertFetcher.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertFetcher.java
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GraduationClassicsCertFetcher {
 
+    private static final int PASS_STATUS_INDEX = 0;
+
     private final LoginProperties properties;
     private final GraduationHtmlParser parser;
     private final GraduationCertDocumentFetcher documentFetcher;
@@ -33,8 +35,9 @@ public class GraduationClassicsCertFetcher {
     }
 
     private boolean parsePass(Document document) {
-        String approvalText = parser.selectClassicsPassText(document).trim();
-        return !approvalText.equals("아니오");
+        String[] passTextParts = parser.selectClassicsPassText(document);
+        String passText = passTextParts[PASS_STATUS_INDEX];
+        return !passText.equals("아니오");
     }
 
     private ClassicsCounts parseCounts(Document document) {

--- a/src/main/java/kr/allcll/backend/support/graduation/GraduationHtmlParser.java
+++ b/src/main/java/kr/allcll/backend/support/graduation/GraduationHtmlParser.java
@@ -1,5 +1,6 @@
 package kr.allcll.backend.support.graduation;
 
+import java.util.Arrays;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -16,11 +17,14 @@ public class GraduationHtmlParser {
         return document.select("span.certificate:has(button)");
     }
 
-    public String selectClassicsPassText(Document document) {
-        return document.select(
+    public String[] selectClassicsPassText(Document document) {
+        String text = document.select(
             ".b-con-box:has(h4.b-h4-tit01:contains(사용자 정보)) " +
                 "table tbody tr:has(th:contains(인증여부)) td"
         ).text();
+        return Arrays.stream(text.split("[()]", 2))
+            .map(String::trim)
+            .toArray(String[]::new);
     }
 
     public Element selectClassicsDetailTable(Document document) {

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertFetcherTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertFetcherTest.java
@@ -1,0 +1,255 @@
+package kr.allcll.backend.domain.graduation.check.cert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import kr.allcll.backend.client.LoginProperties;
+import kr.allcll.backend.domain.graduation.check.cert.dto.ClassicsResult;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.backend.support.graduation.GraduationHtmlParser;
+import okhttp3.OkHttpClient;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GraduationClassicsCertFetcherTest {
+
+    @Mock
+    private LoginProperties properties;
+
+    @Mock
+    private GraduationHtmlParser parser;
+
+    @Mock
+    private GraduationCertDocumentFetcher documentFetcher;
+
+    @InjectMocks
+    private GraduationClassicsCertFetcher classicsCertFetcher;
+
+    private OkHttpClient client;
+    private Document mockDocument;
+
+    @BeforeEach
+    void setUp() {
+        client = new OkHttpClient();
+        mockDocument = Jsoup.parse("<html><body></body></html>");
+    }
+
+    @Test
+    @DisplayName("고전인증 합격 시 true를 반환한다")
+    void fetchClassics_pass() {
+        // given
+        given(properties.studentInfoPageUrl()).willReturn("http://test.com");
+        given(documentFetcher.fetch(any(OkHttpClient.class), eq("http://test.com"),
+            eq(AllcllErrorCode.CLASSIC_INFO_FETCH_FAIL)))
+            .willReturn(mockDocument);
+        given(parser.selectClassicsPassText(mockDocument)).willReturn(new String[]{"예", "2024-01-01"});
+
+        Document detailDoc = createMockClassicsDetailDocument(2, 2, 2, 2);
+        given(parser.selectClassicsDetailTable(mockDocument)).willReturn(detailDoc.selectFirst("table"));
+
+        // when
+        ClassicsResult result = classicsCertFetcher.fetchClassics(client);
+
+        // then
+        assertThat(result.passed()).isTrue();
+        assertThat(result.counts().myCountWestern()).isEqualTo(2);
+        assertThat(result.counts().myCountEastern()).isEqualTo(2);
+        assertThat(result.counts().myCountEasternAndWestern()).isEqualTo(2);
+        assertThat(result.counts().myCountScience()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("고전인증 불합격 시 false를 반환한다")
+    void fetchClassics_fail() {
+        // given
+        given(properties.studentInfoPageUrl()).willReturn("http://test.com");
+        given(documentFetcher.fetch(any(OkHttpClient.class), eq("http://test.com"),
+            eq(AllcllErrorCode.CLASSIC_INFO_FETCH_FAIL)))
+            .willReturn(mockDocument);
+        given(parser.selectClassicsPassText(mockDocument)).willReturn(new String[]{"아니오", ""});
+
+        Document detailDoc = createMockClassicsDetailDocument(1, 1, 1, 1);
+        given(parser.selectClassicsDetailTable(mockDocument)).willReturn(detailDoc.selectFirst("table"));
+
+        // when
+        ClassicsResult result = classicsCertFetcher.fetchClassics(client);
+
+        // then
+        assertThat(result.passed()).isFalse();
+        assertThat(result.counts().myCountWestern()).isEqualTo(1);
+        assertThat(result.counts().myCountEastern()).isEqualTo(1);
+        assertThat(result.counts().myCountEasternAndWestern()).isEqualTo(1);
+        assertThat(result.counts().myCountScience()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("고전 영역별 이수 권수가 0인 경우 0을 반환한다")
+    void fetchClassics_noBooksCompleted() {
+        // given
+        given(properties.studentInfoPageUrl()).willReturn("http://test.com");
+        given(documentFetcher.fetch(any(OkHttpClient.class), eq("http://test.com"),
+            eq(AllcllErrorCode.CLASSIC_INFO_FETCH_FAIL)))
+            .willReturn(mockDocument);
+        given(parser.selectClassicsPassText(mockDocument)).willReturn(new String[]{"아니오", ""});
+
+        Document detailDoc = createMockClassicsDetailDocument(0, 0, 0, 0);
+        given(parser.selectClassicsDetailTable(mockDocument)).willReturn(detailDoc.selectFirst("table"));
+
+        // when
+        ClassicsResult result = classicsCertFetcher.fetchClassics(client);
+
+        // then
+        assertThat(result.passed()).isFalse();
+        assertThat(result.counts().myCountWestern()).isEqualTo(0);
+        assertThat(result.counts().myCountEastern()).isEqualTo(0);
+        assertThat(result.counts().myCountEasternAndWestern()).isEqualTo(0);
+        assertThat(result.counts().myCountScience()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("고전특강 대상자인 경우에도 불합격으로 처리한다")
+    void fetchClassics_failWithClassicsLectureTarget() {
+        // given
+        given(properties.studentInfoPageUrl()).willReturn("http://test.com");
+        given(documentFetcher.fetch(any(OkHttpClient.class), eq("http://test.com"),
+            eq(AllcllErrorCode.CLASSIC_INFO_FETCH_FAIL)))
+            .willReturn(mockDocument);
+        given(parser.selectClassicsPassText(mockDocument)).willReturn(new String[]{"아니오", "고전특강 대상자"});
+
+        Document detailDoc = createMockClassicsDetailDocument(1, 1, 1, 1);
+        given(parser.selectClassicsDetailTable(mockDocument)).willReturn(detailDoc.selectFirst("table"));
+
+        // when
+        ClassicsResult result = classicsCertFetcher.fetchClassics(client);
+
+        // then
+        assertThat(result.passed()).isFalse();
+        assertThat(result.counts().myCountWestern()).isEqualTo(1);
+        assertThat(result.counts().myCountEastern()).isEqualTo(1);
+        assertThat(result.counts().myCountEasternAndWestern()).isEqualTo(1);
+        assertThat(result.counts().myCountScience()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("고전 상세 테이블이 null인 경우 예외를 발생시킨다")
+    void fetchClassics_throwsWhenTableIsNull() {
+        // given
+        given(properties.studentInfoPageUrl()).willReturn("http://test.com");
+        given(documentFetcher.fetch(any(OkHttpClient.class), eq("http://test.com"),
+            eq(AllcllErrorCode.CLASSIC_INFO_FETCH_FAIL)))
+            .willReturn(mockDocument);
+        given(parser.selectClassicsPassText(mockDocument)).willReturn(new String[]{"아니오", ""});
+        given(parser.selectClassicsDetailTable(mockDocument)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> classicsCertFetcher.fetchClassics(client))
+            .isInstanceOf(AllcllException.class)
+            .hasMessageContaining(AllcllErrorCode.CLASSIC_DETAIL_INFO_FETCH_FAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("공백이 포함된 인증 텍스트를 정상적으로 처리한다")
+    void fetchClassics_withWhitespace() {
+        // given
+        given(properties.studentInfoPageUrl()).willReturn("http://test.com");
+        given(documentFetcher.fetch(any(OkHttpClient.class), eq("http://test.com"),
+            eq(AllcllErrorCode.CLASSIC_INFO_FETCH_FAIL)))
+            .willReturn(mockDocument);
+        // 공백이 포함된 텍스트 (trim 전제)
+        given(parser.selectClassicsPassText(mockDocument)).willReturn(new String[]{"  예  ", "2024-01-01"});
+
+        Document detailDoc = createMockClassicsDetailDocument(2, 2, 2, 2);
+        given(parser.selectClassicsDetailTable(mockDocument)).willReturn(detailDoc.selectFirst("table"));
+
+        // when
+        ClassicsResult result = classicsCertFetcher.fetchClassics(client);
+
+        // then
+        assertThat(result.passed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("숫자 파싱 실패 시 0을 반환한다")
+    void fetchClassics_invalidNumberFormat() {
+        // given
+        given(properties.studentInfoPageUrl()).willReturn("http://test.com");
+        given(documentFetcher.fetch(any(OkHttpClient.class), eq("http://test.com"),
+            eq(AllcllErrorCode.CLASSIC_INFO_FETCH_FAIL)))
+            .willReturn(mockDocument);
+        given(parser.selectClassicsPassText(mockDocument)).willReturn(new String[]{"아니오", ""});
+
+        // 잘못된 숫자 형식 포함
+        Document detailDoc = createMockClassicsDetailDocumentWithInvalidNumber();
+        given(parser.selectClassicsDetailTable(mockDocument)).willReturn(detailDoc.selectFirst("table"));
+
+        // when
+        ClassicsResult result = classicsCertFetcher.fetchClassics(client);
+
+        // then
+        assertThat(result.counts().myCountWestern()).isEqualTo(0);
+    }
+
+    private Document createMockClassicsDetailDocument(int western, int eastern, int literature, int science) {
+        String html = String.format("""
+            <table class="b-board-table">
+                <tbody>
+                    <tr>
+                        <th>서양의 역사와 사상</th>
+                        <td>%d권</td>
+                    </tr>
+                    <tr>
+                        <th>동양의 역사와 사상</th>
+                        <td>%d권</td>
+                    </tr>
+                    <tr>
+                        <th>동·서양의 문학</th>
+                        <td>%d권</td>
+                    </tr>
+                    <tr>
+                        <th>과학 사상</th>
+                        <td>%d권</td>
+                    </tr>
+                </tbody>
+            </table>
+            """, western, eastern, literature, science);
+        return Jsoup.parse(html);
+    }
+
+    private Document createMockClassicsDetailDocumentWithInvalidNumber() {
+        String html = """
+            <table class="b-board-table">
+                <tbody>
+                    <tr>
+                        <th>서양의 역사와 사상</th>
+                        <td>잘못된값</td>
+                    </tr>
+                    <tr>
+                        <th>동양의 역사와 사상</th>
+                        <td>1권</td>
+                    </tr>
+                    <tr>
+                        <th>동·서양의 문학</th>
+                        <td>1권</td>
+                    </tr>
+                    <tr>
+                        <th>과학 사상</th>
+                        <td>1권</td>
+                    </tr>
+                </tbody>
+            </table>
+            """;
+        return Jsoup.parse(html);
+    }
+}


### PR DESCRIPTION
## Summary
  고전인증 텍스트 파싱 로직의 책임 소재를 명확히 하고, 향후 확장성을 고려한 구조로 개선했습니다.

  ### 주요 변경 사항
  - **파싱 책임 이관**: `GraduationHtmlParser`가 `trim()` 처리까지 담당하도록 수정
  - **확장 가능한 구조**: 고전특강 대상자 정보를 활용할 수 있도록 `String[]` 반환
  - **변수명 개선**: `approvalText`/`approveText` → `passTextParts`/`passText`로 명확화
  - **매직 넘버 제거**: 배열 인덱스를 `PASS_STATUS_INDEX` 상수로 추출
  - **테스트 추가**: `GraduationClassicsCertFetcher` 단위 테스트 작성

  ## Changes

  ### 🔧 Before
  ```java
  // GraduationHtmlParser.java
  public String selectClassicsPassText(Document document) {
      return document.select(...).text();
  }

  // GraduationClassicsCertFetcher.java
  private boolean parsePass(Document document) {
      String approvalText = parser.selectClassicsPassText(document).trim();
      return !approvalText.equals("아니오");
  }
```
  문제점:
  1. Parser가 반환한 데이터를 Fetcher에서 trim() 처리 → 책임 소재 불명확
  2. "아니오(고전특강 대상자)" 같은 추가 정보가 손실됨
  3. approvalText와 approveText 변수명이 유사해서 헷갈림
  4. 배열 인덱스 [0] 매직 넘버 사용

  ✅ After
``` java
  // GraduationHtmlParser.java
  public String[] selectClassicsPassText(Document document) {
      String text = document.select(...).text();
      return Arrays.stream(text.split("[()]", 2))
          .map(String::trim)
          .toArray(String[]::new);
  }

  // GraduationClassicsCertFetcher.java
  private static final int PASS_STATUS_INDEX = 0;

  private boolean parsePass(Document document) {
      String[] passTextParts = parser.selectClassicsPassText(document);
      String passText = passTextParts[PASS_STATUS_INDEX];
      return !passText.equals("아니오");
  }
```
  개선 효과:
  1. Parser가 파싱과 정제를 모두 책임지고, Fetcher는 비즈니스 로직에 집중
  2. 변수명으로 배열과 개별 값을 명확히 구분 (passTextParts, passText)
  3. 상수로 의미 명확화 및 유지보수성 향상
  4. 확장성 확보: 괄호 안 대상자 정보(고전특강 대상자, 초과학기생 등)를 배열로 보존

##  새로 추가된 테스트

  - ✅ 고전인증 합격 케이스
  - ✅ 고전인증 불합격 케이스
  - ✅ 고전특강 대상자("아니오(고전특강 대상자)") 불합격 처리 ← 확장성 검증
  - ✅ 이수 권수 0인 경우
  - ✅ 공백 포함 텍스트 처리
  - ✅ 상세 테이블 null 예외 처리
  - ✅ 숫자 파싱 실패 시 0 반환
