### PR TITLE
[TSK-79] 세션 연결 시 빈 body값에 대한 에러 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# AI 학습
+.claude/skills/
+.claude/docs/

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,3 @@ out/
 
 ### VS Code ###
 .vscode/
-
-# AI 학습
-.claude/skills/
-.claude/docs/

--- a/src/main/java/kr/allcll/backend/admin/session/AdminSessionApi.java
+++ b/src/main/java/kr/allcll/backend/admin/session/AdminSessionApi.java
@@ -30,7 +30,7 @@ public class AdminSessionApi {
         if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
             return ResponseEntity.status(401).build();
         }
-        if (!setCredentialRequest.isValid()) {
+        if (!setCredentialRequest.hasAllTokens()) {
             return ResponseEntity.badRequest().build();
         }
         sessionService.setCredential(setCredentialRequest);

--- a/src/main/java/kr/allcll/backend/admin/session/AdminSessionApi.java
+++ b/src/main/java/kr/allcll/backend/admin/session/AdminSessionApi.java
@@ -1,6 +1,7 @@
 package kr.allcll.backend.admin.session;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.List;
 import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.admin.session.dto.CredentialResponse;
@@ -26,7 +27,7 @@ public class AdminSessionApi {
 
     @PostMapping("/api/admin/session")
     public ResponseEntity<Void> setCredential(HttpServletRequest request,
-        @RequestBody SetCredentialRequest setCredentialRequest) {
+        @Valid @RequestBody SetCredentialRequest setCredentialRequest) {
         if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
             return ResponseEntity.status(401).build();
         }

--- a/src/main/java/kr/allcll/backend/admin/session/AdminSessionApi.java
+++ b/src/main/java/kr/allcll/backend/admin/session/AdminSessionApi.java
@@ -1,7 +1,6 @@
 package kr.allcll.backend.admin.session;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.Valid;
 import java.util.List;
 import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.admin.session.dto.CredentialResponse;
@@ -27,9 +26,12 @@ public class AdminSessionApi {
 
     @PostMapping("/api/admin/session")
     public ResponseEntity<Void> setCredential(HttpServletRequest request,
-        @Valid @RequestBody SetCredentialRequest setCredentialRequest) {
+        @RequestBody SetCredentialRequest setCredentialRequest) {
         if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
             return ResponseEntity.status(401).build();
+        }
+        if (!setCredentialRequest.isValid()) {
+            return ResponseEntity.badRequest().build();
         }
         sessionService.setCredential(setCredentialRequest);
         return ResponseEntity.ok().build();

--- a/src/main/java/kr/allcll/backend/admin/session/SessionService.java
+++ b/src/main/java/kr/allcll/backend/admin/session/SessionService.java
@@ -32,10 +32,6 @@ public class SessionService {
     private final Map<String, LocalDateTime> sessionUpdatedTimes = new ConcurrentHashMap<>();
 
     public void setCredential(SetCredentialRequest request) {
-        boolean isValidRequest = isValidCredentialRequest(request);
-        if (!isValidRequest) {
-            return;
-        }
         Credential credential = request.toCredential();
         validateCredential(credential);
         credentials.addCredential(credential);
@@ -90,14 +86,6 @@ public class SessionService {
         threadPoolTaskScheduler.cancelAll();
         credentials.deleteAll();
         sessionUpdatedTimes.clear();
-    }
-
-    private boolean isValidCredentialRequest(SetCredentialRequest request) {
-        if (request.tokenJ() == null || request.tokenU() == null || request.tokenR() == null
-            || request.tokenL() == null) {
-            return false;
-        }
-        return true;
     }
 
     private boolean validateCredential(Credential credential) {

--- a/src/main/java/kr/allcll/backend/admin/session/SessionService.java
+++ b/src/main/java/kr/allcll/backend/admin/session/SessionService.java
@@ -33,13 +33,13 @@ public class SessionService {
 
     public void setCredential(SetCredentialRequest request) {
         Credential credential = request.toCredential();
-        validateCredential(credential);
+        isSessionValid(credential);
         credentials.addCredential(credential);
     }
 
     public CredentialResponse getCredential(String userId) {
         Credential credential = credentials.findByUserId(userId);
-        boolean isValid = validateCredential(credential);
+        boolean isValid = isSessionValid(credential);
         if (isValid) {
             return CredentialResponse.fromCredential(credential);
         }
@@ -88,7 +88,7 @@ public class SessionService {
         sessionUpdatedTimes.clear();
     }
 
-    private boolean validateCredential(Credential credential) {
+    private boolean isSessionValid(Credential credential) {
         try {
             sessionClient.execute(credential, new EmptyPayload());
             return true;

--- a/src/main/java/kr/allcll/backend/admin/session/dto/SetCredentialRequest.java
+++ b/src/main/java/kr/allcll/backend/admin/session/dto/SetCredentialRequest.java
@@ -1,11 +1,19 @@
 package kr.allcll.backend.admin.session.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import kr.allcll.crawler.credential.Credential;
 
 public record SetCredentialRequest(
+    @NotBlank
     String tokenJ,
+
+    @NotBlank
     String tokenU,
+
+    @NotBlank
     String tokenR,
+
+    @NotBlank
     String tokenL
 ) {
 

--- a/src/main/java/kr/allcll/backend/admin/session/dto/SetCredentialRequest.java
+++ b/src/main/java/kr/allcll/backend/admin/session/dto/SetCredentialRequest.java
@@ -9,7 +9,7 @@ public record SetCredentialRequest(
     String tokenL
 ) {
 
-    public boolean isValid() {
+    public boolean hasAllTokens() {
         return !isBlank(tokenJ) && !isBlank(tokenU) && !isBlank(tokenR) && !isBlank(tokenL);
     }
 

--- a/src/main/java/kr/allcll/backend/admin/session/dto/SetCredentialRequest.java
+++ b/src/main/java/kr/allcll/backend/admin/session/dto/SetCredentialRequest.java
@@ -1,23 +1,23 @@
 package kr.allcll.backend.admin.session.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import kr.allcll.crawler.credential.Credential;
 
 public record SetCredentialRequest(
-    @NotBlank
     String tokenJ,
-
-    @NotBlank
     String tokenU,
-
-    @NotBlank
     String tokenR,
-
-    @NotBlank
     String tokenL
 ) {
 
+    public boolean isValid() {
+        return !isBlank(tokenJ) && !isBlank(tokenU) && !isBlank(tokenR) && !isBlank(tokenL);
+    }
+
     public Credential toCredential() {
         return Credential.of(tokenJ, tokenU, tokenR, tokenL);
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/src/test/java/kr/allcll/backend/admin/session/AdminSessionApiTest.java
+++ b/src/test/java/kr/allcll/backend/admin/session/AdminSessionApiTest.java
@@ -1,0 +1,112 @@
+package kr.allcll.backend.admin.session;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import kr.allcll.backend.admin.AdminRequestValidator;
+import kr.allcll.backend.admin.session.dto.SetCredentialRequest;
+import kr.allcll.crawler.credential.Credentials;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AdminSessionApi.class)
+class AdminSessionApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private SessionService sessionService;
+
+    @MockitoBean
+    private AdminRequestValidator validator;
+
+    @MockitoBean
+    private Credentials credentials;
+
+    @Test
+    @DisplayName("정상 요청은 자격 증명을 저장하고 200을 반환한다.")
+    void setCredential() throws Exception {
+        SetCredentialRequest request = new SetCredentialRequest("J", "U", "R", "L");
+        when(validator.isRateLimited(any(HttpServletRequest.class))).thenReturn(false);
+        when(validator.isUnauthorized(any(HttpServletRequest.class))).thenReturn(false);
+
+        mockMvc.perform(post("/api/admin/session")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk());
+
+        verify(sessionService).setCredential(request);
+    }
+
+    @Test
+    @DisplayName("빈 JSON 요청은 400을 반환하고 서비스가 호출되지 않는다.")
+    void setCredential_emptyJson() throws Exception {
+        when(validator.isRateLimited(any(HttpServletRequest.class))).thenReturn(false);
+        when(validator.isUnauthorized(any(HttpServletRequest.class))).thenReturn(false);
+
+        mockMvc.perform(post("/api/admin/session")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isBadRequest());
+
+        verify(sessionService, never()).setCredential(any());
+    }
+
+    @Test
+    @DisplayName("토큰 일부가 누락된 요청은 400을 반환한다.")
+    void setCredential_missingToken() throws Exception {
+        when(validator.isRateLimited(any(HttpServletRequest.class))).thenReturn(false);
+        when(validator.isUnauthorized(any(HttpServletRequest.class))).thenReturn(false);
+        SetCredentialRequest request = new SetCredentialRequest("J", "U", "R", null);
+
+        mockMvc.perform(post("/api/admin/session")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+
+        verify(sessionService, never()).setCredential(any());
+    }
+
+    @Test
+    @DisplayName("토큰이 빈 문자열인 요청은 400을 반환한다.")
+    void setCredential_blankToken() throws Exception {
+        when(validator.isRateLimited(any(HttpServletRequest.class))).thenReturn(false);
+        when(validator.isUnauthorized(any(HttpServletRequest.class))).thenReturn(false);
+        SetCredentialRequest request = new SetCredentialRequest("J", "U", "R", "");
+
+        mockMvc.perform(post("/api/admin/session")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+
+        verify(sessionService, never()).setCredential(any());
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 요청은 401을 반환한다.")
+    void setCredential_unauthorized() throws Exception {
+        SetCredentialRequest request = new SetCredentialRequest("J", "U", "R", "L");
+        when(validator.isRateLimited(any(HttpServletRequest.class))).thenReturn(false);
+        when(validator.isUnauthorized(any(HttpServletRequest.class))).thenReturn(true);
+
+        mockMvc.perform(post("/api/admin/session")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/kr/allcll/backend/admin/session/AdminSessionApiTest.java
+++ b/src/test/java/kr/allcll/backend/admin/session/AdminSessionApiTest.java
@@ -109,4 +109,17 @@ class AdminSessionApiTest {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    @DisplayName("인증되지 않은 요청은 빈 body여도 401을 반환하고 서비스가 호출되지 않는다.")
+    void setCredential_unauthorized_emptyBody() throws Exception {
+        when(validator.isUnauthorized(any(HttpServletRequest.class))).thenReturn(true);
+
+        mockMvc.perform(post("/api/admin/session")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isUnauthorized());
+
+        verify(sessionService, never()).setCredential(any());
+    }
 }


### PR DESCRIPTION
## 작업 내용
### 1. 에러 해결 및 테스트 코드 작성
⚠️ `POST /api/admin/session` 엔드포인트에 빈 body로 요청 보낼 시 아래와 같은 문제가 있었습니다.
- 200 응답 반환
- 응답 body는 비어있음

[😇 해결]
클로드 cli를 통해 skill파일 적용시켜 코드 작성 후, 검토 완료했습니다.

프롬프트
```
프론트에서 다음 버그 보고했어:

POST /api/admin/session 엔드포인트에 빈 body로 요청 보내도 
200 응답이 오고, 응답 body는 비어있는 문제.

검증 로직 추가해서 잘못된 요청이면 적절한 에러 응답 주도록 수정해줘.
```

코드 작성 플로우
```
1. 패턴 확인 + 버그 원인 분석
2. AdminSessionApiTest.java 작성 (테스트 먼저)
3. ./gradlew :test --tests "AdminSessionApiTest"
   → "재현 테스트 3개 모두 실패 → 버그 확실히 재현됨"
4. 구현 (Update SetCredentialRequest, AdminSessionApi, SessionService)
5. 다시 ./gradlew :test
   → 통과 확인
6. 회귀 검증 (./gradlew :test --tests "admin.*")
```
관련 내용 노션에 다시 정리 후 공유드리겠습니다!

### 2. git ignore에 claude 파일 추가
```
.claude/skills/
.claude/docs/
```
스킬 파일은 아직 미완성이라.. 일단 git ignore에 올려두고 푸시했습니다!

## 고민 지점과 리뷰 포인트

덱스님의 리뷰에 대해 의견 부탁드립니다!
https://github.com/allcll/allcll-backend/pull/316#discussion_r3146189509