### PR TITLE
[AI] refactor: Admin Controller 중복 검증 코드 제거

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/basket/AdminBasketApi.java
+++ b/src/main/java/kr/allcll/backend/admin/basket/AdminBasketApi.java
@@ -1,7 +1,5 @@
 package kr.allcll.backend.admin.basket;
 
-import jakarta.servlet.http.HttpServletRequest;
-import kr.allcll.backend.admin.AdminRequestValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,14 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminBasketApi {
 
     private final AdminBasketService adminBasketService;
-    private final AdminRequestValidator validator;
 
     @PostMapping("/api/admin/basket/fetch")
-    public ResponseEntity<Void> getSubjects(HttpServletRequest request,
-        @RequestParam String userId) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<Void> getSubjects(@RequestParam String userId) {
         adminBasketService.fetchAndSaveBaskets(userId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kr/allcll/backend/admin/department/AdminDepartmentApi.java
+++ b/src/main/java/kr/allcll/backend/admin/department/AdminDepartmentApi.java
@@ -1,8 +1,5 @@
 package kr.allcll.backend.admin.department;
 
-import jakarta.servlet.http.HttpServletRequest;
-import kr.allcll.backend.admin.AdminRequestValidator;
-import kr.allcll.backend.domain.department.DepartmentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,18 +11,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminDepartmentApi {
 
     private final AdminDepartmentService adminDepartmentService;
-    private final DepartmentService departmentService;
-    private final AdminRequestValidator validator;
 
     @PostMapping("/api/admin/departments")
-    public ResponseEntity<Void> fetchAndSaveDepartments(HttpServletRequest request,
+    public ResponseEntity<Void> fetchAndSaveDepartments(
         @RequestParam String userId,
         @RequestParam String year,
         @RequestParam String semesterCode
     ) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
         adminDepartmentService.fetchAndSaveDepartments(userId, year, semesterCode);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kr/allcll/backend/admin/graduation/AdminGraduationApi.java
+++ b/src/main/java/kr/allcll/backend/admin/graduation/AdminGraduationApi.java
@@ -1,7 +1,5 @@
 package kr.allcll.backend.admin.graduation;
 
-import jakarta.servlet.http.HttpServletRequest;
-import kr.allcll.backend.admin.AdminRequestValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,14 +9,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AdminGraduationApi {
 
-    private final AdminRequestValidator validator;
     private final AdminGraduationSyncService adminGraduationSyncService;
 
     @PostMapping("/api/admin/graduation/sync")
-    public ResponseEntity<Void> syncGraduationRules(HttpServletRequest request) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<Void> syncGraduationRules() {
         adminGraduationSyncService.syncGraduationRules();
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kr/allcll/backend/admin/notice/AdminNoticeApi.java
+++ b/src/main/java/kr/allcll/backend/admin/notice/AdminNoticeApi.java
@@ -1,8 +1,6 @@
 package kr.allcll.backend.admin.notice;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.admin.notice.dto.CreateNoticeRequest;
 import kr.allcll.backend.admin.notice.dto.CreateNoticeResponse;
 import kr.allcll.backend.admin.notice.dto.AdminNoticesResponse;
@@ -24,50 +22,32 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminNoticeApi {
 
     private final AdminNoticeService adminNoticeService;
-    private final AdminRequestValidator validator;
 
     @GetMapping("/api/admin/notices")
-    public ResponseEntity<AdminNoticesResponse> getAllNotice(HttpServletRequest request) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<AdminNoticesResponse> getAllNotice() {
         AdminNoticesResponse response = adminNoticeService.getAllNotice();
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/api/admin/notices")
     public ResponseEntity<CreateNoticeResponse> createNotice(
-        HttpServletRequest request,
         @Valid @RequestBody CreateNoticeRequest createNoticeRequest
     ) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
         CreateNoticeResponse response = adminNoticeService.createNewNotice(createNoticeRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PatchMapping("/api/admin/notices/{id}")
     public ResponseEntity<UpdateNoticeResponse> modifyNotice(
-        HttpServletRequest request,
         @PathVariable Long id,
         @Valid @RequestBody UpdateNoticeRequest updateNoticeRequest
     ) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
         UpdateNoticeResponse response = adminNoticeService.updateNotice(id, updateNoticeRequest);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/api/admin/notices/{id}")
-    public ResponseEntity<Void> deleteNotice(
-        HttpServletRequest request,
-        @PathVariable Long id
-    ) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<Void> deleteNotice(@PathVariable Long id) {
         adminNoticeService.deleteNotice(id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/src/main/java/kr/allcll/backend/admin/operationperiod/AdminOperationPeriodApi.java
+++ b/src/main/java/kr/allcll/backend/admin/operationperiod/AdminOperationPeriodApi.java
@@ -1,7 +1,5 @@
 package kr.allcll.backend.admin.operationperiod;
 
-import jakarta.servlet.http.HttpServletRequest;
-import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.admin.operationperiod.dto.OperationPeriodRequest;
 import kr.allcll.backend.domain.operationperiod.OperationType;
 import kr.allcll.backend.support.semester.Semester;
@@ -18,28 +16,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminOperationPeriodApi {
 
     private final AdminOperationPeriodService operationPeriodService;
-    private final AdminRequestValidator validator;
 
     @PostMapping("/api/admin/operation-period")
-    public ResponseEntity<Void> saveOperationPeriod(HttpServletRequest request,
+    public ResponseEntity<Void> saveOperationPeriod(
         @RequestParam("semesterCode") Semester semester,
         @RequestBody OperationPeriodRequest operationPeriodRequest
     ) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
         operationPeriodService.saveOperationPeriod(semester, operationPeriodRequest);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/api/admin/operation-period")
-    public ResponseEntity<Void> deleteOperationPeriod(HttpServletRequest request,
+    public ResponseEntity<Void> deleteOperationPeriod(
         @RequestParam("semesterCode") Semester semester,
         @RequestParam OperationType operationType
     ) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
         operationPeriodService.deleteOperationPeriod(semester, operationType);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kr/allcll/backend/admin/preseat/AdminPreSeatApi.java
+++ b/src/main/java/kr/allcll/backend/admin/preseat/AdminPreSeatApi.java
@@ -1,7 +1,5 @@
 package kr.allcll.backend.admin.preseat;
 
-import jakarta.servlet.http.HttpServletRequest;
-import kr.allcll.backend.admin.AdminRequestValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,14 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminPreSeatApi {
 
     private final AdminPreSeatService adminPreSeatService;
-    private final AdminRequestValidator validator;
 
     @PostMapping("/api/admin/pre-seat/fetch")
-    public ResponseEntity<Void> getAllPreSeats(HttpServletRequest request,
-        @RequestParam(required = false) String userId) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<Void> getAllPreSeats(@RequestParam(required = false) String userId) {
         adminPreSeatService.getAllPreSeat(userId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kr/allcll/backend/admin/review/AdminUserReviewApi.java
+++ b/src/main/java/kr/allcll/backend/admin/review/AdminUserReviewApi.java
@@ -1,7 +1,5 @@
 package kr.allcll.backend.admin.review;
 
-import jakarta.servlet.http.HttpServletRequest;
-import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.admin.review.dto.AdminUserReviewsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,14 +10,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AdminUserReviewApi {
 
-    private final AdminRequestValidator validator;
     private final AdminUserReviewService adminUserReviewService;
 
     @GetMapping("/api/admin/review")
-    public ResponseEntity<AdminUserReviewsResponse> getReview(HttpServletRequest request) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<AdminUserReviewsResponse> getReview() {
         AdminUserReviewsResponse responses = adminUserReviewService.getReview();
         return ResponseEntity.ok(responses);
     }

--- a/src/main/java/kr/allcll/backend/admin/seat/AdminSeatApi.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/AdminSeatApi.java
@@ -1,7 +1,5 @@
 package kr.allcll.backend.admin.seat;
 
-import jakarta.servlet.http.HttpServletRequest;
-import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.admin.seat.dto.SeatStatusResponse;
 import kr.allcll.backend.support.batch.BatchService;
 import lombok.RequiredArgsConstructor;
@@ -18,15 +16,9 @@ public class AdminSeatApi {
     private final AdminSeatService adminSeatService;
     private final BatchService batchService;
     private final TargetSubjectService targetSubjectService;
-    private final AdminRequestValidator validator;
 
     @PostMapping("/api/admin/seat/start")
-    public ResponseEntity<Void> getSeatPeriodically(HttpServletRequest request,
-        @RequestParam(required = false) String userId) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
-
+    public ResponseEntity<Void> getSeatPeriodically(@RequestParam(required = false) String userId) {
         targetSubjectService.loadGeneralSubjects();
         adminSeatService.getAllSeatPeriodically(userId);
 
@@ -34,12 +26,7 @@ public class AdminSeatApi {
     }
 
     @PostMapping("/api/admin/season-seat/start")
-    public ResponseEntity<Void> seasonSeatStart(HttpServletRequest request,
-        @RequestParam(required = false) String userId) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
-
+    public ResponseEntity<Void> seasonSeatStart(@RequestParam(required = false) String userId) {
         targetSubjectService.loadAllSubjects();
         adminSeatService.getSeasonSeatPeriodically(userId);
 
@@ -47,19 +34,13 @@ public class AdminSeatApi {
     }
 
     @GetMapping("/api/admin/seat/check")
-    public ResponseEntity<SeatStatusResponse> getSeatStatus(HttpServletRequest request) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<SeatStatusResponse> getSeatStatus() {
         SeatStatusResponse seatStatusResponse = adminSeatService.getSeatCrawlerStatus();
         return ResponseEntity.ok(seatStatusResponse);
     }
 
     @PostMapping("/api/admin/seat/cancel")
-    public ResponseEntity<Void> cancelSeatScheduling(HttpServletRequest request) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<Void> cancelSeatScheduling() {
         adminSeatService.cancelSeatScheduling();
         batchService.flushAllBatch();
 

--- a/src/main/java/kr/allcll/backend/admin/session/AdminSessionApi.java
+++ b/src/main/java/kr/allcll/backend/admin/session/AdminSessionApi.java
@@ -1,8 +1,6 @@
 package kr.allcll.backend.admin.session;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
-import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.admin.session.dto.CredentialResponse;
 import kr.allcll.backend.admin.session.dto.SessionStatusResponse;
 import kr.allcll.backend.admin.session.dto.SetCredentialRequest;
@@ -21,65 +19,41 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminSessionApi {
 
     private final SessionService sessionService;
-    private final AdminRequestValidator validator;
     private final Credentials credentials;
 
     @PostMapping("/api/admin/session")
-    public ResponseEntity<Void> setCredential(HttpServletRequest request,
-        @RequestBody SetCredentialRequest setCredentialRequest) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<Void> setCredential(@RequestBody SetCredentialRequest setCredentialRequest) {
         sessionService.setCredential(setCredentialRequest);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/api/admin/session")
-    public ResponseEntity<CredentialResponse> getCredential(HttpServletRequest request,
-        @RequestParam("userId") String userId) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<CredentialResponse> getCredential(@RequestParam("userId") String userId) {
         CredentialResponse credentialResponse = sessionService.getCredential(userId);
         return ResponseEntity.ok().body(credentialResponse);
     }
 
     @PostMapping("/api/admin/session-keep-alive")
-    public ResponseEntity<Void> startSessionScheduling(HttpServletRequest request,
-        @RequestParam("userId") String userId) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<Void> startSessionScheduling(@RequestParam("userId") String userId) {
         sessionService.startSession(userId);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/api/admin/session/check")
-    public ResponseEntity<SessionStatusResponse> getSessionStatus(HttpServletRequest request,
-        @RequestParam("userId") String userId) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<SessionStatusResponse> getSessionStatus(@RequestParam("userId") String userId) {
         SessionStatusResponse sessionStatusResponse = sessionService.getSessionStatus(userId);
         return ResponseEntity.ok().body(sessionStatusResponse);
     }
 
     @GetMapping("/api/admin/sessions/check")
-    public ResponseEntity<UserSessionsStatusResponse> getSessionsStatus(HttpServletRequest request) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
-
+    public ResponseEntity<UserSessionsStatusResponse> getSessionsStatus() {
         List<String> usersId = credentials.getAllUserIds();
         UserSessionsStatusResponse sessionsStatusResponse = sessionService.getSessionsStatus(usersId);
         return ResponseEntity.ok().body(sessionsStatusResponse);
     }
 
     @PostMapping("/api/admin/session/cancel")
-    public ResponseEntity<Void> cancelSessionScheduling(HttpServletRequest request) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<Void> cancelSessionScheduling() {
         sessionService.cancelSessionScheduling();
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kr/allcll/backend/admin/sse/AdminSseApi.java
+++ b/src/main/java/kr/allcll/backend/admin/sse/AdminSseApi.java
@@ -1,7 +1,5 @@
 package kr.allcll.backend.admin.sse;
 
-import jakarta.servlet.http.HttpServletRequest;
-import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.support.scheduler.SchedulerService;
 import kr.allcll.backend.support.scheduler.dto.SeatSchedulerStatusResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,31 +13,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminSseApi {
 
     private final SchedulerService schedulerService;
-    private final AdminRequestValidator validator;
 
     @PostMapping("/api/admin/seat-scheduler/start")
-    public ResponseEntity<Void> startScheduling(HttpServletRequest request) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<Void> startScheduling() {
         schedulerService.startScheduling();
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/api/admin/seat-scheduler/cancel")
-    public ResponseEntity<Void> cancelScheduling(HttpServletRequest request) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<Void> cancelScheduling() {
         schedulerService.cancelScheduling();
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/api/admin/seat-scheduler/check")
-    public ResponseEntity<SeatSchedulerStatusResponse> checkSchedulerStatus(HttpServletRequest request) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
+    public ResponseEntity<SeatSchedulerStatusResponse> checkSchedulerStatus() {
         SeatSchedulerStatusResponse seatSchedulerStatusResponse = schedulerService.getSeatSchedulerStatus();
         return ResponseEntity.ok(seatSchedulerStatusResponse);
     }

--- a/src/main/java/kr/allcll/backend/admin/subject/AdminSubjectApi.java
+++ b/src/main/java/kr/allcll/backend/admin/subject/AdminSubjectApi.java
@@ -1,8 +1,6 @@
 package kr.allcll.backend.admin.subject;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
-import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.domain.subject.subjectReport.CrawlingMetaData;
 import kr.allcll.backend.domain.subject.subjectReport.SubjectReportService;
 import lombok.RequiredArgsConstructor;
@@ -15,20 +13,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AdminSubjectApi {
 
-    private final AdminRequestValidator validator;
     private final AdminSubjectService adminSubjectService;
     private final SubjectReportService subjectReportService;
 
-
     @PostMapping("/api/admin/subjects")
-    public ResponseEntity<Void> syncSubjects(HttpServletRequest request,
+    public ResponseEntity<Void> syncSubjects(
         @RequestParam String userId,
         @RequestParam String year,
         @RequestParam String semesterCode
     ) {
-        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
-            return ResponseEntity.status(401).build();
-        }
         LocalDateTime startTime = LocalDateTime.now();
         SubjectSyncResult syncResult = adminSubjectService.syncSubjects(userId, year, semesterCode);
         LocalDateTime endTime = LocalDateTime.now();

--- a/src/test/java/kr/allcll/backend/domain/department/DepartmentApiTest.java
+++ b/src/test/java/kr/allcll/backend/domain/department/DepartmentApiTest.java
@@ -6,8 +6,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
-import kr.allcll.backend.admin.AdminRequestValidator;
-import kr.allcll.backend.admin.department.AdminDepartmentService;
 import kr.allcll.backend.domain.department.dto.DepartmentResponse;
 import kr.allcll.backend.domain.department.dto.DepartmentsResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -26,10 +24,6 @@ class DepartmentApiTest {
 
     @MockitoBean
     private DepartmentService departmentService;
-    @MockitoBean
-    private AdminDepartmentService adminDepartmentService;
-    @MockitoBean
-    private AdminRequestValidator validator;
 
     @Test
     @DisplayName("과목 코드 전체 조회의 요청과 응답을 확인한다.")


### PR DESCRIPTION
## Summary

- Admin Controller 11개에서 `AdminRequestValidator` 직접 호출 코드 제거
- `AdminAuthFilter`가 `/api/admin/**` 경로의 인증/Rate Limiting을 중앙 처리하므로 Controller 레벨의 중복 검증이 불필요
- `DepartmentApiTest`에서 불필요한 mock 제거

## 변경 파일 (12개)
- `AdminBasketApi`, `AdminDepartmentApi`, `AdminGraduationApi`, `AdminNoticeApi`, `AdminOperationPeriodApi`, `AdminPreSeatApi`, `AdminUserReviewApi`, `AdminSeatApi`, `AdminSessionApi`, `AdminSseApi`, `AdminSubjectApi`
- `DepartmentApiTest`

## Test plan

- [x] `./gradlew compileJava compileTestJava` 성공
- [ ] CI 통과 확인

Closes #328

Generated with [Claude Code](https://claude.com/claude-code)