### PR TITLE
[TSK-70] 교양 학점 보정 로직 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapper.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapper.java
@@ -120,79 +120,6 @@ public class GraduationCheckResponseMapper {
         return rule.getRequiredAreasCnt();
     }
 
-    // 졸업인증 전체 기준 정보 생성
-    private GraduationCertifications toCertifications(CertResult certResult) {
-        return new GraduationCertifications(
-            new CertificationPolicy(certResult.ruleType(), certResult.requiredPassCount()),
-            certResult.passedCount(),
-            certResult.requiredPassCount(),
-            certResult.isSatisfied(),
-            toEnglishCertification(certResult),
-            toCodingCertification(certResult),
-            toClassicCertification(certResult)
-        );
-    }
-
-    private EnglishCertification toEnglishCertification(CertResult certResult) {
-        return new EnglishCertification(
-            isRequiredByCertRule(certResult.ruleType(), GraduationCertType.CERT_ENGLISH),
-            certResult.isEnglishCertPassed(),
-            EnglishTargetType.NON_MAJOR
-        );
-    }
-
-    private CodingCertification toCodingCertification(CertResult certResult) {
-        return new CodingCertification(
-            isRequiredByCertRule(certResult.ruleType(), GraduationCertType.CERT_CODING),
-            certResult.isCodingCertPassed(),
-            CodingTargetType.CODING_MAJOR
-        );
-    }
-
-    private ClassicCertification toClassicCertification(CertResult certResult) {
-        return new ClassicCertification(
-            isRequiredByCertRule(certResult.ruleType(), GraduationCertType.CERT_CLASSIC),
-            certResult.isClassicsCertPassed(),
-            certResult.classicsTotalRequiredCount(),
-            certResult.classicsTotalMyCount(),
-            List.of(
-                new ClassicDomainRequirement(
-                    "WESTERN_HISTORY_THOUGHT",
-                    certResult.requiredCountWestern(),
-                    certResult.myCountWestern(),
-                    certResult.isClassicsWesternCertPassed()
-                ),
-                new ClassicDomainRequirement(
-                    "EASTERN_HISTORY_THOUGHT",
-                    certResult.requiredCountEastern(),
-                    certResult.myCountEastern(),
-                    certResult.isClassicsEasternCertPassed()
-                ),
-                new ClassicDomainRequirement(
-                    "EAST_WEST_LITERATURE",
-                    certResult.requiredCountEasternAndWestern(),
-                    certResult.myCountEasternAndWestern(),
-                    certResult.isClassicsEasternAndWesternCertPassed()
-                ),
-                new ClassicDomainRequirement(
-                    "SCIENCE_THOUGHT",
-                    certResult.requiredCountScience(),
-                    certResult.myCountScience(),
-                    certResult.isClassicsScienceCertPassed()
-                )
-            )
-        );
-    }
-
-    private Boolean isRequiredByCertRule(String ruleTypeName, GraduationCertType certType) {
-        GraduationCertRuleType ruleType = GraduationCertRuleType.valueOf(ruleTypeName);
-        return ruleType.getGraduationCertTypes().contains(certType);
-    }
-
-    private List<GraduationCategory> adjustMajorCategories(List<GraduationCategory> graduationCategories) {
-        return reallocateCredits(graduationCategories);
-    }
-
     private List<GraduationCategory> reallocateCredits(List<GraduationCategory> graduationCategories) {
         Map<MajorScope, List<GraduationCategory>> groupedReallocateTargets = graduationCategories.stream()
             .filter(this::isReallocateTarget)
@@ -222,125 +149,57 @@ public class GraduationCheckResponseMapper {
             MajorScope majorScope = entry.getKey();
             List<GraduationCategory> reallocateCategory = entry.getValue();
 
-            GraduationCategory majorRequired = findCategory(reallocateCategory, CategoryType.MAJOR_REQUIRED);
-            GraduationCategory majorElective = findCategory(reallocateCategory, CategoryType.MAJOR_ELECTIVE);
-            GraduationCategory general = findCategory(reallocateCategory, CategoryType.GENERAL);
+            GraduationCategory majorRequired = findCategoryOrEmpty(reallocateCategory, CategoryType.MAJOR_REQUIRED, majorScope);
+            GraduationCategory majorElective = findCategoryOrEmpty(reallocateCategory, CategoryType.MAJOR_ELECTIVE, majorScope);
+            GraduationCategory general = findCategoryOrEmpty(reallocateCategory, CategoryType.GENERAL, majorScope);
 
-            boolean hasMajorRequired = hasCategoryType(majorRequired);
-            boolean hasMajorElective = hasCategoryType(majorElective);
-            boolean hasGeneral = hasCategoryType(general);
+            boolean hasMajorRequired = findCategory(reallocateCategory, CategoryType.MAJOR_REQUIRED) != null;
+            boolean hasMajorElective = findCategory(reallocateCategory, CategoryType.MAJOR_ELECTIVE) != null;
+            boolean hasGeneral = findCategory(reallocateCategory, CategoryType.GENERAL) != null;
 
-            if (!hasMajorRequired) {
-                majorRequired = GraduationCategory.createEmptyGraduationCategory(
-                    majorScope,
-                    CategoryType.MAJOR_REQUIRED
-                );
-            }
-            if (!hasMajorElective) {
-                majorElective = GraduationCategory.createEmptyGraduationCategory(
-                    majorScope,
-                    CategoryType.MAJOR_ELECTIVE
-                );
-            }
-            if (!hasGeneral) {
-                general = GraduationCategory.createEmptyGraduationCategory(
-                    majorScope,
-                    CategoryType.GENERAL
-                );
-            }
-
-            double adjustedMajorRequiredCredits = Math.min(
-                majorRequired.earnedCredits(),
-                majorRequired.requiredCredits()
-            );
-            double overMajorRequiredCredits = Math.max(
-                majorRequired.earnedCredits() - majorRequired.requiredCredits(),
-                0
+            double overMajorRequired = majorRequired.overflowCredits();
+            GraduationCategory adjustedRequired = majorRequired.withEarnedCredits(
+                Math.min(majorRequired.earnedCredits(), majorRequired.requiredCredits())
             );
 
-            double electiveWithCarry = majorElective.earnedCredits() + overMajorRequiredCredits;
-            double adjustedMajorElectiveCredits;
-            double overMajorElectiveCredits;
+            GraduationCategory electiveWithCarry = majorElective.addCredits(overMajorRequired);
+            double overMajorElective;
+            GraduationCategory adjustedElective;
             if (hasMajorElective) {
-                adjustedMajorElectiveCredits = Math.min(
-                    electiveWithCarry,
-                    majorElective.requiredCredits()
-                );
-                overMajorElectiveCredits = Math.max(
-                    electiveWithCarry - majorElective.requiredCredits(),
-                    0
+                overMajorElective = electiveWithCarry.overflowCredits();
+                adjustedElective = electiveWithCarry.withEarnedCredits(
+                    Math.min(electiveWithCarry.earnedCredits(), majorElective.requiredCredits())
                 );
             } else {
-                adjustedMajorElectiveCredits = electiveWithCarry;
-                overMajorElectiveCredits = 0;
+                overMajorElective = 0;
+                adjustedElective = electiveWithCarry;
             }
 
-            double adjustedGeneralCredits = general.earnedCredits() + overMajorElectiveCredits;
+            GraduationCategory adjustedGeneral = general.addCredits(overMajorElective);
 
-            boolean shouldAddMajorRequired = isShouldAdd(hasMajorRequired, adjustedMajorRequiredCredits);
-            boolean shouldAddMajorElective = isShouldAdd(hasMajorElective, overMajorRequiredCredits);
-            boolean shouldAddGeneral = isShouldAdd(hasGeneral, overMajorElectiveCredits);
-
-            if (shouldAddMajorRequired) {
-                finishReallocate.add(createAdjustedMajorCategory(majorRequired, adjustedMajorRequiredCredits));
+            if (hasMajorRequired || adjustedRequired.earnedCredits() > 0) {
+                finishReallocate.add(adjustedRequired);
             }
-            if (shouldAddMajorElective) {
-                finishReallocate.add(createAdjustedMajorCategory(majorElective, adjustedMajorElectiveCredits));
+            if (hasMajorElective || overMajorRequired > 0) {
+                finishReallocate.add(adjustedElective);
             }
-            if (shouldAddGeneral) {
-                finishReallocate.add(createAdjustedMajorCategory(general, adjustedGeneralCredits));
+            if (hasGeneral || overMajorElective > 0) {
+                finishReallocate.add(adjustedGeneral);
             }
         }
     }
 
-    private static boolean isShouldAdd(boolean hasCategory, double adjustedCredits) {
-        return hasCategory || adjustedCredits > 0;
-    }
-
-    private static boolean hasCategoryType(GraduationCategory category) {
-        return category != null;
+    private GraduationCategory findCategoryOrEmpty(
+        List<GraduationCategory> categories,
+        CategoryType categoryType,
+        MajorScope majorScope
+    ) {
+        GraduationCategory found = findCategory(categories, categoryType);
+        return found != null ? found : GraduationCategory.createEmptyGraduationCategory(majorScope, categoryType);
     }
 
     private boolean isReallocateTarget(GraduationCategory graduationCategory) {
         return graduationCategory.categoryType().isReallocateTarget();
-    }
-
-    private boolean isMajorCategory(GraduationCategory category) {
-        return category.categoryType().isMajorCategory();
-    }
-
-    private void adjustMajorCreditsByScope(
-        Map<MajorScope, List<GraduationCategory>> majorByScope,
-        List<GraduationCategory> result
-    ) {
-        for (Map.Entry<MajorScope, List<GraduationCategory>> entry : majorByScope.entrySet()) {
-            List<GraduationCategory> majorCategoriesByScope = entry.getValue();
-
-            GraduationCategory majorRequiredCategory = findMajorRequired(majorCategoriesByScope);
-            GraduationCategory majorElectiveCategory = findMajorElective(majorCategoriesByScope);
-
-            // 전공(전필/전선) 이 아니면 그대로 추가
-            if (majorRequiredCategory == null || majorElectiveCategory == null) {
-                result.addAll(majorCategoriesByScope);
-                continue;
-            }
-
-            // 초과된 전필 학점
-            double majorRequiredOverflowCredits = Math.max(
-                0,
-                majorRequiredCategory.earnedCredits() - majorRequiredCategory.requiredCredits()
-            );
-
-            // 보정 된 전공(전필/전선) 학점 저장
-            double adjustedRequiredCredits = Math.min(
-                majorRequiredCategory.earnedCredits(),
-                majorRequiredCategory.requiredCredits()
-            );
-            double adjustedElectiveCredits = majorElectiveCategory.earnedCredits() + majorRequiredOverflowCredits;
-
-            result.add(createAdjustedMajorCategory(majorRequiredCategory, adjustedRequiredCredits));
-            result.add(createAdjustedMajorCategory(majorElectiveCategory, adjustedElectiveCredits));
-        }
     }
 
     private boolean calculateGraduatable(boolean originalGraduatable, List<GraduationCategory> categories) {
@@ -357,48 +216,6 @@ public class GraduationCheckResponseMapper {
             .filter(category -> category.categoryType() == categoryType)
             .findFirst()
             .orElse(null);
-    }
-
-    private GraduationCategory findMajorRequired(List<GraduationCategory> categories) {
-        for (GraduationCategory category : categories) {
-            if (CategoryType.MAJOR_REQUIRED.equals(category.categoryType())) {
-                return category;
-            }
-        }
-        return null;
-    }
-
-    private GraduationCategory findMajorElective(List<GraduationCategory> categories) {
-        for (GraduationCategory category : categories) {
-            if (CategoryType.MAJOR_ELECTIVE.equals(category.categoryType())) {
-                return category;
-            }
-        }
-        return null;
-    }
-
-    private GraduationCategory createAdjustedMajorCategory(
-        GraduationCategory graduationCategory,
-        double adjustedCredits
-    ) {
-        double remainingCredits = Math.max(0, graduationCategory.requiredCredits() - adjustedCredits);
-        boolean isSatisfied = isSatisfiedCreditCriterion(graduationCategory, adjustedCredits);
-
-        return new GraduationCategory(
-            graduationCategory.majorScope(),
-            graduationCategory.categoryType(),
-            adjustedCredits,
-            graduationCategory.requiredCredits(),
-            remainingCredits,
-            null,
-            null,
-            null,
-            isSatisfied
-        );
-    }
-
-    private static boolean isSatisfiedCreditCriterion(GraduationCategory graduationCategory, double adjustedCredits) {
-        return adjustedCredits >= graduationCategory.requiredCredits();
     }
 
     private EnglishTargetType parseEnglishTargetType(GraduationCertCriteriaResponse response) {

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapper.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapper.java
@@ -279,7 +279,7 @@ public class GraduationCheckResponseMapper {
         double adjustedCredits
     ) {
         double remainingCredits = Math.max(0, graduationCategory.requiredCredits() - adjustedCredits);
-        boolean isSatisfied = adjustedCredits >= graduationCategory.requiredCredits();
+        boolean isSatisfied = isSatisfiedCreditCriterion(graduationCategory, adjustedCredits);
 
         return new GraduationCategory(
             graduationCategory.majorScope(),
@@ -292,6 +292,10 @@ public class GraduationCheckResponseMapper {
             null,
             isSatisfied
         );
+    }
+
+    private static boolean isSatisfiedCreditCriterion(GraduationCategory graduationCategory, double adjustedCredits) {
+        return adjustedCredits >= graduationCategory.requiredCredits();
     }
 
     private EnglishTargetType parseEnglishTargetType(GraduationCertCriteriaResponse response) {

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapper.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapper.java
@@ -121,11 +121,15 @@ public class GraduationCheckResponseMapper {
     }
 
     private List<GraduationCategory> reallocateCredits(List<GraduationCategory> graduationCategories) {
-        Map<MajorScope, List<GraduationCategory>> groupedReallocateTargets = graduationCategories.stream()
-            .filter(this::isReallocateTarget)
+        Map<MajorScope, List<GraduationCategory>> groupedMajorCategories = graduationCategories.stream()
+            .filter(category -> category.categoryType().isMajorCategory())
             .collect(groupingBy(GraduationCategory::majorScope));
 
-        if (groupedReallocateTargets.isEmpty()) {
+        List<GraduationCategory> generalCategories = graduationCategories.stream()
+            .filter(category -> category.categoryType() == CategoryType.GENERAL)
+            .toList();
+
+        if (groupedMajorCategories.isEmpty()) {
             return graduationCategories;
         }
 
@@ -136,26 +140,27 @@ public class GraduationCheckResponseMapper {
             }
         }
 
-        adjustReallocateTargetCredits(groupedReallocateTargets, finishReallocate);
+        double generalOverflowCredits = adjustMajorCategoryCredits(groupedMajorCategories, finishReallocate);
+        mergeGeneralCredits(generalCategories, generalOverflowCredits, finishReallocate);
 
         return finishReallocate;
     }
 
-    private void adjustReallocateTargetCredits(
-        Map<MajorScope, List<GraduationCategory>> groupedReallocateTargets,
+    private double adjustMajorCategoryCredits(
+        Map<MajorScope, List<GraduationCategory>> groupedMajorCategories,
         List<GraduationCategory> finishReallocate
     ) {
-        for (Map.Entry<MajorScope, List<GraduationCategory>> entry : groupedReallocateTargets.entrySet()) {
+        double totalGeneralOverflowCredits = 0;
+
+        for (Map.Entry<MajorScope, List<GraduationCategory>> entry : groupedMajorCategories.entrySet()) {
             MajorScope majorScope = entry.getKey();
             List<GraduationCategory> reallocateCategory = entry.getValue();
 
             GraduationCategory majorRequired = findCategoryOrEmpty(reallocateCategory, CategoryType.MAJOR_REQUIRED, majorScope);
             GraduationCategory majorElective = findCategoryOrEmpty(reallocateCategory, CategoryType.MAJOR_ELECTIVE, majorScope);
-            GraduationCategory general = findCategoryOrEmpty(reallocateCategory, CategoryType.GENERAL, majorScope);
 
             boolean hasMajorRequired = findCategory(reallocateCategory, CategoryType.MAJOR_REQUIRED) != null;
             boolean hasMajorElective = findCategory(reallocateCategory, CategoryType.MAJOR_ELECTIVE) != null;
-            boolean hasGeneral = findCategory(reallocateCategory, CategoryType.GENERAL) != null;
 
             double overMajorRequired = majorRequired.overflowCredits();
             GraduationCategory adjustedRequired = majorRequired.withEarnedCredits(
@@ -174,8 +179,7 @@ public class GraduationCheckResponseMapper {
                 overMajorElective = 0;
                 adjustedElective = electiveWithCarry;
             }
-
-            GraduationCategory adjustedGeneral = general.addCredits(overMajorElective);
+            totalGeneralOverflowCredits += overMajorElective;
 
             if (hasMajorRequired || adjustedRequired.earnedCredits() > 0) {
                 finishReallocate.add(adjustedRequired);
@@ -183,10 +187,46 @@ public class GraduationCheckResponseMapper {
             if (hasMajorElective || overMajorRequired > 0) {
                 finishReallocate.add(adjustedElective);
             }
-            if (hasGeneral || overMajorElective > 0) {
-                finishReallocate.add(adjustedGeneral);
-            }
         }
+
+        return totalGeneralOverflowCredits;
+    }
+
+    private void mergeGeneralCredits(
+        List<GraduationCategory> generalCategories,
+        double generalOverflowCredits,
+        List<GraduationCategory> finishReallocate
+    ) {
+        GraduationCategory mergedGeneral = mergeGeneralCategories(generalCategories);
+        if (mergedGeneral == null && generalOverflowCredits <= 0) {
+            return;
+        }
+
+        GraduationCategory baseGeneral = mergedGeneral;
+        if (baseGeneral == null) {
+            baseGeneral = GraduationCategory.createEmptyGraduationCategory(
+                MajorScope.PRIMARY,
+                CategoryType.GENERAL
+            );
+        }
+        finishReallocate.add(baseGeneral.addCredits(generalOverflowCredits));
+    }
+
+    private GraduationCategory mergeGeneralCategories(List<GraduationCategory> generalCategories) {
+        if (generalCategories.isEmpty()) {
+            return null;
+        }
+
+        GraduationCategory baseGeneral = generalCategories.stream()
+            .filter(category -> category.majorScope() == MajorScope.PRIMARY)
+            .findFirst()
+            .orElse(generalCategories.get(0));
+
+        double mergedEarnedCredits = generalCategories.stream()
+            .mapToDouble(GraduationCategory::earnedCredits)
+            .sum();
+
+        return baseGeneral.withEarnedCredits(mergedEarnedCredits);
     }
 
     private GraduationCategory findCategoryOrEmpty(

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapper.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapper.java
@@ -64,32 +64,7 @@ public class GraduationCheckResponseMapper {
         Integer requiredAreasCnt = findRequiredAreasCnt(userId);
 
         List<GraduationCategory> categories = categoryResults.stream()
-            .map(result -> {
-                if (result.getCategoryType() == CategoryType.BALANCE_REQUIRED) {
-                    return new GraduationCategory(
-                        result.getMajorScope(),
-                        result.getCategoryType(),
-                        result.getMyCredits(),
-                        result.getRequiredCredits(),
-                        result.getRemainingCredits(),
-                        earnedAreas.size(),
-                        requiredAreasCnt,
-                        earnedAreas,
-                        result.getIsSatisfied()
-                    );
-                }
-                return new GraduationCategory(
-                    result.getMajorScope(),
-                    result.getCategoryType(),
-                    result.getMyCredits(),
-                    result.getRequiredCredits(),
-                    result.getRemainingCredits(),
-                    null,
-                    null,
-                    null,
-                    result.getIsSatisfied()
-                );
-            })
+            .map(result -> GraduationCategory.of(result, earnedAreas, requiredAreasCnt))
             .toList();
 
         // 2. 전필 초과 시 전선으로 학점 보정

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapper.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapper.java
@@ -1,5 +1,7 @@
 package kr.allcll.backend.domain.graduation.check.result;
 
+import static java.util.stream.Collectors.groupingBy;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -56,8 +58,7 @@ public class GraduationCheckResponseMapper {
         // 균형교양 이수 영역 조회
         Set<BalanceRequiredArea> earnedAreas = graduationCheckBalanceAreaResultRepository.findAllByUserId(userId)
             .stream()
-            .map(
-                kr.allcll.backend.domain.graduation.check.result.GraduationCheckBalanceAreaResult::getBalanceRequiredArea)
+            .map(GraduationCheckBalanceAreaResult::getBalanceRequiredArea)
             .collect(Collectors.toSet());
 
         // 균형교양 필요 영역 수 조회
@@ -67,8 +68,8 @@ public class GraduationCheckResponseMapper {
             .map(result -> GraduationCategory.of(result, earnedAreas, requiredAreasCnt))
             .toList();
 
-        // 2. 전필 초과 시 전선으로 학점 보정
-        List<GraduationCategory> adjustedCategories = adjustMajorCategories(categories);
+        // 2. 전필 초과 시 전선으로, 전선 초과 시 교양으로 학점 보정
+        List<GraduationCategory> adjustedCategories = reallocateCredits(categories);
 
         boolean adjustedGraduatable = calculateGraduatable(
             check.getCanGraduate(),
@@ -189,27 +190,119 @@ public class GraduationCheckResponseMapper {
     }
 
     private List<GraduationCategory> adjustMajorCategories(List<GraduationCategory> graduationCategories) {
-        // MAJOR_REQUIRED/MAJOR_ELECTIVE 별 그룹화
-        Map<MajorScope, List<GraduationCategory>> majorByScope = graduationCategories.stream()
-            .filter(this::isMajorCategory)
-            .collect(Collectors.groupingBy(GraduationCategory::majorScope));
+        return reallocateCredits(graduationCategories);
+    }
 
-        if (majorByScope.isEmpty()) {
+    private List<GraduationCategory> reallocateCredits(List<GraduationCategory> graduationCategories) {
+        Map<MajorScope, List<GraduationCategory>> groupedReallocateTargets = graduationCategories.stream()
+            .filter(this::isReallocateTarget)
+            .collect(groupingBy(GraduationCategory::majorScope));
+
+        if (groupedReallocateTargets.isEmpty()) {
             return graduationCategories;
         }
 
-        // 비전공 카테고리 추가
-        List<GraduationCategory> result = new ArrayList<>();
+        List<GraduationCategory> finishReallocate = new ArrayList<>();
         for (GraduationCategory category : graduationCategories) {
-            if (!isMajorCategory(category)) {
-                result.add(category);
+            if (!isReallocateTarget(category)) {
+                finishReallocate.add(category);
             }
         }
 
-        // scope(주전공/복수전공)별로 전필/전선 찾고 학점 adjust
-        adjustMajorCreditsByScope(majorByScope, result);
+        adjustReallocateTargetCredits(groupedReallocateTargets, finishReallocate);
 
-        return result;
+        return finishReallocate;
+    }
+
+    private void adjustReallocateTargetCredits(
+        Map<MajorScope, List<GraduationCategory>> groupedReallocateTargets,
+        List<GraduationCategory> finishReallocate
+    ) {
+        for (Map.Entry<MajorScope, List<GraduationCategory>> entry : groupedReallocateTargets.entrySet()) {
+            MajorScope majorScope = entry.getKey();
+            List<GraduationCategory> reallocateCategory = entry.getValue();
+
+            GraduationCategory majorRequired = findCategory(reallocateCategory, CategoryType.MAJOR_REQUIRED);
+            GraduationCategory majorElective = findCategory(reallocateCategory, CategoryType.MAJOR_ELECTIVE);
+            GraduationCategory general = findCategory(reallocateCategory, CategoryType.GENERAL);
+
+            boolean hasMajorRequired = hasCategoryType(majorRequired);
+            boolean hasMajorElective = hasCategoryType(majorElective);
+            boolean hasGeneral = hasCategoryType(general);
+
+            if (!hasMajorRequired) {
+                majorRequired = GraduationCategory.createEmptyGraduationCategory(
+                    majorScope,
+                    CategoryType.MAJOR_REQUIRED
+                );
+            }
+            if (!hasMajorElective) {
+                majorElective = GraduationCategory.createEmptyGraduationCategory(
+                    majorScope,
+                    CategoryType.MAJOR_ELECTIVE
+                );
+            }
+            if (!hasGeneral) {
+                general = GraduationCategory.createEmptyGraduationCategory(
+                    majorScope,
+                    CategoryType.GENERAL
+                );
+            }
+
+            double adjustedMajorRequiredCredits = Math.min(
+                majorRequired.earnedCredits(),
+                majorRequired.requiredCredits()
+            );
+            double overMajorRequiredCredits = Math.max(
+                majorRequired.earnedCredits() - majorRequired.requiredCredits(),
+                0
+            );
+
+            double electiveWithCarry = majorElective.earnedCredits() + overMajorRequiredCredits;
+            double adjustedMajorElectiveCredits;
+            double overMajorElectiveCredits;
+            if (hasMajorElective) {
+                adjustedMajorElectiveCredits = Math.min(
+                    electiveWithCarry,
+                    majorElective.requiredCredits()
+                );
+                overMajorElectiveCredits = Math.max(
+                    electiveWithCarry - majorElective.requiredCredits(),
+                    0
+                );
+            } else {
+                adjustedMajorElectiveCredits = electiveWithCarry;
+                overMajorElectiveCredits = 0;
+            }
+
+            double adjustedGeneralCredits = general.earnedCredits() + overMajorElectiveCredits;
+
+            boolean shouldAddMajorRequired = isShouldAdd(hasMajorRequired, adjustedMajorRequiredCredits);
+            boolean shouldAddMajorElective = isShouldAdd(hasMajorElective, overMajorRequiredCredits);
+            boolean shouldAddGeneral = isShouldAdd(hasGeneral, overMajorElectiveCredits);
+
+            if (shouldAddMajorRequired) {
+                finishReallocate.add(createAdjustedMajorCategory(majorRequired, adjustedMajorRequiredCredits));
+            }
+            if (shouldAddMajorElective) {
+                finishReallocate.add(createAdjustedMajorCategory(majorElective, adjustedMajorElectiveCredits));
+            }
+            if (shouldAddGeneral) {
+                finishReallocate.add(createAdjustedMajorCategory(general, adjustedGeneralCredits));
+            }
+        }
+    }
+
+    private static boolean isShouldAdd(boolean hasCategory, double adjustedCredits) {
+        return hasCategory || adjustedCredits > 0;
+    }
+
+    private static boolean hasCategoryType(GraduationCategory category) {
+        return category != null;
+    }
+
+    private boolean isReallocateTarget(GraduationCategory graduationCategory) {
+        return graduationCategory.categoryType().isReallocateTarget();
     }
 
     private boolean isMajorCategory(GraduationCategory category) {
@@ -254,6 +347,16 @@ public class GraduationCheckResponseMapper {
         boolean majorSatisfied = categories.stream()
             .allMatch(GraduationCategory::satisfied);
         return originalGraduatable && majorSatisfied;
+    }
+
+    private GraduationCategory findCategory(
+        List<GraduationCategory> categories,
+        CategoryType categoryType
+    ) {
+        return categories.stream()
+            .filter(category -> category.categoryType() == categoryType)
+            .findFirst()
+            .orElse(null);
     }
 
     private GraduationCategory findMajorRequired(List<GraduationCategory> categories) {

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/dto/GraduationCategory.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/dto/GraduationCategory.java
@@ -3,6 +3,7 @@ package kr.allcll.backend.domain.graduation.check.result.dto;
 import java.util.Set;
 import kr.allcll.backend.domain.graduation.MajorScope;
 import kr.allcll.backend.domain.graduation.balance.BalanceRequiredArea;
+import kr.allcll.backend.domain.graduation.check.result.GraduationCheckCategoryResult;
 import kr.allcll.backend.domain.graduation.credit.CategoryType;
 
 public record GraduationCategory(
@@ -17,4 +18,42 @@ public record GraduationCategory(
     Boolean satisfied
 ) {
 
+    public static GraduationCategory of(
+        GraduationCheckCategoryResult categoryResult,
+        Set<BalanceRequiredArea> earnedAreas,
+        Integer requiredAreasCnt
+    ) {
+        if (categoryResult.getCategoryType() == CategoryType.BALANCE_REQUIRED) {
+            return GraduationCategory.ofBalance(categoryResult, earnedAreas, requiredAreasCnt);
+        }
+        return new GraduationCategory(
+            categoryResult.getMajorScope(),
+            categoryResult.getCategoryType(),
+            categoryResult.getMyCredits(),
+            categoryResult.getRequiredCredits(),
+            categoryResult.getRemainingCredits(),
+            null,
+            null,
+            null,
+            categoryResult.getIsSatisfied()
+        );
+    }
+
+    private static GraduationCategory ofBalance(
+        GraduationCheckCategoryResult balanceCategory,
+        Set<BalanceRequiredArea> earnedAreas,
+        Integer requiredAreasCnt
+    ) {
+        return new GraduationCategory(
+            balanceCategory.getMajorScope(),
+            balanceCategory.getCategoryType(),
+            balanceCategory.getMyCredits(),
+            balanceCategory.getRequiredCredits(),
+            balanceCategory.getRemainingCredits(),
+            earnedAreas.size(),
+            requiredAreasCnt,
+            earnedAreas,
+            balanceCategory.getIsSatisfied()
+        );
+    }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/dto/GraduationCategory.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/dto/GraduationCategory.java
@@ -39,6 +39,20 @@ public record GraduationCategory(
         );
     }
 
+    public static GraduationCategory createEmptyGraduationCategory(MajorScope majorScope, CategoryType categoryType) {
+        return new GraduationCategory(
+            majorScope,
+            categoryType,
+            0.0,
+            0,
+            0.0,
+            null,
+            null,
+            null,
+            true
+        );
+    }
+
     private static GraduationCategory ofBalance(
         GraduationCheckCategoryResult balanceCategory,
         Set<BalanceRequiredArea> earnedAreas,

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/dto/GraduationCategory.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/dto/GraduationCategory.java
@@ -53,6 +53,23 @@ public record GraduationCategory(
         );
     }
 
+    public double overflowCredits() {
+        return Math.max(earnedCredits - requiredCredits, 0);
+    }
+
+    public GraduationCategory withEarnedCredits(double credits) {
+        double remaining = Math.max(0, requiredCredits - credits);
+        boolean isSatisfied = credits >= requiredCredits;
+        return new GraduationCategory(
+            majorScope, categoryType, credits, requiredCredits, remaining,
+            null, null, null, isSatisfied
+        );
+    }
+
+    public GraduationCategory addCredits(double additional) {
+        return withEarnedCredits(earnedCredits + additional);
+    }
+
     private static GraduationCategory ofBalance(
         GraduationCheckCategoryResult balanceCategory,
         Set<BalanceRequiredArea> earnedAreas,

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/CategoryType.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/CategoryType.java
@@ -32,9 +32,18 @@ public enum CategoryType { // 이수구분
         MAJOR_REQUIRED,
         MAJOR_ELECTIVE
     );
+    private static final Set<CategoryType> REALLOCATE_TARGET_CATEGORIES = EnumSet.of(
+        MAJOR_REQUIRED,
+        MAJOR_ELECTIVE,
+        GENERAL
+    );
 
     public boolean isMajorCategory() {
         return MAJOR_CATEGORIES.contains(this);
+    }
+
+    public boolean isReallocateTarget() {
+        return REALLOCATE_TARGET_CATEGORIES.contains(this);
     }
 
     public boolean isNonMajorCategory() {
@@ -64,7 +73,7 @@ public enum CategoryType { // 이수구분
     }
 
     private static CategoryType normalizeMajorBasic(int admissionYear) {
-        if (shouldConvertMajorBasicAsAcademicBasic(admissionYear)){
+        if (shouldConvertMajorBasicAsAcademicBasic(admissionYear)) {
             return ACADEMIC_BASIC;
         }
         return MAJOR_BASIC;

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapperTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapperTest.java
@@ -26,8 +26,8 @@ class GraduationCheckResponseMapperTest {
     @DisplayName("전필 초과 학점이 있으면 전선 카테고리를 생성해서 넘긴다")
     void createMajorElectiveWhenMajorRequiredOverflows() {
         List<GraduationCategory> result = invokeReallocateCredits(List.of(
-            category(CategoryType.MAJOR_REQUIRED, 36.0, 33),
-            category(CategoryType.GENERAL_ELECTIVE, 21.0, 21)
+            category(MajorScope.PRIMARY, CategoryType.MAJOR_REQUIRED, 36.0, 33),
+            category(MajorScope.PRIMARY, CategoryType.GENERAL_ELECTIVE, 21.0, 21)
         ));
 
         assertAll(
@@ -41,8 +41,8 @@ class GraduationCheckResponseMapperTest {
     @DisplayName("전선 초과 학점이 있으면 교양 카테고리를 생성해서 넘긴다")
     void createGeneralWhenMajorElectiveOverflows() {
         List<GraduationCategory> result = invokeReallocateCredits(List.of(
-            category(CategoryType.MAJOR_REQUIRED, 36.0, 33),
-            category(CategoryType.MAJOR_ELECTIVE, 41.0, 39)
+            category(MajorScope.PRIMARY, CategoryType.MAJOR_REQUIRED, 36.0, 33),
+            category(MajorScope.PRIMARY, CategoryType.MAJOR_ELECTIVE, 41.0, 39)
         ));
 
         assertAll(
@@ -56,8 +56,8 @@ class GraduationCheckResponseMapperTest {
     @DisplayName("초과 학점이 없으면 빈 전선이나 교양 카테고리를 만들지 않는다")
     void doNotCreateEmptyCategoriesWhenNoOverflow() {
         List<GraduationCategory> result = invokeReallocateCredits(List.of(
-            category(CategoryType.MAJOR_REQUIRED, 33.0, 33),
-            category(CategoryType.GENERAL_ELECTIVE, 21.0, 21)
+            category(MajorScope.PRIMARY, CategoryType.MAJOR_REQUIRED, 33.0, 33),
+            category(MajorScope.PRIMARY, CategoryType.GENERAL_ELECTIVE, 21.0, 21)
         ));
 
         assertAll(
@@ -65,6 +65,27 @@ class GraduationCheckResponseMapperTest {
             () -> assertThat(findNullableCategory(result, CategoryType.GENERAL)).isNull(),
             () -> assertThat(findCategory(result, CategoryType.MAJOR_REQUIRED).earnedCredits()).isEqualTo(33.0),
             () -> assertThat(findCategory(result, CategoryType.GENERAL_ELECTIVE).earnedCredits()).isEqualTo(21.0)
+        );
+    }
+
+    @Test
+    @DisplayName("복수전공의 전선 초과 학점은 마지막에 PRIMARY GENERAL로 합산한다")
+    void mergeGeneralOverflowIntoPrimaryAtTheEnd() {
+        List<GraduationCategory> result = invokeReallocateCredits(List.of(
+            category(MajorScope.PRIMARY, CategoryType.MAJOR_REQUIRED, 36.0, 33),
+            category(MajorScope.PRIMARY, CategoryType.MAJOR_ELECTIVE, 42.0, 39),
+            category(MajorScope.SECONDARY, CategoryType.MAJOR_REQUIRED, 18.0, 15),
+            category(MajorScope.SECONDARY, CategoryType.MAJOR_ELECTIVE, 24.0, 21),
+            category(MajorScope.PRIMARY, CategoryType.GENERAL, 10.0, 12)
+        ));
+
+        assertAll(
+            () -> assertThat(findCategory(result, MajorScope.PRIMARY, CategoryType.MAJOR_REQUIRED).earnedCredits()).isEqualTo(33.0),
+            () -> assertThat(findCategory(result, MajorScope.PRIMARY, CategoryType.MAJOR_ELECTIVE).earnedCredits()).isEqualTo(39.0),
+            () -> assertThat(findCategory(result, MajorScope.SECONDARY, CategoryType.MAJOR_REQUIRED).earnedCredits()).isEqualTo(15.0),
+            () -> assertThat(findCategory(result, MajorScope.SECONDARY, CategoryType.MAJOR_ELECTIVE).earnedCredits()).isEqualTo(21.0),
+            () -> assertThat(findCategory(result, MajorScope.PRIMARY, CategoryType.GENERAL).earnedCredits()).isEqualTo(22.0),
+            () -> assertThat(findNullableCategory(result, MajorScope.SECONDARY, CategoryType.GENERAL)).isNull()
         );
     }
 
@@ -77,10 +98,15 @@ class GraduationCheckResponseMapperTest {
         );
     }
 
-    private GraduationCategory category(CategoryType categoryType, double earnedCredits, int requiredCredits) {
+    private GraduationCategory category(
+        MajorScope majorScope,
+        CategoryType categoryType,
+        double earnedCredits,
+        int requiredCredits
+    ) {
         double remainingCredits = Math.max(requiredCredits - earnedCredits, 0);
         return new GraduationCategory(
-            MajorScope.PRIMARY,
+            majorScope,
             categoryType,
             earnedCredits,
             requiredCredits,
@@ -93,14 +119,32 @@ class GraduationCheckResponseMapperTest {
     }
 
     private GraduationCategory findCategory(List<GraduationCategory> categories, CategoryType categoryType) {
+        return findCategory(categories, MajorScope.PRIMARY, categoryType);
+    }
+
+    private GraduationCategory findCategory(
+        List<GraduationCategory> categories,
+        MajorScope majorScope,
+        CategoryType categoryType
+    ) {
         return categories.stream()
+            .filter(category -> category.majorScope() == majorScope)
             .filter(category -> category.categoryType() == categoryType)
             .findFirst()
             .orElseThrow();
     }
 
     private GraduationCategory findNullableCategory(List<GraduationCategory> categories, CategoryType categoryType) {
+        return findNullableCategory(categories, MajorScope.PRIMARY, categoryType);
+    }
+
+    private GraduationCategory findNullableCategory(
+        List<GraduationCategory> categories,
+        MajorScope majorScope,
+        CategoryType categoryType
+    ) {
         return categories.stream()
+            .filter(category -> category.majorScope() == majorScope)
             .filter(category -> category.categoryType() == categoryType)
             .findFirst()
             .orElse(null);

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapperTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckResponseMapperTest.java
@@ -1,0 +1,108 @@
+package kr.allcll.backend.domain.graduation.check.result;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import kr.allcll.backend.domain.graduation.MajorScope;
+import kr.allcll.backend.domain.graduation.check.result.dto.GraduationCategory;
+import kr.allcll.backend.domain.graduation.credit.CategoryType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class GraduationCheckResponseMapperTest {
+
+    private final GraduationCheckResponseMapper graduationCheckResponseMapper =
+        new GraduationCheckResponseMapper(null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+
+    @Test
+    @DisplayName("전필 초과 학점이 있으면 전선 카테고리를 생성해서 넘긴다")
+    void createMajorElectiveWhenMajorRequiredOverflows() {
+        List<GraduationCategory> result = invokeReallocateCredits(List.of(
+            category(CategoryType.MAJOR_REQUIRED, 36.0, 33),
+            category(CategoryType.GENERAL_ELECTIVE, 21.0, 21)
+        ));
+
+        assertAll(
+            () -> assertThat(findCategory(result, CategoryType.MAJOR_REQUIRED).earnedCredits()).isEqualTo(33.0),
+            () -> assertThat(findCategory(result, CategoryType.MAJOR_ELECTIVE).earnedCredits()).isEqualTo(3.0),
+            () -> assertThat(findCategory(result, CategoryType.GENERAL_ELECTIVE).earnedCredits()).isEqualTo(21.0)
+        );
+    }
+
+    @Test
+    @DisplayName("전선 초과 학점이 있으면 교양 카테고리를 생성해서 넘긴다")
+    void createGeneralWhenMajorElectiveOverflows() {
+        List<GraduationCategory> result = invokeReallocateCredits(List.of(
+            category(CategoryType.MAJOR_REQUIRED, 36.0, 33),
+            category(CategoryType.MAJOR_ELECTIVE, 41.0, 39)
+        ));
+
+        assertAll(
+            () -> assertThat(findCategory(result, CategoryType.MAJOR_REQUIRED).earnedCredits()).isEqualTo(33.0),
+            () -> assertThat(findCategory(result, CategoryType.MAJOR_ELECTIVE).earnedCredits()).isEqualTo(39.0),
+            () -> assertThat(findCategory(result, CategoryType.GENERAL).earnedCredits()).isEqualTo(5.0)
+        );
+    }
+
+    @Test
+    @DisplayName("초과 학점이 없으면 빈 전선이나 교양 카테고리를 만들지 않는다")
+    void doNotCreateEmptyCategoriesWhenNoOverflow() {
+        List<GraduationCategory> result = invokeReallocateCredits(List.of(
+            category(CategoryType.MAJOR_REQUIRED, 33.0, 33),
+            category(CategoryType.GENERAL_ELECTIVE, 21.0, 21)
+        ));
+
+        assertAll(
+            () -> assertThat(findNullableCategory(result, CategoryType.MAJOR_ELECTIVE)).isNull(),
+            () -> assertThat(findNullableCategory(result, CategoryType.GENERAL)).isNull(),
+            () -> assertThat(findCategory(result, CategoryType.MAJOR_REQUIRED).earnedCredits()).isEqualTo(33.0),
+            () -> assertThat(findCategory(result, CategoryType.GENERAL_ELECTIVE).earnedCredits()).isEqualTo(21.0)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<GraduationCategory> invokeReallocateCredits(List<GraduationCategory> categories) {
+        return (List<GraduationCategory>) ReflectionTestUtils.invokeMethod(
+            graduationCheckResponseMapper,
+            "reallocateCredits",
+            categories
+        );
+    }
+
+    private GraduationCategory category(CategoryType categoryType, double earnedCredits, int requiredCredits) {
+        double remainingCredits = Math.max(requiredCredits - earnedCredits, 0);
+        return new GraduationCategory(
+            MajorScope.PRIMARY,
+            categoryType,
+            earnedCredits,
+            requiredCredits,
+            remainingCredits,
+            null,
+            null,
+            null,
+            remainingCredits <= 0
+        );
+    }
+
+    private GraduationCategory findCategory(List<GraduationCategory> categories, CategoryType categoryType) {
+        return categories.stream()
+            .filter(category -> category.categoryType() == categoryType)
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private GraduationCategory findNullableCategory(List<GraduationCategory> categories, CategoryType categoryType) {
+        return categories.stream()
+            .filter(category -> category.categoryType() == categoryType)
+            .findFirst()
+            .orElse(null);
+    }
+}


### PR DESCRIPTION
## 작업 내용
기존에는 전공필수(MAJOR_REQUIRED) 초과 학점을 전공선택(MAJOR_ELECTIVE)으로만 넘겨주고 있었습니다.
이번 작업에서는 여기에 더해, 전공선택도 초과할 경우 교양(GENERAL)으로 넘겨주는 로직을 추가했습니다.

즉 현재 보정 순서는 아래와 같습니다.

`MAJOR_REQUIRED` -> `MAJOR_ELECTIVE`
`MAJOR_ELECTIVE` -> `GENERAL`

재배분 대상은 MAJOR_REQUIRED, MAJOR_ELECTIVE, GENERAL 3개입니다.

findCategory()는 현재 결과 카테고리 목록에서 해당 타입이 실제로 존재하는지 확인합니다.
없으면 null을 반환하고, 이월 학점을 계산해야 하는 경우에만 createEmptyGraduationCategory()로 계산용 fallback 객체를 생성합니다.

이 fallback은 학점을 담기 위한 임시 객체이고, 현재는 requiredCredits=0으로 생성됩니다.
즉 “실제 기준 학점이 0”이라기보다는, “기준 정보를 별도로 조회하지 않았기 때문에 0으로 채워둔 상태”입니다.

보정 후에는:
원래 존재하던 카테고리는 그대로 유지하고
원래 없던 카테고리라도 실제 이월 학점이 생긴 경우에만 결과 DTO에 추가합니다
반대로 이월 후에도 값이 없으면 DTO에는 추가하지 않습니다
예를 들어 전필 초과분이 전선으로는 넘어가지만, 전선에서 다시 교양으로 넘길 초과분이 없다면 GENERAL은 응답에 추가하지 않습니다.
```
"전필이 3학점 초과, 전선은 10학점 더 들어야됨, GENERAL 들은 이력 없음"의 경우, 
전선에 3학점이 넘어가더라도 교양으로 넘어갈 초과 학점은 없잖아요? 10-3=7학점을 아직 더 들어야하니까요. 
이 때에 GENERAL 정보를 생성한 후 `finishReallocate`에 넣어주지 않는다는 것입니다.
``` 

### 그런데 다음과 같은 문제가 있습니다.
현재 로직은 응답 DTO 생성 단계에서 동작합니다.
그래서 카테고리가 원래 없을 경우, fallback 객체는 만들 수 있어도 실제 requiredCredits 기준은 알 수 없습니다.

예를 들어 전필을 매우 많이 이수했고 전선/교양 이력이 아예 없는 경우:
전필 초과분을 전선으로 넘기는 것은 가능하지만
전선 기준학점까지 초과했는지 정확히 판단하려면 실제 기준 정보 조회가 필요합니다
즉 이 문제를 완전히 해결하려면 CreditCriterion 등 실제 기준 학점을 함께 참조하는 방향의 리팩토링이 필요할 수 있습니다.

### 테스트
아래 케이스를 테스트로 추가했습니다.
1. 전필 초과 시 전선 카테고리가 생성되는지
2. 전선 초과 시 교양 카테고리가 생성되는지
3. 초과가 없을 때 빈 전선/교양 카테고리가 생기지 않는지

로컬 테스트 결과는 다음과 같습니다. 제 성적표에서 교선 3학점 짜리 두개, 단순 교양 한개를 전선으로 바꾸고 돌려봤을때, 기존에는 하단과 같이 23학점 이수였던 교선 학점이,
<img width="357" height="238" alt="image" src="https://github.com/user-attachments/assets/db354a4d-6bdb-4542-93a0-a56a9f21336e" />

아래와 같이 17학점으로 줄었습니다.
<img width="357" height="238" alt="image" src="https://github.com/user-attachments/assets/890ecb81-cc81-49ce-9a77-5b3bf532f5d8" />

그리고 GENERAL 필드가 생기면서 9학점으로 계산이 되었습니다.
<img width="357" height="238" alt="image" src="https://github.com/user-attachments/assets/632df452-6988-4426-b94d-c6aa0a9b9e8f" />


## 고민 지점과 리뷰 포인트
테스트도 추가 했는데, 그럼에도 정말 꼼꼼꼼꼼꼼꼼한 리뷰가 필요합니다.
1. 코드가 제대로 동작하는게 맞는가? 
2. 재배분 로직을 ResponseMapper에서 처리하는 현재 위치가 적절한지
3. fallback 카테고리의 requiredCredits=0 처리 방식이 괜찮은지

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->