### PR TITLE
[TSK-56-150] TOSC 로그인 실패 시 toscLoginFailed가 항상 false로 반환되는 문제 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/user/ToscAuthService.java
+++ b/src/main/java/kr/allcll/backend/domain/user/ToscAuthService.java
@@ -6,6 +6,8 @@ import java.net.SocketTimeoutException;
 import kr.allcll.backend.client.LoginProperties;
 import kr.allcll.backend.domain.user.dto.LoginRequest;
 import kr.allcll.backend.domain.user.dto.ToscResponse;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.FormBody;
@@ -39,13 +41,13 @@ public class ToscAuthService {
             if (!response.isSuccessful()) {
                 log.error("[TOSC] HTTP 요청 실패 (상태 코드: {}, 학번: {})",
                     response.code(), loginRequest.studentId());
-                return;
+                throw new AllcllException(AllcllErrorCode.TOSC_LOGIN_FAIL);
             }
 
             ResponseBody responseBody = response.body();
             if (responseBody == null) {
                 log.error("[TOSC] 응답 본문이 비어있음 (학번: {})", loginRequest.studentId());
-                return;
+                throw new AllcllException(AllcllErrorCode.TOSC_LOGIN_FAIL);
             }
 
             String responseString = responseBody.string();
@@ -54,13 +56,14 @@ public class ToscAuthService {
             if (!toscResponse.success()) {
                 log.error("[TOSC] 로그인 실패 (학번: {}, 에러: {})",
                     loginRequest.studentId(), toscResponse.getErrorMessage());
+                throw new AllcllException(AllcllErrorCode.TOSC_LOGIN_FAIL);
             }
         } catch (SocketTimeoutException exception) {
             log.error("[TOSC] 타임아웃 발생 (학번: {})", loginRequest.studentId(), exception);
+            throw new AllcllException(AllcllErrorCode.TOSC_LOGIN_IO_ERROR);
         } catch (IOException exception) {
             log.error("[TOSC] I/O 오류 발생 (학번: {})", loginRequest.studentId(), exception);
-        } catch (Exception exception) {
-            log.error("[TOSC] 예상치 못한 오류 발생 (학번: {})", loginRequest.studentId(), exception);
+            throw new AllcllException(AllcllErrorCode.TOSC_LOGIN_IO_ERROR);
         }
     }
 }


### PR DESCRIPTION
## 📌 Summary

이전 PR에서 TOSC 로그인 실패 시 전체 로그인이 차단되지 않도록 개선했으나, `ToscAuthService.loginTosc`가 모든 실패를 내부에서 catch하여 정상 리턴하면서 `AuthFacade`의 catch 블록이 실행되지 않는 문제가 있었습니다.

이로 인해 `LoginResult.toscLoginFailed`가 항상 `false`로 반환되어 클라이언트가 TOSC 로그인 실패를 감지할 수 없었습니다.

이전 PR URL : https://github.com/allcll/allcll-backend/pull/308

## ✅ Solution

`ToscAuthService.loginTosc`에서 실패 시 로깅 후 `AllcllException`을 던지도록 변경하여, `AuthFacade`의 catch 블록이 정상적으로 `toscLoginFailed=true`를 설정하도록 수정했습니다.

- HTTP 실패 / 빈 body / `success=false` → `AllcllException(TOSC_LOGIN_FAIL)` throw
- `SocketTimeoutException` / `IOException` → `AllcllException(TOSC_LOGIN_IO_ERROR)` throw
- 기존 로깅은 그대로 유지

## 📝 Changes

- `src/main/java/kr/allcll/backend/domain/user/ToscAuthService.java`
  - 실패 경로에서 로그 후 `return` → 로그 후 `AllcllException` throw로 변경
  - 불필요한 `catch (Exception)` 블록 제거
