### PR TITLE
[TSK-72] 영어 졸업 인증 수정 기능

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCheckCertResult.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/cert/GraduationCheckCertResult.java
@@ -210,6 +210,10 @@ public class GraduationCheckCertResult {
         return Boolean.TRUE.equals(this.isClassicsCertPassed);
     }
 
+    public void updateEnglish(boolean passed) {
+        isEnglishCertPassed = passed;
+    }
+
     public static GraduationCheckCertResult empty() {
         return new GraduationCheckCertResult(
             null,

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckApi.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckApi.java
@@ -1,12 +1,16 @@
 package kr.allcll.backend.domain.graduation.check.result;
 
+import jakarta.validation.Valid;
 import kr.allcll.backend.domain.graduation.check.result.dto.CompletedCoursesResponse;
 import kr.allcll.backend.domain.graduation.check.result.dto.GraduationCheckResponse;
+import kr.allcll.backend.domain.graduation.check.result.dto.UpdateEnglishCertRequest;
 import kr.allcll.backend.support.web.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -36,5 +40,14 @@ public class GraduationCheckApi {
     public ResponseEntity<CompletedCoursesResponse> getAllCompletedCourses(@Auth Long userId) {
         CompletedCoursesResponse response = graduationCheckService.getAllCompletedCourses(userId);
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/api/graduation/check/certifications/english")
+    public ResponseEntity<Void> updateEnglishCertPass(
+        @Auth Long userId,
+        @Valid @RequestBody UpdateEnglishCertRequest updateEnglishCertRequest
+    ) {
+        graduationCheckService.updateEnglishCertPass(userId, updateEnglishCertRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckService.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckService.java
@@ -1,6 +1,8 @@
 package kr.allcll.backend.domain.graduation.check.result;
 
 import java.util.List;
+import kr.allcll.backend.domain.graduation.check.cert.GraduationCheckCertResult;
+import kr.allcll.backend.domain.graduation.check.cert.GraduationCheckCertResultRepository;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourseDto;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCoursePersistenceService;
@@ -9,23 +11,28 @@ import kr.allcll.backend.domain.graduation.check.excel.GradeExcelParser;
 import kr.allcll.backend.domain.graduation.check.result.dto.CheckResult;
 import kr.allcll.backend.domain.graduation.check.result.dto.CompletedCoursesResponse;
 import kr.allcll.backend.domain.graduation.check.result.dto.GraduationCheckResponse;
+import kr.allcll.backend.domain.graduation.check.result.dto.UpdateEnglishCertRequest;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
 import kr.allcll.backend.support.exception.AllcllException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class GraduationCheckService {
 
     private final GradeExcelParser gradeExcelParser;
     private final GraduationChecker graduationChecker;
     private final GraduationCheckRepository graduationCheckRepository;
+    private final GraduationCheckCertResultRepository graduationCheckCertResultRepository;
     private final GraduationCheckResponseMapper graduationCheckResponseMapper;
     private final CompletedCoursePersistenceService completedCoursePersistenceService;
     private final GraduationCheckPersistenceService graduationCheckPersistenceService;
 
+    @Transactional
     public void checkGraduationRequirements(Long userId, MultipartFile gradeExcel) {
         validateExcelFile(gradeExcel);
 
@@ -62,5 +69,13 @@ public class GraduationCheckService {
         List<CompletedCourse> userCompletedCourses = completedCoursePersistenceService.getCompletedCourses(userId);
         CompletedCourses completedCourses = new CompletedCourses(userCompletedCourses);
         return CompletedCoursesResponse.from(completedCourses);
+    }
+
+    @Transactional
+    public void updateEnglishCertPass(Long userId, UpdateEnglishCertRequest updateEnglishCertRequest) {
+        GraduationCheckCertResult graduationResult = graduationCheckCertResultRepository.findByUserId(userId)
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.GRADUATION_CERT_NOT_FOUND));
+        graduationResult.updateEnglish(updateEnglishCertRequest.isPassed());
+        graduationResult.reCalculate();
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/dto/UpdateEnglishCertRequest.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/dto/UpdateEnglishCertRequest.java
@@ -1,0 +1,10 @@
+package kr.allcll.backend.domain.graduation.check.result.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateEnglishCertRequest(
+    @NotNull
+    Boolean isPassed
+) {
+
+}

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckServiceTest.java
@@ -4,13 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
+import kr.allcll.backend.domain.graduation.certification.GraduationCertRuleType;
+import kr.allcll.backend.domain.graduation.check.cert.GraduationCheckCertResult;
+import kr.allcll.backend.domain.graduation.check.cert.GraduationCheckCertResultRepository;
 import kr.allcll.backend.domain.graduation.certification.CodingTargetType;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourseDto;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCoursePersistenceService;
 import kr.allcll.backend.domain.graduation.check.result.dto.CompletedCoursesResponse;
+import kr.allcll.backend.domain.graduation.check.result.dto.UpdateEnglishCertRequest;
 import kr.allcll.backend.domain.graduation.department.GraduationDepartmentInfo;
 import kr.allcll.backend.domain.user.User;
 import kr.allcll.backend.domain.user.UserRepository;
+import kr.allcll.backend.fixture.GraduationCheckCertResultFixture;
 import kr.allcll.backend.fixture.GraduationDepartmentInfoFixture;
 import kr.allcll.backend.fixture.UserFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -18,8 +23,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@Transactional
 class GraduationCheckServiceTest {
 
     @Autowired
@@ -30,6 +37,9 @@ class GraduationCheckServiceTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private GraduationCheckCertResultRepository graduationCheckCertResultRepository;
 
     @Test
     @DisplayName("빈환값의 개수와 내용을 확인한다.")
@@ -69,5 +79,59 @@ class GraduationCheckServiceTest {
                 tuple("123456", "과목명A", true),
                 tuple("654321", "과목명B", false)
             );
+    }
+
+    @Test
+    @DisplayName("영어 인증을 true로 수정하면 passedCount와 만족 여부를 재계산한다.")
+    void updateEnglishCertPass_true_recalculatesResult() {
+        // given
+        GraduationDepartmentInfo graduationDepartmentInfo = GraduationDepartmentInfoFixture
+            .createDepartmentInfo(2021, CodingTargetType.CODING_MAJOR);
+        User user = userRepository.save(UserFixture.singleMajorUser(2021, graduationDepartmentInfo));
+        GraduationCheckCertResult certResult = GraduationCheckCertResultFixture.createCertResult(
+            user,
+            GraduationCertRuleType.BOTH_REQUIRED,
+            false,
+            false,
+            true
+        );
+        graduationCheckCertResultRepository.save(certResult);
+
+        // when
+        graduationCheckService.updateEnglishCertPass(user.getId(), new UpdateEnglishCertRequest(true));
+        GraduationCheckCertResult updated = graduationCheckCertResultRepository.findByUserId(user.getId()).orElseThrow();
+
+        // then
+        assertThat(updated.getIsEnglishCertPassed()).isTrue();
+        assertThat(updated.getPassedCount()).isEqualTo(2);
+        assertThat(updated.getRequiredPassCount()).isEqualTo(2);
+        assertThat(updated.getIsSatisfied()).isTrue();
+    }
+
+    @Test
+    @DisplayName("영어 인증을 false로 수정하면 passedCount와 만족 여부를 재계산한다.")
+    void updateEnglishCertPass_false_recalculatesResult() {
+        // given
+        GraduationDepartmentInfo graduationDepartmentInfo = GraduationDepartmentInfoFixture
+            .createDepartmentInfo(2021, CodingTargetType.CODING_MAJOR);
+        User user = userRepository.save(UserFixture.singleMajorUser(2021, graduationDepartmentInfo));
+        GraduationCheckCertResult certResult = GraduationCheckCertResultFixture.createCertResult(
+            user,
+            GraduationCertRuleType.BOTH_REQUIRED,
+            true,
+            false,
+            true
+        );
+        graduationCheckCertResultRepository.save(certResult);
+
+        // when
+        graduationCheckService.updateEnglishCertPass(user.getId(), new UpdateEnglishCertRequest(false));
+        GraduationCheckCertResult updated = graduationCheckCertResultRepository.findByUserId(user.getId()).orElseThrow();
+
+        // then
+        assertThat(updated.getIsEnglishCertPassed()).isFalse();
+        assertThat(updated.getPassedCount()).isEqualTo(1);
+        assertThat(updated.getRequiredPassCount()).isEqualTo(2);
+        assertThat(updated.getIsSatisfied()).isFalse();
     }
 }


### PR DESCRIPTION
## 작업 내용
영어 졸업 인증 결과를 사용자가 수정할 수 있도록 합니다.
https://www.notion.so/33eacf7c3162802d8901f390af8b69b3?source=copy_link
명세는 위의 링크에서 확인할 수 있습니다.

작업 배경은 다음과 같습니다.
- 영어 인증을 메일로 제출하던 시기가 있습니다.
- 이 때의 제출은 확인할 방도가 없습니다.
- 따라서 사용자가 직접 갱신할 수 있도록 기능을 추가합니다.

## 고민 지점과 리뷰 포인트
- API의 위치가 적절한지 함께 봐주세요.

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->