### PR TITLE
Fix: `required_courses` Flyway migration 수정

### DIFF
--- a/src/main/resources/db/migration/V5__add_same_course_code_to_required_courses.sql
+++ b/src/main/resources/db/migration/V5__add_same_course_code_to_required_courses.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `required_courses`
+    ADD COLUMN `same_course_code` varchar(255) DEFAULT NULL;

--- a/src/main/resources/db/migration/V5__rename_required_courses_group_code_to_same_course_code.sql
+++ b/src/main/resources/db/migration/V5__rename_required_courses_group_code_to_same_course_code.sql
@@ -1,2 +1,0 @@
-ALTER TABLE `required_courses`
-    RENAME COLUMN `group_code` TO `same_course_code`;


### PR DESCRIPTION
## flyway 실패 원인
실제 DB에 `group_code` 컬럼이 존재하지 않아 migration 실패가 발생했습니다. (V5)
저의 수정사항 중점으로 생각하다 보니, 잘못된 쿼리를 작성했던 것이었습니다.

## 작업 내용
`required_courses` 테이블에 `same_course_code` 컬럼을 추가하도록 Flyway migration을 수정했습니다.
기존 `group_code` 컬럼 rename 방식에서 신규 컬럼 추가 방식으로 변경했습니다.

## 고민 지점과 리뷰 포인트
-
<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->