### PR TITLE
[TSK-69-1] 사용자 공지 조회 시 updatedAt 필드 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/notice/dto/NoticeResponse.java
+++ b/src/main/java/kr/allcll/backend/domain/notice/dto/NoticeResponse.java
@@ -9,7 +9,8 @@ public record NoticeResponse(
     String title,
     String content,
     OperationType operationType,
-    LocalDateTime createdAt
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
 ) {
 
     public static NoticeResponse from(Notice notice) {
@@ -18,7 +19,8 @@ public record NoticeResponse(
             notice.getTitle(),
             notice.getContent(),
             notice.getOperationType(),
-            notice.getCreatedAt()
+            notice.getCreatedAt(),
+            notice.getUpdatedAt()
         );
     }
 }


### PR DESCRIPTION
## 작업 내용
프론트 요청에 따라 사용자가 공지를 조회하는 api인 GET `/api/notices`에도 updatedAt을 추가하였습니다.

프론트의 이유는 아래와 같다고 합니다.

> 이유: 클라에서 읽은 공지를 localStorage 에 저장해서 한 번 본 공지는 다시 알림 안 띄우는 구조인데, 공지가 수정되면 사용자가 수정된 내용을 못 보고 지나가는 케이스가 있을 것 같습니다. updatedAt 받으면 수정된 공지는 다시 안 읽은 상태 처럼 보이게 하려고 합니다.

## 고민 지점과 리뷰 포인트

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->