### PR TITLE
[TSK-85] 영어 인증 상태 갱신 후 수정된 졸업 요건 결과 반환하도록 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheck.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheck.java
@@ -56,4 +56,8 @@ public class GraduationCheck extends BaseEntity {
         this.requiredTotalCredits = requiredTotalCredits;
         this.remainingCredits = remainingCredits;
     }
+
+    public void update(Boolean canGraduate) {
+        this.canGraduate = canGraduate;
+    }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckApi.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckApi.java
@@ -43,11 +43,12 @@ public class GraduationCheckApi {
     }
 
     @PatchMapping("/api/graduation/check/certifications/english")
-    public ResponseEntity<Void> updateEnglishCertPass(
+    public ResponseEntity<GraduationCheckResponse> updateEnglishCertPass(
         @Auth Long userId,
         @Valid @RequestBody UpdateEnglishCertRequest updateEnglishCertRequest
     ) {
-        graduationCheckService.updateEnglishCertPass(userId, updateEnglishCertRequest);
-        return ResponseEntity.ok().build();
+        GraduationCheckResponse response = graduationCheckService
+            .updateEnglishCertPassAndGetCheckResult(userId, updateEnglishCertRequest);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckService.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckService.java
@@ -1,8 +1,6 @@
 package kr.allcll.backend.domain.graduation.check.result;
 
 import java.util.List;
-import kr.allcll.backend.domain.graduation.check.cert.GraduationCheckCertResult;
-import kr.allcll.backend.domain.graduation.check.cert.GraduationCheckCertResultRepository;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourseDto;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCoursePersistenceService;
@@ -27,11 +25,10 @@ public class GraduationCheckService {
     private final GradeExcelParser gradeExcelParser;
     private final GraduationChecker graduationChecker;
     private final GraduationCheckRepository graduationCheckRepository;
-    private final GraduationCheckCategoryResultRepository graduationCheckCategoryResultRepository;
-    private final GraduationCheckCertResultRepository graduationCheckCertResultRepository;
     private final GraduationCheckResponseMapper graduationCheckResponseMapper;
     private final CompletedCoursePersistenceService completedCoursePersistenceService;
     private final GraduationCheckPersistenceService graduationCheckPersistenceService;
+    private final GraduationEnglishCertPassUpdateService graduationEnglishCertPassUpdateService;
 
     @Transactional
     public void checkGraduationRequirements(Long userId, MultipartFile gradeExcel) {
@@ -72,31 +69,11 @@ public class GraduationCheckService {
         return CompletedCoursesResponse.from(completedCourses);
     }
 
-    @Transactional
     public GraduationCheckResponse updateEnglishCertPassAndGetCheckResult(
         Long userId,
         UpdateEnglishCertRequest updateEnglishCertRequest
     ) {
-        updateEnglishCertPass(userId, updateEnglishCertRequest);
+        graduationEnglishCertPassUpdateService.updateEnglishCertPass(userId, updateEnglishCertRequest);
         return getCheckResult(userId);
-    }
-
-    private void updateEnglishCertPass(Long userId, UpdateEnglishCertRequest updateEnglishCertRequest) {
-        GraduationCheckCertResult graduationResult = graduationCheckCertResultRepository.findByUserId(userId)
-            .orElseThrow(() -> new AllcllException(AllcllErrorCode.GRADUATION_CERT_NOT_FOUND));
-        graduationResult.updateEnglish(updateEnglishCertRequest.isPassed());
-        graduationResult.reCalculate();
-        updateGraduationAvailability(userId, graduationResult);
-    }
-
-    private void updateGraduationAvailability(Long userId, GraduationCheckCertResult graduationResult) {
-        GraduationCheck graduationCheck = graduationCheckRepository.findByUserId(userId)
-            .orElseThrow(() -> new AllcllException(AllcllErrorCode.GRADUATION_CHECK_NOT_FOUND));
-
-        boolean allCategoriesSatisfied = graduationCheckCategoryResultRepository.findAllByUserId(userId)
-            .stream()
-            .allMatch(GraduationCheckCategoryResult::getIsSatisfied);
-
-        graduationCheck.update(allCategoriesSatisfied && graduationResult.getIsSatisfied());
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckService.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckService.java
@@ -27,6 +27,7 @@ public class GraduationCheckService {
     private final GradeExcelParser gradeExcelParser;
     private final GraduationChecker graduationChecker;
     private final GraduationCheckRepository graduationCheckRepository;
+    private final GraduationCheckCategoryResultRepository graduationCheckCategoryResultRepository;
     private final GraduationCheckCertResultRepository graduationCheckCertResultRepository;
     private final GraduationCheckResponseMapper graduationCheckResponseMapper;
     private final CompletedCoursePersistenceService completedCoursePersistenceService;
@@ -72,10 +73,30 @@ public class GraduationCheckService {
     }
 
     @Transactional
-    public void updateEnglishCertPass(Long userId, UpdateEnglishCertRequest updateEnglishCertRequest) {
+    public GraduationCheckResponse updateEnglishCertPassAndGetCheckResult(
+        Long userId,
+        UpdateEnglishCertRequest updateEnglishCertRequest
+    ) {
+        updateEnglishCertPass(userId, updateEnglishCertRequest);
+        return getCheckResult(userId);
+    }
+
+    private void updateEnglishCertPass(Long userId, UpdateEnglishCertRequest updateEnglishCertRequest) {
         GraduationCheckCertResult graduationResult = graduationCheckCertResultRepository.findByUserId(userId)
             .orElseThrow(() -> new AllcllException(AllcllErrorCode.GRADUATION_CERT_NOT_FOUND));
         graduationResult.updateEnglish(updateEnglishCertRequest.isPassed());
         graduationResult.reCalculate();
+        updateGraduationAvailability(userId, graduationResult);
+    }
+
+    private void updateGraduationAvailability(Long userId, GraduationCheckCertResult graduationResult) {
+        GraduationCheck graduationCheck = graduationCheckRepository.findByUserId(userId)
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.GRADUATION_CHECK_NOT_FOUND));
+
+        boolean allCategoriesSatisfied = graduationCheckCategoryResultRepository.findAllByUserId(userId)
+            .stream()
+            .allMatch(GraduationCheckCategoryResult::getIsSatisfied);
+
+        graduationCheck.update(allCategoriesSatisfied && graduationResult.getIsSatisfied());
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationEnglishCertPassUpdateService.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationEnglishCertPassUpdateService.java
@@ -20,14 +20,14 @@ public class GraduationEnglishCertPassUpdateService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updateEnglishCertPass(Long userId, UpdateEnglishCertRequest updateEnglishCertRequest) {
-        GraduationCheckCertResult graduationResult = graduationCheckCertResultRepository.findByUserId(userId)
+        GraduationCheckCertResult graduationCertResult = graduationCheckCertResultRepository.findByUserId(userId)
             .orElseThrow(() -> new AllcllException(AllcllErrorCode.GRADUATION_CERT_NOT_FOUND));
-        graduationResult.updateEnglish(updateEnglishCertRequest.isPassed());
-        graduationResult.reCalculate();
-        updateGraduationAvailability(userId, graduationResult);
+        graduationCertResult.updateEnglish(updateEnglishCertRequest.isPassed());
+        graduationCertResult.reCalculate();
+        updateGraduationAvailability(userId, graduationCertResult);
     }
 
-    private void updateGraduationAvailability(Long userId, GraduationCheckCertResult graduationResult) {
+    private void updateGraduationAvailability(Long userId, GraduationCheckCertResult graduationCertResult) {
         GraduationCheck graduationCheck = graduationCheckRepository.findByUserId(userId)
             .orElseThrow(() -> new AllcllException(AllcllErrorCode.GRADUATION_CHECK_NOT_FOUND));
 
@@ -35,6 +35,6 @@ public class GraduationEnglishCertPassUpdateService {
             .stream()
             .allMatch(GraduationCheckCategoryResult::getIsSatisfied);
 
-        graduationCheck.update(allCategoriesSatisfied && graduationResult.getIsSatisfied());
+        graduationCheck.update(allCategoriesSatisfied && graduationCertResult.getIsSatisfied());
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationEnglishCertPassUpdateService.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationEnglishCertPassUpdateService.java
@@ -1,0 +1,40 @@
+package kr.allcll.backend.domain.graduation.check.result;
+
+import kr.allcll.backend.domain.graduation.check.cert.GraduationCheckCertResult;
+import kr.allcll.backend.domain.graduation.check.cert.GraduationCheckCertResultRepository;
+import kr.allcll.backend.domain.graduation.check.result.dto.UpdateEnglishCertRequest;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GraduationEnglishCertPassUpdateService {
+
+    private final GraduationCheckCertResultRepository graduationCheckCertResultRepository;
+    private final GraduationCheckRepository graduationCheckRepository;
+    private final GraduationCheckCategoryResultRepository graduationCheckCategoryResultRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateEnglishCertPass(Long userId, UpdateEnglishCertRequest updateEnglishCertRequest) {
+        GraduationCheckCertResult graduationResult = graduationCheckCertResultRepository.findByUserId(userId)
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.GRADUATION_CERT_NOT_FOUND));
+        graduationResult.updateEnglish(updateEnglishCertRequest.isPassed());
+        graduationResult.reCalculate();
+        updateGraduationAvailability(userId, graduationResult);
+    }
+
+    private void updateGraduationAvailability(Long userId, GraduationCheckCertResult graduationResult) {
+        GraduationCheck graduationCheck = graduationCheckRepository.findByUserId(userId)
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.GRADUATION_CHECK_NOT_FOUND));
+
+        boolean allCategoriesSatisfied = graduationCheckCategoryResultRepository.findAllByUserId(userId)
+            .stream()
+            .allMatch(GraduationCheckCategoryResult::getIsSatisfied);
+
+        graduationCheck.update(allCategoriesSatisfied && graduationResult.getIsSatisfied());
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/review/UserReviewApi.java
+++ b/src/main/java/kr/allcll/backend/domain/review/UserReviewApi.java
@@ -1,5 +1,6 @@
 package kr.allcll.backend.domain.review;
 
+import jakarta.validation.Valid;
 import kr.allcll.backend.domain.review.dto.UserReviewRequest;
 import kr.allcll.backend.support.web.Auth;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ public class UserReviewApi {
     @PostMapping("/api/review")
     public ResponseEntity<Void> createReview(
         @Auth Long userId,
-        @RequestBody UserReviewRequest userReviewRequest
+        @Valid @RequestBody UserReviewRequest userReviewRequest
     ) {
         userReviewService.createReview(userId, userReviewRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/kr/allcll/backend/domain/review/dto/UserReviewRequest.java
+++ b/src/main/java/kr/allcll/backend/domain/review/dto/UserReviewRequest.java
@@ -1,10 +1,14 @@
 package kr.allcll.backend.domain.review.dto;
 
+import jakarta.validation.constraints.Size;
 import kr.allcll.backend.domain.operationperiod.OperationType;
 
 public record UserReviewRequest(
     Short rate,
+
+    @Size(max = 1000)
     String detail,
+
     OperationType operationType
 ) {
 

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.google.api.services.sheets.v4.Sheets;
 import java.util.List;
 import kr.allcll.backend.domain.graduation.MajorScope;
 import kr.allcll.backend.domain.graduation.certification.CodingCertCriterionRepository;
@@ -16,6 +17,7 @@ import kr.allcll.backend.domain.graduation.check.cert.GraduationCheckCertResult;
 import kr.allcll.backend.domain.graduation.check.cert.GraduationCheckCertResultRepository;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourseDto;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCoursePersistenceService;
+import kr.allcll.backend.domain.graduation.check.excel.CompletedCourseRepository;
 import kr.allcll.backend.domain.graduation.check.result.dto.CompletedCoursesResponse;
 import kr.allcll.backend.domain.graduation.check.result.dto.GraduationCheckResponse;
 import kr.allcll.backend.domain.graduation.check.result.dto.UpdateEnglishCertRequest;
@@ -29,19 +31,23 @@ import kr.allcll.backend.fixture.EnglishCertCriterionFixture;
 import kr.allcll.backend.fixture.GraduationCheckCertResultFixture;
 import kr.allcll.backend.fixture.GraduationDepartmentInfoFixture;
 import kr.allcll.backend.fixture.UserFixture;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
-@Transactional
 class GraduationCheckServiceTest {
 
     @Autowired
     private CompletedCoursePersistenceService completedCoursePersistenceService;
+
+    @Autowired
+    private CompletedCourseRepository completedCourseRepository;
 
     @Autowired
     private GraduationCheckService graduationCheckService;
@@ -69,6 +75,25 @@ class GraduationCheckServiceTest {
 
     @Autowired
     private CodingCertCriterionRepository codingCertCriterionRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @MockitoBean
+    private Sheets sheets;
+
+    @AfterEach
+    void clean() {
+        graduationCheckCategoryResultRepository.deleteAllInBatch();
+        graduationCheckRepository.deleteAllInBatch();
+        graduationCheckCertResultRepository.deleteAllInBatch();
+        completedCourseRepository.deleteAllInBatch();
+        codingCertCriterionRepository.deleteAllInBatch();
+        englishCertCriterionRepository.deleteAllInBatch();
+        graduationCertRuleRepository.deleteAllInBatch();
+        graduationDepartmentInfoRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
 
     @Test
     @DisplayName("빈환값의 개수와 내용을 확인한다.")
@@ -114,24 +139,16 @@ class GraduationCheckServiceTest {
     @DisplayName("영어 인증을 true로 수정하면 passedCount와 만족 여부를 재계산한다.")
     void updateEnglishCertPassTrueRecalculatesResult() {
         // given
-        GraduationDepartmentInfo graduationDepartmentInfo = GraduationDepartmentInfoFixture
-            .createDepartmentInfo(2021, CodingTargetType.CODING_MAJOR);
-        graduationDepartmentInfoRepository.save(graduationDepartmentInfo);
-        User user = userRepository.save(UserFixture.singleMajorUser(2021, graduationDepartmentInfo));
-        saveSatisfiedGraduationCheck(user.getId());
-        saveGraduationCriteria(2021);
-        GraduationCheckCertResult certResult = GraduationCheckCertResultFixture.createCertResult(
-            user,
+        Long userId = saveUserWithSatisfiedGraduationCheckAndCertResult(
             GraduationCertRuleType.BOTH_REQUIRED,
             false,
             false,
             true
         );
-        graduationCheckCertResultRepository.save(certResult);
 
         // when
-        graduationCheckService.updateEnglishCertPassAndGetCheckResult(user.getId(), new UpdateEnglishCertRequest(true));
-        GraduationCheckCertResult updated = graduationCheckCertResultRepository.findByUserId(user.getId())
+        graduationCheckService.updateEnglishCertPassAndGetCheckResult(userId, new UpdateEnglishCertRequest(true));
+        GraduationCheckCertResult updated = graduationCheckCertResultRepository.findByUserId(userId)
             .orElseThrow();
 
         // then
@@ -145,25 +162,16 @@ class GraduationCheckServiceTest {
     @DisplayName("영어 인증을 false로 수정하면 passedCount와 만족 여부를 재계산한다.")
     void updateEnglishCertPassFalseRecalculatesResult() {
         // given
-        GraduationDepartmentInfo graduationDepartmentInfo = GraduationDepartmentInfoFixture
-            .createDepartmentInfo(2021, CodingTargetType.CODING_MAJOR);
-        graduationDepartmentInfoRepository.save(graduationDepartmentInfo);
-        User user = userRepository.save(UserFixture.singleMajorUser(2021, graduationDepartmentInfo));
-        saveSatisfiedGraduationCheck(user.getId());
-        saveGraduationCriteria(2021);
-        GraduationCheckCertResult certResult = GraduationCheckCertResultFixture.createCertResult(
-            user,
+        Long userId = saveUserWithSatisfiedGraduationCheckAndCertResult(
             GraduationCertRuleType.BOTH_REQUIRED,
             true,
             false,
             true
         );
-        graduationCheckCertResultRepository.save(certResult);
 
         // when
-        graduationCheckService.updateEnglishCertPassAndGetCheckResult(user.getId(),
-            new UpdateEnglishCertRequest(false));
-        GraduationCheckCertResult updated = graduationCheckCertResultRepository.findByUserId(user.getId())
+        graduationCheckService.updateEnglishCertPassAndGetCheckResult(userId, new UpdateEnglishCertRequest(false));
+        GraduationCheckCertResult updated = graduationCheckCertResultRepository.findByUserId(userId)
             .orElseThrow();
 
         // then
@@ -177,34 +185,50 @@ class GraduationCheckServiceTest {
     @DisplayName("영어 인증을 false로 수정하면 졸업 가능 여부도 false로 갱신된다.")
     void updateEnglishCertPassFalseUpdatesGraduatableResult() {
         // given
-        GraduationDepartmentInfo graduationDepartmentInfo = GraduationDepartmentInfoFixture
-            .createDepartmentInfo(2021, CodingTargetType.CODING_MAJOR);
-        graduationDepartmentInfoRepository.save(graduationDepartmentInfo);
-        User user = userRepository.save(UserFixture.singleMajorUser(2021, graduationDepartmentInfo));
-        saveSatisfiedGraduationCheck(user.getId());
-        saveGraduationCriteria(2021);
-
-        GraduationCheckCertResult certResult = GraduationCheckCertResultFixture.createCertResult(
-            user,
+        Long userId = saveUserWithSatisfiedGraduationCheckAndCertResult(
             GraduationCertRuleType.BOTH_REQUIRED,
             true,
             false,
             true
         );
-        graduationCheckCertResultRepository.save(certResult);
 
         // when
         GraduationCheckResponse response = graduationCheckService.updateEnglishCertPassAndGetCheckResult(
-            user.getId(),
+            userId,
             new UpdateEnglishCertRequest(false)
         );
-        GraduationCheck updatedCheck = graduationCheckRepository.findByUserId(user.getId()).orElseThrow();
+        GraduationCheck updatedCheck = graduationCheckRepository.findByUserId(userId).orElseThrow();
 
         // then
         assertAll(
             () -> assertThat(updatedCheck.getCanGraduate()).isFalse(),
             () -> assertThat(response.isGraduatable()).isFalse()
         );
+    }
+
+    private Long saveUserWithSatisfiedGraduationCheckAndCertResult(
+        GraduationCertRuleType certRuleType,
+        boolean isEnglishCertPassed,
+        boolean isCodingCertPassed,
+        boolean isClassicsCertPassed
+    ) {
+        return transactionTemplate.execute(status -> {
+            GraduationDepartmentInfo graduationDepartmentInfo = GraduationDepartmentInfoFixture
+                .createDepartmentInfo(2021, CodingTargetType.CODING_MAJOR);
+            graduationDepartmentInfoRepository.save(graduationDepartmentInfo);
+            User user = userRepository.save(UserFixture.singleMajorUser(2021, graduationDepartmentInfo));
+            saveSatisfiedGraduationCheck(user.getId());
+            saveGraduationCriteria(2021);
+            GraduationCheckCertResult certResult = GraduationCheckCertResultFixture.createCertResult(
+                user,
+                certRuleType,
+                isEnglishCertPassed,
+                isCodingCertPassed,
+                isClassicsCertPassed
+            );
+            graduationCheckCertResultRepository.save(certResult);
+            return user.getId();
+        });
     }
 
     private void saveSatisfiedGraduationCheck(Long userId) {

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/result/GraduationCheckServiceTest.java
@@ -2,19 +2,30 @@ package kr.allcll.backend.domain.graduation.check.result;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
+import kr.allcll.backend.domain.graduation.MajorScope;
+import kr.allcll.backend.domain.graduation.certification.CodingCertCriterionRepository;
+import kr.allcll.backend.domain.graduation.certification.CodingTargetType;
+import kr.allcll.backend.domain.graduation.certification.EnglishCertCriterionRepository;
+import kr.allcll.backend.domain.graduation.certification.GraduationCertRule;
+import kr.allcll.backend.domain.graduation.certification.GraduationCertRuleRepository;
 import kr.allcll.backend.domain.graduation.certification.GraduationCertRuleType;
 import kr.allcll.backend.domain.graduation.check.cert.GraduationCheckCertResult;
 import kr.allcll.backend.domain.graduation.check.cert.GraduationCheckCertResultRepository;
-import kr.allcll.backend.domain.graduation.certification.CodingTargetType;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourseDto;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCoursePersistenceService;
 import kr.allcll.backend.domain.graduation.check.result.dto.CompletedCoursesResponse;
+import kr.allcll.backend.domain.graduation.check.result.dto.GraduationCheckResponse;
 import kr.allcll.backend.domain.graduation.check.result.dto.UpdateEnglishCertRequest;
+import kr.allcll.backend.domain.graduation.credit.CategoryType;
 import kr.allcll.backend.domain.graduation.department.GraduationDepartmentInfo;
+import kr.allcll.backend.domain.graduation.department.GraduationDepartmentInfoRepository;
 import kr.allcll.backend.domain.user.User;
 import kr.allcll.backend.domain.user.UserRepository;
+import kr.allcll.backend.fixture.CodingCertCriterionFixture;
+import kr.allcll.backend.fixture.EnglishCertCriterionFixture;
 import kr.allcll.backend.fixture.GraduationCheckCertResultFixture;
 import kr.allcll.backend.fixture.GraduationDepartmentInfoFixture;
 import kr.allcll.backend.fixture.UserFixture;
@@ -40,6 +51,24 @@ class GraduationCheckServiceTest {
 
     @Autowired
     private GraduationCheckCertResultRepository graduationCheckCertResultRepository;
+
+    @Autowired
+    private GraduationCheckRepository graduationCheckRepository;
+
+    @Autowired
+    private GraduationCheckCategoryResultRepository graduationCheckCategoryResultRepository;
+
+    @Autowired
+    private GraduationDepartmentInfoRepository graduationDepartmentInfoRepository;
+
+    @Autowired
+    private GraduationCertRuleRepository graduationCertRuleRepository;
+
+    @Autowired
+    private EnglishCertCriterionRepository englishCertCriterionRepository;
+
+    @Autowired
+    private CodingCertCriterionRepository codingCertCriterionRepository;
 
     @Test
     @DisplayName("빈환값의 개수와 내용을 확인한다.")
@@ -83,11 +112,14 @@ class GraduationCheckServiceTest {
 
     @Test
     @DisplayName("영어 인증을 true로 수정하면 passedCount와 만족 여부를 재계산한다.")
-    void updateEnglishCertPass_true_recalculatesResult() {
+    void updateEnglishCertPassTrueRecalculatesResult() {
         // given
         GraduationDepartmentInfo graduationDepartmentInfo = GraduationDepartmentInfoFixture
             .createDepartmentInfo(2021, CodingTargetType.CODING_MAJOR);
+        graduationDepartmentInfoRepository.save(graduationDepartmentInfo);
         User user = userRepository.save(UserFixture.singleMajorUser(2021, graduationDepartmentInfo));
+        saveSatisfiedGraduationCheck(user.getId());
+        saveGraduationCriteria(2021);
         GraduationCheckCertResult certResult = GraduationCheckCertResultFixture.createCertResult(
             user,
             GraduationCertRuleType.BOTH_REQUIRED,
@@ -98,8 +130,9 @@ class GraduationCheckServiceTest {
         graduationCheckCertResultRepository.save(certResult);
 
         // when
-        graduationCheckService.updateEnglishCertPass(user.getId(), new UpdateEnglishCertRequest(true));
-        GraduationCheckCertResult updated = graduationCheckCertResultRepository.findByUserId(user.getId()).orElseThrow();
+        graduationCheckService.updateEnglishCertPassAndGetCheckResult(user.getId(), new UpdateEnglishCertRequest(true));
+        GraduationCheckCertResult updated = graduationCheckCertResultRepository.findByUserId(user.getId())
+            .orElseThrow();
 
         // then
         assertThat(updated.getIsEnglishCertPassed()).isTrue();
@@ -110,11 +143,14 @@ class GraduationCheckServiceTest {
 
     @Test
     @DisplayName("영어 인증을 false로 수정하면 passedCount와 만족 여부를 재계산한다.")
-    void updateEnglishCertPass_false_recalculatesResult() {
+    void updateEnglishCertPassFalseRecalculatesResult() {
         // given
         GraduationDepartmentInfo graduationDepartmentInfo = GraduationDepartmentInfoFixture
             .createDepartmentInfo(2021, CodingTargetType.CODING_MAJOR);
+        graduationDepartmentInfoRepository.save(graduationDepartmentInfo);
         User user = userRepository.save(UserFixture.singleMajorUser(2021, graduationDepartmentInfo));
+        saveSatisfiedGraduationCheck(user.getId());
+        saveGraduationCriteria(2021);
         GraduationCheckCertResult certResult = GraduationCheckCertResultFixture.createCertResult(
             user,
             GraduationCertRuleType.BOTH_REQUIRED,
@@ -125,13 +161,76 @@ class GraduationCheckServiceTest {
         graduationCheckCertResultRepository.save(certResult);
 
         // when
-        graduationCheckService.updateEnglishCertPass(user.getId(), new UpdateEnglishCertRequest(false));
-        GraduationCheckCertResult updated = graduationCheckCertResultRepository.findByUserId(user.getId()).orElseThrow();
+        graduationCheckService.updateEnglishCertPassAndGetCheckResult(user.getId(),
+            new UpdateEnglishCertRequest(false));
+        GraduationCheckCertResult updated = graduationCheckCertResultRepository.findByUserId(user.getId())
+            .orElseThrow();
 
         // then
         assertThat(updated.getIsEnglishCertPassed()).isFalse();
         assertThat(updated.getPassedCount()).isEqualTo(1);
         assertThat(updated.getRequiredPassCount()).isEqualTo(2);
         assertThat(updated.getIsSatisfied()).isFalse();
+    }
+
+    @Test
+    @DisplayName("영어 인증을 false로 수정하면 졸업 가능 여부도 false로 갱신된다.")
+    void updateEnglishCertPassFalseUpdatesGraduatableResult() {
+        // given
+        GraduationDepartmentInfo graduationDepartmentInfo = GraduationDepartmentInfoFixture
+            .createDepartmentInfo(2021, CodingTargetType.CODING_MAJOR);
+        graduationDepartmentInfoRepository.save(graduationDepartmentInfo);
+        User user = userRepository.save(UserFixture.singleMajorUser(2021, graduationDepartmentInfo));
+        saveSatisfiedGraduationCheck(user.getId());
+        saveGraduationCriteria(2021);
+
+        GraduationCheckCertResult certResult = GraduationCheckCertResultFixture.createCertResult(
+            user,
+            GraduationCertRuleType.BOTH_REQUIRED,
+            true,
+            false,
+            true
+        );
+        graduationCheckCertResultRepository.save(certResult);
+
+        // when
+        GraduationCheckResponse response = graduationCheckService.updateEnglishCertPassAndGetCheckResult(
+            user.getId(),
+            new UpdateEnglishCertRequest(false)
+        );
+        GraduationCheck updatedCheck = graduationCheckRepository.findByUserId(user.getId()).orElseThrow();
+
+        // then
+        assertAll(
+            () -> assertThat(updatedCheck.getCanGraduate()).isFalse(),
+            () -> assertThat(response.isGraduatable()).isFalse()
+        );
+    }
+
+    private void saveSatisfiedGraduationCheck(Long userId) {
+        graduationCheckRepository.save(new GraduationCheck(userId, true, 130.0, 130, 0.0));
+        graduationCheckCategoryResultRepository.save(new GraduationCheckCategoryResult(
+            userId,
+            MajorScope.PRIMARY,
+            CategoryType.TOTAL_COMPLETION,
+            130.0,
+            130,
+            0.0,
+            true
+        ));
+    }
+
+    private void saveGraduationCriteria(int admissionYear) {
+        graduationCertRuleRepository.save(new GraduationCertRule(
+            admissionYear,
+            admissionYear % 100,
+            GraduationCertRuleType.BOTH_REQUIRED
+        ));
+        englishCertCriterionRepository.save(
+            EnglishCertCriterionFixture.createNonMajorEnglishCertCriterion(admissionYear)
+        );
+        codingCertCriterionRepository.save(
+            CodingCertCriterionFixture.createMajorCodingCertCriterion(admissionYear)
+        );
     }
 }


### PR DESCRIPTION
## 작업 배경
영어 인증을 변경한 후에도 변경된 졸업 요건 검사 결과를 반환해주지 않아서 그대로 남아있는 문제가 있었습니다. 그래서 이를 위해 `@GetMapping("/api/graduation/check")` 에서 사용하는 `GraduationCheckResponse`를 한번 더 조회해서 함께 반환해주려했어요.
그런데 이 과정에서 엣지를 하나 발견했습니다.

기존에는 영어 인증 상태를 변경하면 인증 결과 엔티티 자체는 갱신됐지만, 최종 응답의 `isGraduatable`는 이전에 저장된 졸업 가능 여부를 그대로 사용하고 있었습니다. 즉 그냥 영어 상태와 졸업인증시험 충족 여부를 표현하는 isSatisfied만 false가 될 뿐 이었어요. 실제 졸업 가능 여부(`canGraduate`)는 변경되지 않고 있었습니다.

그 결과, 이미 졸업 가능 상태인 사용자가 영어 인증을 해제해도 최종 졸업 가능 여부가 즉시 졸업 불가로 반영되지 않는 문제가 있었습니다.

## 작업 내용
> 변경이 존재하는 api는`@PatchMapping("/api/graduation/check/certifications/english")` 입니다!

- 영어 인증 상태 변경 API가 최신 `GraduationCheckResponse`를 반환하도록 수정했습니다.
- ⭐️ 영어 인증 상태 변경 시 저장된 `GraduationCheck.canGraduate`를 최신 인증 결과와 카테고리 충족 여부 기준으로 다시 계산해 반영하도록 수정했습니다. => 이를 통해 발견한 엣지를 커버했습니다.
- 이로 인해 영어 인증을 `false`로 변경하면 최종 졸업 가능 여부도 즉시 `false`로 반영되도록 했습니다.
- 관련 테스트를 보강해
  - 영어 인증 변경 후 인증 결과 재계산
  - 영어 인증을 false로 변경하면 졸업 가능 여부도 false로 변경
  시나리오를 검증하도록 했습니다.

### 포스트맨으로 직접 테스트한 결과...
영어 인증을 수정했을 때(`@PatchMapping("/api/graduation/check/certifications/english")`) 졸업 가능 여부가 어떻게 돌아오는지 확인했고, 
졸업 요건 검사 결과 조회인 `@GetMapping("/api/graduation/check")`를 찔러봐도 동일하게 오는지 확인했습니다. 흐름대로 첨부할테니 참고해주시면 감사하겠습니다.

[1. 영어 인증 수정 api 호출 - false로 수정]
<img width="2142" height="1496" alt="image" src="https://github.com/user-attachments/assets/8f613bf8-36fe-4f98-bb82-c01eac44d682" />

[2. 이후 졸업검사결과 조회 재호출 시]
<img width="2142" height="1496" alt="image" src="https://github.com/user-attachments/assets/d342eec8-5410-44e2-93c4-32544692af8d" />

[3. 다시 영어 인증 수정 api 호출 - true로 수정]
<img width="2142" height="1496" alt="image" src="https://github.com/user-attachments/assets/de392bb2-979c-4c27-af36-63565e1d7298" />

[4. 이후 졸업검사결과 조회 재호출 시]
<img width="2142" height="1496" alt="image" src="https://github.com/user-attachments/assets/3b25956a-dd58-4300-9014-b0dc97e0183a" />

## 고민 지점과 리뷰 포인트
updateEnglishCertPassAndGetCheckResult의 트랜잭션을 분리하는게 나을까요? getCheckResult는 하나의 트랜잭션으로 묶이지 않도록, updateEnglishCertPass만 따로 분리하는게 나을지 고민입니다. 의견 부탁드려요!!

## 추가 사소한 작업
사용자 리뷰 request에서 1000자 제한을 추가해놨습니다!! DB도 이미 1000자로 설정되어있어서, 이제 일관성 있게 맞춰졌습니다.

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->