### PR TITLE
[TSK-73] 어드민 공지 응답, 리뷰 조회 응답 updatedAt, createdAt 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/notice/dto/AdminNoticeResponse.java
+++ b/src/main/java/kr/allcll/backend/admin/notice/dto/AdminNoticeResponse.java
@@ -9,7 +9,8 @@ public record AdminNoticeResponse(
     String title,
     String content,
     OperationType operationType,
-    LocalDateTime createdAt
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
 ) {
 
     public static AdminNoticeResponse from(Notice notice) {
@@ -18,7 +19,8 @@ public record AdminNoticeResponse(
             notice.getTitle(),
             notice.getContent(),
             notice.getOperationType(),
-            notice.getCreatedAt()
+            notice.getCreatedAt(),
+            notice.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/kr/allcll/backend/admin/notice/dto/UpdateNoticeResponse.java
+++ b/src/main/java/kr/allcll/backend/admin/notice/dto/UpdateNoticeResponse.java
@@ -9,6 +9,7 @@ public record UpdateNoticeResponse(
     String title,
     String content,
     OperationType operationType,
+    LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {
 
@@ -18,6 +19,7 @@ public record UpdateNoticeResponse(
             notice.getTitle(),
             notice.getContent(),
             notice.getOperationType(),
+            notice.getCreatedAt(),
             notice.getUpdatedAt()
         );
     }

--- a/src/main/java/kr/allcll/backend/admin/review/AdminUserReviewApi.java
+++ b/src/main/java/kr/allcll/backend/admin/review/AdminUserReviewApi.java
@@ -2,7 +2,7 @@ package kr.allcll.backend.admin.review;
 
 import jakarta.servlet.http.HttpServletRequest;
 import kr.allcll.backend.admin.AdminRequestValidator;
-import kr.allcll.backend.admin.review.dto.AdminUserReviewResponses;
+import kr.allcll.backend.admin.review.dto.AdminUserReviewsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,11 +16,11 @@ public class AdminUserReviewApi {
     private final AdminUserReviewService adminUserReviewService;
 
     @GetMapping("/api/admin/review")
-    public ResponseEntity<AdminUserReviewResponses> getReview(HttpServletRequest request) {
+    public ResponseEntity<AdminUserReviewsResponse> getReview(HttpServletRequest request) {
         if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
             return ResponseEntity.status(401).build();
         }
-        AdminUserReviewResponses responses = adminUserReviewService.getReview();
+        AdminUserReviewsResponse responses = adminUserReviewService.getReview();
         return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/kr/allcll/backend/admin/review/AdminUserReviewService.java
+++ b/src/main/java/kr/allcll/backend/admin/review/AdminUserReviewService.java
@@ -1,8 +1,7 @@
 package kr.allcll.backend.admin.review;
 
 import java.util.List;
-import kr.allcll.backend.admin.review.dto.AdminUserReviewResponse;
-import kr.allcll.backend.admin.review.dto.AdminUserReviewResponses;
+import kr.allcll.backend.admin.review.dto.AdminUserReviewsResponse;
 import kr.allcll.backend.domain.review.UserReview;
 import kr.allcll.backend.domain.review.UserReviewRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +15,8 @@ public class AdminUserReviewService {
 
     private final UserReviewRepository userReviewRepository;
 
-    public AdminUserReviewResponses getReview() {
+    public AdminUserReviewsResponse getReview() {
         List<UserReview> reviews = userReviewRepository.findAll();
-        return new AdminUserReviewResponses(
-            reviews.stream()
-                .map(AdminUserReviewResponse::from)
-                .toList()
-        );
+        return AdminUserReviewsResponse.from(reviews);
     }
 }

--- a/src/main/java/kr/allcll/backend/admin/review/dto/AdminUserReviewResponse.java
+++ b/src/main/java/kr/allcll/backend/admin/review/dto/AdminUserReviewResponse.java
@@ -1,5 +1,6 @@
 package kr.allcll.backend.admin.review.dto;
 
+import java.time.LocalDateTime;
 import kr.allcll.backend.domain.operationPeriod.OperationType;
 import kr.allcll.backend.domain.review.UserReview;
 
@@ -7,7 +8,8 @@ public record AdminUserReviewResponse(
     String studentId,
     Short rate,
     String detail,
-    OperationType operationType
+    OperationType operationType,
+    LocalDateTime createdAt
 ) {
 
     public static AdminUserReviewResponse from(UserReview userReview) {
@@ -15,7 +17,8 @@ public record AdminUserReviewResponse(
             userReview.getStudentId(),
             userReview.getRate(),
             userReview.getDetail(),
-            userReview.getOperationType()
+            userReview.getOperationType(),
+            userReview.getCreatedAt()
         );
     }
 }

--- a/src/main/java/kr/allcll/backend/admin/review/dto/AdminUserReviewResponses.java
+++ b/src/main/java/kr/allcll/backend/admin/review/dto/AdminUserReviewResponses.java
@@ -1,9 +1,0 @@
-package kr.allcll.backend.admin.review.dto;
-
-import java.util.List;
-
-public record AdminUserReviewResponses(
-    List<AdminUserReviewResponse> reviews
-) {
-
-}

--- a/src/main/java/kr/allcll/backend/admin/review/dto/AdminUserReviewsResponse.java
+++ b/src/main/java/kr/allcll/backend/admin/review/dto/AdminUserReviewsResponse.java
@@ -1,0 +1,17 @@
+package kr.allcll.backend.admin.review.dto;
+
+import java.util.List;
+import kr.allcll.backend.domain.review.UserReview;
+
+public record AdminUserReviewsResponse(
+    List<AdminUserReviewResponse> reviews
+) {
+
+    public static AdminUserReviewsResponse from(List<UserReview> reviews) {
+        return new AdminUserReviewsResponse(
+            reviews.stream()
+                .map(AdminUserReviewResponse::from)
+                .toList()
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 어드민 공지 **수정** 후 응답과 어드민 공지 **조회** 시 응답에 updatedAt과 createdAt을 둘 다 반환하도록 추가했습니다. 
  - [공지사항 API 명세](https://www.notion.so/API-32cacf7c316280e998f1eb91d986ef42?source=copy_link)에 해당 내용 업데이트 해두었습니다.

- 리뷰 조회 시 createdAt 응답을 추가해주었습니다.

## 고민 지점과 리뷰 포인트
- 제가 혹시 잘못된 곳에 추가했는지 간단하게 같이 봐주시면 되겠습니다~!

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->