### PR TITLE
[TSK-56-151] 고전 독서 영역 별 인증 권수 만족 시, 인증 여부 보정 로직 구현

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCertResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCertResolver.java
@@ -35,7 +35,7 @@ public class GraduationCertResolver {
         List<CompletedCourse> completedCourses = completedCourseRepository.findAllByUserId(user.getId());
 
         GraduationCheckCertResult certResult = graduationCheckCertResultRepository.findByUserId(user.getId())
-            .orElse(null);
+            .orElseGet(GraduationCheckCertResult::empty);
 
         boolean englishPassed = graduationEnglishCertResolver.resolve(
             user,

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCertResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCertResolver.java
@@ -1,6 +1,5 @@
 package kr.allcll.backend.domain.graduation.check.cert;
 
-import java.util.List;
 import kr.allcll.backend.domain.graduation.certification.ClassicAltCoursePolicy;
 import kr.allcll.backend.domain.graduation.certification.GraduationCertificationAltCoursePolicy;
 import kr.allcll.backend.domain.graduation.check.cert.dto.ClassicsCounts;
@@ -17,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -35,32 +36,32 @@ public class GraduationCertResolver {
 
     public GraduationCertInfo resolve(User user, OkHttpClient client) {
         GraduationDepartmentInfo userDept = graduationDepartmentInfoRepository
-            .findByAdmissionYearAndDeptCd(user.getAdmissionYear(), user.getDeptCd())
-            .orElseThrow(() -> new AllcllException(AllcllErrorCode.DEPARTMENT_NOT_FOUND));
+                .findByAdmissionYearAndDeptCd(user.getAdmissionYear(), user.getDeptCd())
+                .orElseThrow(() -> new AllcllException(AllcllErrorCode.DEPARTMENT_NOT_FOUND));
 
         List<CompletedCourse> completedCourses = completedCourseRepository.findAllByUserId(user.getId());
 
         GraduationCheckCertResult certResult = graduationCheckCertResultRepository.findByUserId(user.getId())
-            .orElse(null);
+                .orElse(null);
 
         boolean englishPassed = resolveEnglishPassed(user, client, userDept, completedCourses, certResult);
         boolean codingPassed = resolveCodingPassed(user, client, userDept, completedCourses, certResult);
         ClassicsResult classicsResult = resolveClassics(user, client, certResult);
 
         return GraduationCertInfo.of(
-            englishPassed,
-            codingPassed,
-            classicsResult.passed(),
-            classicsResult.counts()
+                englishPassed,
+                codingPassed,
+                classicsResult.passed(),
+                classicsResult.counts()
         );
     }
 
     private boolean resolveEnglishPassed(
-        User user,
-        OkHttpClient client,
-        GraduationDepartmentInfo userDept,
-        List<CompletedCourse> completedCourses,
-        GraduationCheckCertResult certResult
+            User user,
+            OkHttpClient client,
+            GraduationDepartmentInfo userDept,
+            List<CompletedCourse> completedCourses,
+            GraduationCheckCertResult certResult
     ) {
         if (isEnglishAlreadyPassed(certResult)) {
             return true;
@@ -79,11 +80,11 @@ public class GraduationCertResolver {
     }
 
     private boolean resolveCodingPassed(
-        User user,
-        OkHttpClient client,
-        GraduationDepartmentInfo userDept,
-        List<CompletedCourse> completedCourses,
-        GraduationCheckCertResult certResult
+            User user,
+            OkHttpClient client,
+            GraduationDepartmentInfo userDept,
+            List<CompletedCourse> completedCourses,
+            GraduationCheckCertResult certResult
     ) {
         if (isCodingAlreadyPassed(certResult)) {
             return true;
@@ -102,9 +103,9 @@ public class GraduationCertResolver {
     }
 
     private ClassicsResult resolveClassics(
-        User user,
-        OkHttpClient client,
-        GraduationCheckCertResult certResult
+            User user,
+            OkHttpClient client,
+            GraduationCheckCertResult certResult
     ) {
         ClassicsCounts fallbackCounts = ClassicsCounts.fallback(certResult);
 
@@ -113,11 +114,13 @@ public class GraduationCertResolver {
         }
 
         ClassicsResult classicsResult = fetchClassicsResultFromExternal(client, fallbackCounts);
-        if (classicsResult.passed()) {
-            return classicsResult;
-        }
+        boolean isSatisfiedByCrawledResult = classicsResult.isSatisfiedByCrawledResult();
         boolean satisfiedByAltCourse = classicAltCoursePolicy.isSatisfiedByAltCourse(user);
-        return classicsResult.passedWith(satisfiedByAltCourse, classicsResult.counts());
+        if (isSatisfiedByCrawledResult || satisfiedByAltCourse) {
+            return ClassicsResult.passedWith(classicsResult.counts());
+        }
+
+        return ClassicsResult.failedWith(classicsResult.counts());
     }
 
     private ClassicsResult fetchClassicsResultFromExternal(OkHttpClient client, ClassicsCounts fallbackCounts) {

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCertResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCertResolver.java
@@ -1,8 +1,6 @@
 package kr.allcll.backend.domain.graduation.check.cert;
 
-import kr.allcll.backend.domain.graduation.certification.ClassicAltCoursePolicy;
-import kr.allcll.backend.domain.graduation.certification.GraduationCertificationAltCoursePolicy;
-import kr.allcll.backend.domain.graduation.check.cert.dto.ClassicsCounts;
+import java.util.List;
 import kr.allcll.backend.domain.graduation.check.cert.dto.ClassicsResult;
 import kr.allcll.backend.domain.graduation.check.cert.dto.GraduationCertInfo;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
@@ -17,143 +15,49 @@ import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class GraduationCertResolver {
 
     private final CompletedCourseRepository completedCourseRepository;
-    private final GraduationCodingCertFetcher graduationCodingCertFetcher;
-    private final GraduationEnglishCertFetcher graduationEnglishCertFetcher;
-    private final GraduationClassicsCertFetcher graduationClassicsCertFetcher;
-    private final GraduationCertificationAltCoursePolicy codingAltCoursePolicy;
-    private final GraduationCertificationAltCoursePolicy englishAltCoursePolicy;
-    private final ClassicAltCoursePolicy classicAltCoursePolicy;
     private final GraduationDepartmentInfoRepository graduationDepartmentInfoRepository;
     private final GraduationCheckCertResultRepository graduationCheckCertResultRepository;
+    private final GraduationCodingCertResolver graduationCodingCertResolver;
+    private final GraduationEnglishCertResolver graduationEnglishCertResolver;
+    private final GraduationClassicsCertResolver graduationClassicsCertResolver;
 
     public GraduationCertInfo resolve(User user, OkHttpClient client) {
         GraduationDepartmentInfo userDept = graduationDepartmentInfoRepository
-                .findByAdmissionYearAndDeptCd(user.getAdmissionYear(), user.getDeptCd())
-                .orElseThrow(() -> new AllcllException(AllcllErrorCode.DEPARTMENT_NOT_FOUND));
+            .findByAdmissionYearAndDeptCd(user.getAdmissionYear(), user.getDeptCd())
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.DEPARTMENT_NOT_FOUND));
 
         List<CompletedCourse> completedCourses = completedCourseRepository.findAllByUserId(user.getId());
 
         GraduationCheckCertResult certResult = graduationCheckCertResultRepository.findByUserId(user.getId())
-                .orElse(null);
+            .orElse(null);
 
-        boolean englishPassed = resolveEnglishPassed(user, client, userDept, completedCourses, certResult);
-        boolean codingPassed = resolveCodingPassed(user, client, userDept, completedCourses, certResult);
-        ClassicsResult classicsResult = resolveClassics(user, client, certResult);
+        boolean englishPassed = graduationEnglishCertResolver.resolve(
+            user,
+            client,
+            userDept,
+            completedCourses,
+            certResult
+        );
+        boolean codingPassed = graduationCodingCertResolver.resolve(
+            user,
+            client,
+            userDept,
+            completedCourses,
+            certResult
+        );
+        ClassicsResult classicsResult = graduationClassicsCertResolver.resolve(user, client, certResult);
 
         return GraduationCertInfo.of(
-                englishPassed,
-                codingPassed,
-                classicsResult.passed(),
-                classicsResult.counts()
+            englishPassed,
+            codingPassed,
+            classicsResult.passed(),
+            classicsResult.counts()
         );
-    }
-
-    private boolean resolveEnglishPassed(
-            User user,
-            OkHttpClient client,
-            GraduationDepartmentInfo userDept,
-            List<CompletedCourse> completedCourses,
-            GraduationCheckCertResult certResult
-    ) {
-        if (isEnglishAlreadyPassed(certResult)) {
-            return true;
-        }
-
-        if (englishAltCoursePolicy.isSatisfiedByAltCourse(user, userDept, completedCourses)) {
-            return true;
-        }
-
-        try {
-            return graduationEnglishCertFetcher.fetchEnglishPass(client);
-        } catch (Exception e) {
-            log.error("[졸업요건검사] 영어인증 여부를 불러오지 못했습니다.", e);
-            return false;
-        }
-    }
-
-    private boolean resolveCodingPassed(
-            User user,
-            OkHttpClient client,
-            GraduationDepartmentInfo userDept,
-            List<CompletedCourse> completedCourses,
-            GraduationCheckCertResult certResult
-    ) {
-        if (isCodingAlreadyPassed(certResult)) {
-            return true;
-        }
-
-        if (codingAltCoursePolicy.isSatisfiedByAltCourse(user, userDept, completedCourses)) {
-            return true;
-        }
-
-        try {
-            return graduationCodingCertFetcher.fetchCodingPass(client);
-        } catch (Exception e) {
-            log.error("[졸업요건검사] 코딩인증 정보를 불러오지 못했습니다.", e);
-            return false;
-        }
-    }
-
-    private ClassicsResult resolveClassics(
-            User user,
-            OkHttpClient client,
-            GraduationCheckCertResult certResult
-    ) {
-        ClassicsCounts fallbackCounts = ClassicsCounts.fallback(certResult);
-
-        if (isClassicsAlreadyPassed(certResult)) {
-            return ClassicsResult.passedWith(fallbackCounts);
-        }
-
-        ClassicsResult classicsResult = fetchClassicsResultFromExternal(client, fallbackCounts);
-        boolean isSatisfiedByCrawledResult = classicsResult.isSatisfiedByCrawledResult();
-        boolean satisfiedByAltCourse = classicAltCoursePolicy.isSatisfiedByAltCourse(user);
-        if (isSatisfiedByCrawledResult || satisfiedByAltCourse) {
-            return ClassicsResult.passedWith(classicsResult.counts());
-        }
-
-        return ClassicsResult.failedWith(classicsResult.counts());
-    }
-
-    private ClassicsResult fetchClassicsResultFromExternal(OkHttpClient client, ClassicsCounts fallbackCounts) {
-        try {
-            ClassicsResult classicsResult = graduationClassicsCertFetcher.fetchClassics(client);
-            if (classicsResult == null) {
-                return ClassicsResult.empty();
-            }
-            return classicsResult.withFallbackCounts(fallbackCounts);
-        } catch (Exception e) {
-            log.error("[졸업요건검사] 고전인증 여부를 불러오지 못했습니다.", e);
-            return ClassicsResult.failedWith(fallbackCounts);
-        }
-    }
-
-    private boolean isEnglishAlreadyPassed(GraduationCheckCertResult certResult) {
-        if (certResult == null) {
-            return false;
-        }
-        return Boolean.TRUE.equals(certResult.getIsEnglishCertPassed());
-    }
-
-    private boolean isCodingAlreadyPassed(GraduationCheckCertResult certResult) {
-        if (certResult == null) {
-            return false;
-        }
-        return Boolean.TRUE.equals(certResult.getIsCodingCertPassed());
-    }
-
-    private boolean isClassicsAlreadyPassed(GraduationCheckCertResult certResult) {
-        if (certResult == null) {
-            return false;
-        }
-        return Boolean.TRUE.equals(certResult.getIsClassicsCertPassed());
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCheckCertResult.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCheckCertResult.java
@@ -209,4 +209,31 @@ public class GraduationCheckCertResult {
     public boolean isClassicsPassed() {
         return Boolean.TRUE.equals(this.isClassicsCertPassed);
     }
+
+    public static GraduationCheckCertResult empty() {
+        return new GraduationCheckCertResult(
+            null,
+            null,
+            0,
+            0,
+            false,
+            false,
+            false,
+            false,
+            0,
+            0,
+            0,
+            0,
+            false,
+            0,
+            0,
+            false,
+            0,
+            0,
+            false,
+            0,
+            0,
+            false
+        );
+    }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCheckCertResult.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCheckCertResult.java
@@ -205,4 +205,8 @@ public class GraduationCheckCertResult {
         this.requiredPassCount = this.graduationCertRuleType.getRequiredPassCount();
         this.isSatisfied = this.graduationCertRuleType.isSatisfied(newPassedCount);
     }
+
+    public boolean isClassicsPassed() {
+        return Boolean.TRUE.equals(this.isClassicsCertPassed);
+    }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolver.java
@@ -42,7 +42,8 @@ public class GraduationClassicsCertResolver {
         try {
             ClassicsResult classicsResult = graduationClassicsCertFetcher.fetchClassics(client);
             if (classicsResult == null) {
-                return ClassicsResult.empty();
+                log.warn("[졸업요건검사] 고전인증 결과가 null입니다. fallback 값 사용");
+                return ClassicsResult.failedWith(fallbackCounts);
             }
             return classicsResult.withFallbackCounts(fallbackCounts);
         } catch (Exception e) {

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolver.java
@@ -24,7 +24,7 @@ public class GraduationClassicsCertResolver {
     ) {
         ClassicsCounts fallbackCounts = ClassicsCounts.fallback(certResult);
 
-        if (isClassicsAlreadyPassed(certResult)) {
+        if (certResult.isClassicsPassed()) {
             return ClassicsResult.passedWith(fallbackCounts);
         }
 
@@ -50,12 +50,5 @@ public class GraduationClassicsCertResolver {
             log.error("[졸업요건검사] 고전인증 여부를 불러오지 못했습니다.", e);
             return ClassicsResult.failedWith(fallbackCounts);
         }
-    }
-
-    private boolean isClassicsAlreadyPassed(GraduationCheckCertResult certResult) {
-        if (certResult == null) {
-            return false;
-        }
-        return Boolean.TRUE.equals(certResult.getIsClassicsCertPassed());
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolver.java
@@ -4,6 +4,7 @@ import kr.allcll.backend.domain.graduation.certification.ClassicAltCoursePolicy;
 import kr.allcll.backend.domain.graduation.check.cert.dto.ClassicsCounts;
 import kr.allcll.backend.domain.graduation.check.cert.dto.ClassicsResult;
 import kr.allcll.backend.domain.user.User;
+import kr.allcll.backend.support.exception.AllcllException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
@@ -41,13 +42,9 @@ public class GraduationClassicsCertResolver {
     private ClassicsResult fetchClassicsResultFromExternal(OkHttpClient client, ClassicsCounts fallbackCounts) {
         try {
             ClassicsResult classicsResult = graduationClassicsCertFetcher.fetchClassics(client);
-            if (classicsResult == null) {
-                log.warn("[졸업요건검사] 고전인증 결과가 null입니다. fallback 값 사용");
-                return ClassicsResult.failedWith(fallbackCounts);
-            }
             return classicsResult.withFallbackCounts(fallbackCounts);
-        } catch (Exception e) {
-            log.error("[졸업요건검사] 고전인증 여부를 불러오지 못했습니다.", e);
+        } catch (AllcllException exception) {
+            log.error("[졸업요건검사] 고전인증 여부를 불러오지 못했습니다.", exception);
             return ClassicsResult.failedWith(fallbackCounts);
         }
     }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolver.java
@@ -1,0 +1,60 @@
+package kr.allcll.backend.domain.graduation.check.cert;
+
+import kr.allcll.backend.domain.graduation.certification.ClassicAltCoursePolicy;
+import kr.allcll.backend.domain.graduation.check.cert.dto.ClassicsCounts;
+import kr.allcll.backend.domain.graduation.check.cert.dto.ClassicsResult;
+import kr.allcll.backend.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GraduationClassicsCertResolver {
+
+    private final GraduationClassicsCertFetcher graduationClassicsCertFetcher;
+    private final ClassicAltCoursePolicy classicAltCoursePolicy;
+
+    public ClassicsResult resolve(
+        User user,
+        OkHttpClient client,
+        GraduationCheckCertResult certResult
+    ) {
+        ClassicsCounts fallbackCounts = ClassicsCounts.fallback(certResult);
+
+        if (isClassicsAlreadyPassed(certResult)) {
+            return ClassicsResult.passedWith(fallbackCounts);
+        }
+
+        ClassicsResult classicsResult = fetchClassicsResultFromExternal(client, fallbackCounts);
+        boolean isSatisfiedByCrawledResult = classicsResult.isSatisfiedByCrawledResult();
+        boolean satisfiedByAltCourse = classicAltCoursePolicy.isSatisfiedByAltCourse(user);
+        if (isSatisfiedByCrawledResult || satisfiedByAltCourse) {
+            return ClassicsResult.passedWith(classicsResult.counts());
+        }
+
+        return ClassicsResult.failedWith(classicsResult.counts());
+    }
+
+    private ClassicsResult fetchClassicsResultFromExternal(OkHttpClient client, ClassicsCounts fallbackCounts) {
+        try {
+            ClassicsResult classicsResult = graduationClassicsCertFetcher.fetchClassics(client);
+            if (classicsResult == null) {
+                return ClassicsResult.empty();
+            }
+            return classicsResult.withFallbackCounts(fallbackCounts);
+        } catch (Exception e) {
+            log.error("[졸업요건검사] 고전인증 여부를 불러오지 못했습니다.", e);
+            return ClassicsResult.failedWith(fallbackCounts);
+        }
+    }
+
+    private boolean isClassicsAlreadyPassed(GraduationCheckCertResult certResult) {
+        if (certResult == null) {
+            return false;
+        }
+        return Boolean.TRUE.equals(certResult.getIsClassicsCertPassed());
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolver.java
@@ -23,11 +23,10 @@ public class GraduationClassicsCertResolver {
         OkHttpClient client,
         GraduationCheckCertResult certResult
     ) {
-        ClassicsCounts fallbackCounts = ClassicsCounts.fallback(certResult);
-
         if (certResult.isClassicsPassed()) {
-            return ClassicsResult.passedWith(fallbackCounts);
+            return ClassicsResult.passedWith(ClassicsCounts.fallback(certResult));
         }
+        ClassicsCounts fallbackCounts = ClassicsCounts.fallback(certResult);
 
         ClassicsResult classicsResult = fetchClassicsResultFromExternal(client, fallbackCounts);
         boolean isSatisfiedByCrawledResult = classicsResult.isSatisfiedByCrawledResult();

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCodingCertResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCodingCertResolver.java
@@ -42,9 +42,6 @@ public class GraduationCodingCertResolver {
     }
 
     private boolean isCodingAlreadyPassed(GraduationCheckCertResult certResult) {
-        if (certResult == null) {
-            return false;
-        }
         return Boolean.TRUE.equals(certResult.getIsCodingCertPassed());
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCodingCertResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCodingCertResolver.java
@@ -1,0 +1,50 @@
+package kr.allcll.backend.domain.graduation.check.cert;
+
+import java.util.List;
+import kr.allcll.backend.domain.graduation.certification.GraduationCertificationAltCoursePolicy;
+import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
+import kr.allcll.backend.domain.graduation.department.GraduationDepartmentInfo;
+import kr.allcll.backend.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GraduationCodingCertResolver {
+
+    private final GraduationCodingCertFetcher graduationCodingCertFetcher;
+    private final GraduationCertificationAltCoursePolicy codingAltCoursePolicy;
+
+    public boolean resolve(
+        User user,
+        OkHttpClient client,
+        GraduationDepartmentInfo userDept,
+        List<CompletedCourse> completedCourses,
+        GraduationCheckCertResult certResult
+    ) {
+        if (isCodingAlreadyPassed(certResult)) {
+            return true;
+        }
+
+        if (codingAltCoursePolicy.isSatisfiedByAltCourse(user, userDept, completedCourses)) {
+            return true;
+        }
+
+        try {
+            return graduationCodingCertFetcher.fetchCodingPass(client);
+        } catch (Exception e) {
+            log.error("[졸업요건검사] 코딩인증 정보를 불러오지 못했습니다.", e);
+            return false;
+        }
+    }
+
+    private boolean isCodingAlreadyPassed(GraduationCheckCertResult certResult) {
+        if (certResult == null) {
+            return false;
+        }
+        return Boolean.TRUE.equals(certResult.getIsCodingCertPassed());
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationEnglishCertResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationEnglishCertResolver.java
@@ -1,0 +1,51 @@
+package kr.allcll.backend.domain.graduation.check.cert;
+
+import kr.allcll.backend.domain.graduation.certification.GraduationCertificationAltCoursePolicy;
+import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
+import kr.allcll.backend.domain.graduation.department.GraduationDepartmentInfo;
+import kr.allcll.backend.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GraduationEnglishCertResolver {
+
+    private final GraduationEnglishCertFetcher graduationEnglishCertFetcher;
+    private final GraduationCertificationAltCoursePolicy englishAltCoursePolicy;
+
+    public boolean resolve(
+            User user,
+            OkHttpClient client,
+            GraduationDepartmentInfo userDept,
+            List<CompletedCourse> completedCourses,
+            GraduationCheckCertResult certResult
+    ) {
+        if (isEnglishAlreadyPassed(certResult)) {
+            return true;
+        }
+
+        if (englishAltCoursePolicy.isSatisfiedByAltCourse(user, userDept, completedCourses)) {
+            return true;
+        }
+
+        try {
+            return graduationEnglishCertFetcher.fetchEnglishPass(client);
+        } catch (Exception e) {
+            log.error("[졸업요건검사] 영어인증 여부를 불러오지 못했습니다.", e);
+            return false;
+        }
+    }
+
+    private boolean isEnglishAlreadyPassed(GraduationCheckCertResult certResult) {
+        if (certResult == null) {
+            return false;
+        }
+        return Boolean.TRUE.equals(certResult.getIsEnglishCertPassed());
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationEnglishCertResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationEnglishCertResolver.java
@@ -1,5 +1,6 @@
 package kr.allcll.backend.domain.graduation.check.cert;
 
+import java.util.List;
 import kr.allcll.backend.domain.graduation.certification.GraduationCertificationAltCoursePolicy;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
 import kr.allcll.backend.domain.graduation.department.GraduationDepartmentInfo;
@@ -8,8 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -20,11 +19,11 @@ public class GraduationEnglishCertResolver {
     private final GraduationCertificationAltCoursePolicy englishAltCoursePolicy;
 
     public boolean resolve(
-            User user,
-            OkHttpClient client,
-            GraduationDepartmentInfo userDept,
-            List<CompletedCourse> completedCourses,
-            GraduationCheckCertResult certResult
+        User user,
+        OkHttpClient client,
+        GraduationDepartmentInfo userDept,
+        List<CompletedCourse> completedCourses,
+        GraduationCheckCertResult certResult
     ) {
         if (isEnglishAlreadyPassed(certResult)) {
             return true;
@@ -43,9 +42,6 @@ public class GraduationEnglishCertResolver {
     }
 
     private boolean isEnglishAlreadyPassed(GraduationCheckCertResult certResult) {
-        if (certResult == null) {
-            return false;
-        }
         return Boolean.TRUE.equals(certResult.getIsEnglishCertPassed());
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/dto/ClassicsCounts.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/dto/ClassicsCounts.java
@@ -18,9 +18,6 @@ public record ClassicsCounts(
     }
 
     public static ClassicsCounts fallback(GraduationCheckCertResult certResult) {
-        if (certResult == null) {
-            return ClassicsCounts.empty();
-        }
         return new ClassicsCounts(
             certResult.getMyCountWestern(),
             certResult.getMyCountEastern(),

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/dto/ClassicsCounts.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/dto/ClassicsCounts.java
@@ -32,4 +32,11 @@ public record ClassicsCounts(
     public static ClassicsCounts empty() {
         return new ClassicsCounts(0, 0, 0, 0);
     }
+
+    public boolean isPassed() {
+        return myCountWestern >= ClassicsArea.WESTERN.getMaxRecognizedCount() &&
+            myCountEastern >= ClassicsArea.EASTERN.getMaxRecognizedCount() &&
+            myCountEasternAndWestern >= ClassicsArea.EASTERN_AND_WESTERN.getMaxRecognizedCount() &&
+            myCountScience >= ClassicsArea.SCIENCE.getMaxRecognizedCount();
+    }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/dto/ClassicsResult.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/dto/ClassicsResult.java
@@ -13,10 +13,6 @@ public record ClassicsResult(
         return new ClassicsResult(true, fallbackCounts);
     }
 
-    public ClassicsResult passedWith(boolean passed, ClassicsCounts fallbackCounts) {
-        return new ClassicsResult(passed, fallbackCounts);
-    }
-
     public static ClassicsResult failedWith(ClassicsCounts fallbackCounts) {
         return new ClassicsResult(false, fallbackCounts);
     }
@@ -26,5 +22,9 @@ public record ClassicsResult(
             return new ClassicsResult(passed, fallbackCounts);
         }
         return this;
+    }
+
+    public boolean isSatisfiedByCrawledResult() {
+        return passed || counts.isPassed();
     }
 }

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertFetcherParsingTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertFetcherParsingTest.java
@@ -1,0 +1,157 @@
+package kr.allcll.backend.domain.graduation.check.cert;
+
+import kr.allcll.backend.support.graduation.GraduationHtmlParser;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GraduationClassicsCertFetcherParsingTest {
+
+    private final GraduationHtmlParser parser = new GraduationHtmlParser();
+
+    @DisplayName("사용자 정보의 인증여부 텍스트를 파싱한다")
+    @Test
+    void selectClassicsPassText() {
+        // given
+        int PASS_STATUS_INDEX = 0;
+        String html = """
+                <div class="b-con-box">
+                    <h4 class="b-h4-tit01">사용자 정보</h4>
+                    <div class="table-wrap">
+                        <table class="b-board-table">
+                            <tbody>
+                                <tr>
+                                    <th class="td-left" scope="row">인증여부</th>
+                                    <td class="td-left">
+                
+                
+                
+                
+                
+                                    								2024년도 1학기
+                                    								인증
+                
+                
+                                   </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                """;
+
+        Document document = Jsoup.parse(html);
+
+        // when
+        String[] passTextParts = parser.selectClassicsPassText(document);
+        System.out.println(passTextParts.length);
+        System.out.println(passTextParts[0]);
+        System.out.println(passTextParts[1]);
+
+        String passText = passTextParts[PASS_STATUS_INDEX];
+        boolean expect = !passText.equals("아니오");
+
+        // then
+        assertThat(expect).isEqualTo(true);
+    }
+
+    @DisplayName("고전특강 대상자의 인증여부가 아니오이면 false를 반환한다")
+    @Test
+    void selectClassicsPassText_notPassed_altcourse() {
+        // given
+        int PASS_STATUS_INDEX = 0;
+
+        String html = """
+                <div class="co-board">
+                    <div class="bn-view-common type01">
+                        <div class="b-con-box">
+                            <h4 class="b-h4-tit01">사용자 정보</h4>
+                            <div class="table-wrap">
+                                <table class="b-board-table">
+                                    <tbody>
+                                        <tr>
+                                            <th class="td-left" scope="row">인증여부</th>
+                                            <td class="td-left">
+                
+                
+                                            									아니오(고전특강 대상자)
+                
+                
+                
+                
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                """;
+
+        Document document = Jsoup.parse(html);
+
+        // when
+        String[] passTextParts = parser.selectClassicsPassText(document);
+        System.out.println(passTextParts.length);
+        System.out.println(passTextParts[0]);
+        System.out.println(passTextParts[0]);
+
+        String passText = passTextParts[PASS_STATUS_INDEX];
+        boolean result = !passText.equals("아니오");
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @DisplayName("인증여부가 아니오이면 false를 반환한다")
+    @Test
+    void selectClassicsPassText_notPassed() {
+        // given
+        int PASS_STATUS_INDEX = 0;
+
+        String html = """
+                <div class="co-board">
+                    <div class="bn-view-common type01">
+                        <div class="b-con-box">
+                            <h4 class="b-h4-tit01">사용자 정보</h4>
+                            <div class="table-wrap">
+                                <table class="b-board-table">
+                                    <tbody>
+                                        <tr>
+                                            <th class="td-left" scope="row">인증여부</th>
+                                            <<td class="td-left">
+                
+                
+                                             									아니오
+                
+                
+                
+                
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                """;
+
+        Document document = Jsoup.parse(html);
+
+        // when
+        String[] passTextParts = parser.selectClassicsPassText(document);
+        System.out.println(passTextParts.length);
+        System.out.println(passTextParts[0]);
+
+        String passText = passTextParts[PASS_STATUS_INDEX];
+        boolean result = !passText.equals("아니오");
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertFetcherParsingTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertFetcherParsingTest.java
@@ -26,15 +26,8 @@ public class GraduationClassicsCertFetcherParsingTest {
                                 <tr>
                                     <th class="td-left" scope="row">인증여부</th>
                                     <td class="td-left">
-                
-                
-                
-                
-                
                                     								2024년도 1학기
                                     								인증
-                
-                
                                    </td>
                                 </tr>
                             </tbody>
@@ -47,10 +40,6 @@ public class GraduationClassicsCertFetcherParsingTest {
 
         // when
         String[] passTextParts = parser.selectClassicsPassText(document);
-        System.out.println(passTextParts.length);
-        System.out.println(passTextParts[0]);
-        System.out.println(passTextParts[1]);
-
         String passText = passTextParts[PASS_STATUS_INDEX];
         boolean expect = !passText.equals("아니오");
 
@@ -75,13 +64,7 @@ public class GraduationClassicsCertFetcherParsingTest {
                                         <tr>
                                             <th class="td-left" scope="row">인증여부</th>
                                             <td class="td-left">
-                
-                
                                             									아니오(고전특강 대상자)
-                
-                
-                
-                
                                             </td>
                                         </tr>
                                     </tbody>
@@ -96,9 +79,6 @@ public class GraduationClassicsCertFetcherParsingTest {
 
         // when
         String[] passTextParts = parser.selectClassicsPassText(document);
-        System.out.println(passTextParts.length);
-        System.out.println(passTextParts[0]);
-        System.out.println(passTextParts[0]);
 
         String passText = passTextParts[PASS_STATUS_INDEX];
         boolean result = !passText.equals("아니오");
@@ -124,13 +104,7 @@ public class GraduationClassicsCertFetcherParsingTest {
                                         <tr>
                                             <th class="td-left" scope="row">인증여부</th>
                                             <<td class="td-left">
-                
-                
                                              									아니오
-                
-                
-                
-                
                                             </td>
                                         </tr>
                                     </tbody>
@@ -145,9 +119,6 @@ public class GraduationClassicsCertFetcherParsingTest {
 
         // when
         String[] passTextParts = parser.selectClassicsPassText(document);
-        System.out.println(passTextParts.length);
-        System.out.println(passTextParts[0]);
-
         String passText = passTextParts[PASS_STATUS_INDEX];
         boolean result = !passText.equals("아니오");
 

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertFetcherParsingTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertFetcherParsingTest.java
@@ -1,13 +1,14 @@
 package kr.allcll.backend.domain.graduation.check.cert;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import kr.allcll.backend.support.graduation.GraduationHtmlParser;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+@DisplayName("GraduationClassicsCertFetcher 테스트")
 public class GraduationClassicsCertFetcherParsingTest {
 
     private final GraduationHtmlParser parser = new GraduationHtmlParser();
@@ -18,23 +19,23 @@ public class GraduationClassicsCertFetcherParsingTest {
         // given
         int PASS_STATUS_INDEX = 0;
         String html = """
-                <div class="b-con-box">
-                    <h4 class="b-h4-tit01">사용자 정보</h4>
-                    <div class="table-wrap">
-                        <table class="b-board-table">
-                            <tbody>
-                                <tr>
-                                    <th class="td-left" scope="row">인증여부</th>
-                                    <td class="td-left">
-                                    								2024년도 1학기
-                                    								인증
-                                   </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+            <div class="b-con-box">
+                <h4 class="b-h4-tit01">사용자 정보</h4>
+                <div class="table-wrap">
+                    <table class="b-board-table">
+                        <tbody>
+                            <tr>
+                                <th class="td-left" scope="row">인증여부</th>
+                                <td class="td-left">
+                                								2024년도 1학기
+                                								인증
+                               </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
-                """;
+            </div>
+            """;
 
         Document document = Jsoup.parse(html);
 
@@ -54,26 +55,26 @@ public class GraduationClassicsCertFetcherParsingTest {
         int PASS_STATUS_INDEX = 0;
 
         String html = """
-                <div class="co-board">
-                    <div class="bn-view-common type01">
-                        <div class="b-con-box">
-                            <h4 class="b-h4-tit01">사용자 정보</h4>
-                            <div class="table-wrap">
-                                <table class="b-board-table">
-                                    <tbody>
-                                        <tr>
-                                            <th class="td-left" scope="row">인증여부</th>
-                                            <td class="td-left">
-                                            									아니오(고전특강 대상자)
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
+            <div class="co-board">
+                <div class="bn-view-common type01">
+                    <div class="b-con-box">
+                        <h4 class="b-h4-tit01">사용자 정보</h4>
+                        <div class="table-wrap">
+                            <table class="b-board-table">
+                                <tbody>
+                                    <tr>
+                                        <th class="td-left" scope="row">인증여부</th>
+                                        <td class="td-left">
+                                        									아니오(고전특강 대상자)
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
                         </div>
                     </div>
                 </div>
-                """;
+            </div>
+            """;
 
         Document document = Jsoup.parse(html);
 
@@ -94,26 +95,26 @@ public class GraduationClassicsCertFetcherParsingTest {
         int PASS_STATUS_INDEX = 0;
 
         String html = """
-                <div class="co-board">
-                    <div class="bn-view-common type01">
-                        <div class="b-con-box">
-                            <h4 class="b-h4-tit01">사용자 정보</h4>
-                            <div class="table-wrap">
-                                <table class="b-board-table">
-                                    <tbody>
-                                        <tr>
-                                            <th class="td-left" scope="row">인증여부</th>
-                                            <<td class="td-left">
-                                             									아니오
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
+            <div class="co-board">
+                <div class="bn-view-common type01">
+                    <div class="b-con-box">
+                        <h4 class="b-h4-tit01">사용자 정보</h4>
+                        <div class="table-wrap">
+                            <table class="b-board-table">
+                                <tbody>
+                                    <tr>
+                                        <th class="td-left" scope="row">인증여부</th>
+                                        <<td class="td-left">
+                                         									아니오
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
                         </div>
                     </div>
                 </div>
-                """;
+            </div>
+            """;
 
         Document document = Jsoup.parse(html);
 

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolverTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolverTest.java
@@ -45,6 +45,9 @@ class GraduationClassicsCertResolverTest {
         given(certResult.getMyCountEasternAndWestern()).willReturn(2);
         given(certResult.getMyCountScience()).willReturn(1);
 
+        given(graduationClassicsCertFetcher.fetchClassics(client))
+            .willReturn(new ClassicsResult(false, new ClassicsCounts(1, 0, 0, 0)));
+
         // when
         ClassicsResult result = resolver.resolve(user, client, certResult);
 
@@ -61,7 +64,7 @@ class GraduationClassicsCertResolverTest {
         given(classicAltCoursePolicy.isSatisfiedByAltCourse(user)).willReturn(false);
 
         // when
-        ClassicsResult result = resolver.resolve(user, client, null);
+        ClassicsResult result = resolver.resolve(user, client, GraduationCheckCertResult.empty());
 
         // then
         assertThat(result.passed()).isTrue();
@@ -76,7 +79,7 @@ class GraduationClassicsCertResolverTest {
         given(classicAltCoursePolicy.isSatisfiedByAltCourse(user)).willReturn(false);
 
         // when
-        ClassicsResult result = resolver.resolve(user, client, null);
+        ClassicsResult result = resolver.resolve(user, client, GraduationCheckCertResult.empty());
 
         // then
         assertThat(result.passed()).isTrue();
@@ -91,7 +94,7 @@ class GraduationClassicsCertResolverTest {
         given(classicAltCoursePolicy.isSatisfiedByAltCourse(user)).willReturn(true);
 
         // when
-        ClassicsResult result = resolver.resolve(user, client, null);
+        ClassicsResult result = resolver.resolve(user, client, GraduationCheckCertResult.empty());
 
         // then
         assertThat(result.passed()).isTrue();
@@ -106,7 +109,7 @@ class GraduationClassicsCertResolverTest {
         given(classicAltCoursePolicy.isSatisfiedByAltCourse(user)).willReturn(false);
 
         // when
-        ClassicsResult result = resolver.resolve(user, client, null);
+        ClassicsResult result = resolver.resolve(user, client, GraduationCheckCertResult.empty());
 
         // then
         assertThat(result.passed()).isFalse();

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolverTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolverTest.java
@@ -1,0 +1,114 @@
+package kr.allcll.backend.domain.graduation.check.cert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import kr.allcll.backend.domain.graduation.certification.ClassicAltCoursePolicy;
+import kr.allcll.backend.domain.graduation.check.cert.dto.ClassicsCounts;
+import kr.allcll.backend.domain.graduation.check.cert.dto.ClassicsResult;
+import kr.allcll.backend.domain.user.User;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GraduationClassicsCertResolverTest {
+
+    @Mock
+    private GraduationClassicsCertFetcher graduationClassicsCertFetcher;
+
+    @Mock
+    private ClassicAltCoursePolicy classicAltCoursePolicy;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private OkHttpClient client;
+
+    @InjectMocks
+    private GraduationClassicsCertResolver resolver;
+
+    @Test
+    @DisplayName("DB에 고전인증 통과 이력이 있으면 fallback counts 로 통과 처리한다")
+    void resolve_whenAlreadyPassed() {
+        // given
+        GraduationCheckCertResult certResult = mock(GraduationCheckCertResult.class);
+        given(certResult.getIsClassicsCertPassed()).willReturn(true);
+        given(certResult.getMyCountWestern()).willReturn(4);
+        given(certResult.getMyCountEastern()).willReturn(2);
+        given(certResult.getMyCountEasternAndWestern()).willReturn(2);
+        given(certResult.getMyCountScience()).willReturn(1);
+
+        // when
+        ClassicsResult result = resolver.resolve(user, client, certResult);
+
+        // then
+        assertThat(result.passed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("크롤링 결과 인증 완료이면 통과 처리한다")
+    void resolve_whenPassedByCrawledPass() {
+        // given
+        given(graduationClassicsCertFetcher.fetchClassics(client))
+            .willReturn(new ClassicsResult(true, new ClassicsCounts(1, 0, 0, 0)));
+        given(classicAltCoursePolicy.isSatisfiedByAltCourse(user)).willReturn(false);
+
+        // when
+        ClassicsResult result = resolver.resolve(user, client, null);
+
+        // then
+        assertThat(result.passed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("크롤링 결과의 인증 실패이지만, 모든 영역의 필요 이수 권수를 만족하면 통과 처리한다")
+    void resolve_whenPassedByCounts() {
+        // given
+        given(graduationClassicsCertFetcher.fetchClassics(client))
+            .willReturn(new ClassicsResult(false, new ClassicsCounts(4, 2, 3, 1)));
+        given(classicAltCoursePolicy.isSatisfiedByAltCourse(user)).willReturn(false);
+
+        // when
+        ClassicsResult result = resolver.resolve(user, client, null);
+
+        // then
+        assertThat(result.passed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("대체과목을 만족하면 통과 처리한다")
+    void resolve_whenPassedByAltCourse() {
+        // given
+        given(graduationClassicsCertFetcher.fetchClassics(client))
+            .willReturn(new ClassicsResult(false, new ClassicsCounts(1, 0, 0, 0)));
+        given(classicAltCoursePolicy.isSatisfiedByAltCourse(user)).willReturn(true);
+
+        // when
+        ClassicsResult result = resolver.resolve(user, client, null);
+
+        // then
+        assertThat(result.passed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("크롤링 결과도 불합격이고 대체과목도 미충족이면 실패 처리한다")
+    void resolve_whenFailed() {
+        // given
+        given(graduationClassicsCertFetcher.fetchClassics(client))
+            .willReturn(new ClassicsResult(false, new ClassicsCounts(1, 0, 0, 0)));
+        given(classicAltCoursePolicy.isSatisfiedByAltCourse(user)).willReturn(false);
+
+        // when
+        ClassicsResult result = resolver.resolve(user, client, null);
+
+        // then
+        assertThat(result.passed()).isFalse();
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolverTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/cert/GraduationClassicsCertResolverTest.java
@@ -39,14 +39,11 @@ class GraduationClassicsCertResolverTest {
     void resolve_whenAlreadyPassed() {
         // given
         GraduationCheckCertResult certResult = mock(GraduationCheckCertResult.class);
-        given(certResult.getIsClassicsCertPassed()).willReturn(true);
+        given(certResult.isClassicsPassed()).willReturn(true);
         given(certResult.getMyCountWestern()).willReturn(4);
         given(certResult.getMyCountEastern()).willReturn(2);
         given(certResult.getMyCountEasternAndWestern()).willReturn(2);
         given(certResult.getMyCountScience()).willReturn(1);
-
-        given(graduationClassicsCertFetcher.fetchClassics(client))
-            .willReturn(new ClassicsResult(false, new ClassicsCounts(1, 0, 0, 0)));
 
         // when
         ClassicsResult result = resolver.resolve(user, client, certResult);


### PR DESCRIPTION
## 작업 내용
### 🌁 작업 배경
**🚨문제 상황**: 모든 영역 별 `인증 권수` <= `이수 권수` 임에도 인증 여부가 `false`로 뜨는 문제가 있었습니다. 

**🚨원인 분석**: 이는 대양휴머니티칼리지 페이지에서 사용자의 고전독서 인증 여부를 느리게 업데이트해주어 발생한 문제입니다.

올클의 고전 독서 여부 판정 기준은 대휴칼 페이지 파싱 + 대체과목 이수 여부 확인 을 통해 이루어지기에, 대휴칼 페이지에서 false로 보내주면, 그대로 파싱해 보여줄 수 밖에 없었습니다.
<img width="943" height="527" alt="image" src="https://github.com/user-attachments/assets/9cfd5c7c-1367-4897-b917-d3197a636894" />
<img width="929" height="400" alt="image" src="https://github.com/user-attachments/assets/e12f25bb-c7fa-48b3-adbb-00bbc482e04c" />

### 🫶 해결 방안
영역 별 필요 권수를 저장한 enum(`ClassicsArea`)을 기준으로 사용자의 모든 영역 별 `인증 권수` <= `이수 권수` 인 경우, `classicsResult.passed()`를 true로 반환하도록 했습니다.

이를 판정하기위해 `ClassicsCounts`에 `isPassed` 메서드를 추가했습니다.

### ✍️ 테스트 코드 작성

초반에는 원인 파악이 되지 않아, 파싱 로직의 오류를 판단하기 위해 `GraduationClassicsCertFetcherParsingTest`를 생성했습니다.
이는 `GraduationClassicsCertFetcher` 클래스에대한 테스트이지만, 기존 `GraduationClassicsCertFetcherTest`와 성격이 조금 달라보여 클래스를 분리 후 클래스 단위에 `@DisplayName`를 추가했습니다.

정확한 원인 파악 후 `GraduationClassicsCertResolverTest` 테스트로 현재 PR 작업의 정상 작동 여부를 확인하였습니다. 
기존에는 `GraduationCertResolver`에 영어, 고전, 코딩 인증을 확인하는 private 메서드를 호출하는 방식으로 작동이 되었는데, 
테스트 코드를 작성하기 어려워 `GraduationCertClassicResolver` & `GraduationCertCodingResolver` & `GraduationCertResolver`로 분리하였습니다

## 고민 지점과 리뷰 포인트
적절한 방식으로 작업되었는지 확인부탁드립니다!
<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->