### PR TITLE
[AI] review-pr 커맨드의 .claude/rules 경로 참조를 .claude/skills 로 수정

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -31,24 +31,24 @@ gh pr diff $ARGUMENTS --repo allcll/allcll-backend
 
 #### 검토 카테고리
 
-| 카테고리 | 심각도 | 설명 |
-|----------|--------|------|
-| Bug | 높음 | 버그 또는 런타임 에러 가능성 |
-| Security | 높음 | 보안 취약점 (SQL Injection, XSS 등) |
-| Error Handling | 중간 | 에러 처리 누락 |
-| Style | 낮음 | 코딩 컨벤션 위반 (`.claude/rules/` 기준) |
-| Suggestion | 낮음 | 개선 제안 |
-| Nit | 매우 낮음 | 사소한 지적 |
+| 카테고리           | 심각도   | 설명                               |
+|----------------|-------|----------------------------------|
+| Bug            | 높음    | 버그 또는 런타임 에러 가능성                 |
+| Security       | 높음    | 보안 취약점 (SQL Injection, XSS 등)    |
+| Error Handling | 중간    | 에러 처리 누락                         |
+| Style          | 낮음    | 코딩 컨벤션 위반 (`.claude/skills/` 기준) |
+| Suggestion     | 낮음    | 개선 제안                            |
+| Nit            | 매우 낮음 | 사소한 지적                           |
 
 ### 3. 리뷰 판단 (자동)
 
 강제 옵션이 없는 경우 자동 판단:
 
-| 조건 | 결과 |
-|------|------|
+| 조건                    | 결과                |
+|-----------------------|-------------------|
 | Bug 또는 Security 이슈 있음 | `request-changes` |
-| 개선 필요 사항만 있음 | `comment` |
-| 문제 없음 | `approve` |
+| 개선 필요 사항만 있음          | `comment`         |
+| 문제 없음                 | `approve`         |
 
 ### 4. 리뷰 제출
 
@@ -74,6 +74,6 @@ gh api repos/allcll/allcll-backend/pulls/$PR_NUMBER/comments \
 
 ## 리뷰 원칙
 
-- 프로젝트 코딩 규칙(`.claude/rules/`) 기준으로 검토
+- 프로젝트 코딩 규칙(`.claude/skills/`) 기준으로 검토
 - 비난하지 않는 톤, 개선 방향 제시
 - 사소한 스타일 지적보다 로직/안전성 우선


### PR DESCRIPTION
## 작업 내용

- `.claude/commands/review-pr.md` 의 코딩 규칙 경로 참조를 `.claude/rules/` → `.claude/skills/` 로 수정
  - 검토 카테고리 표의 `Style` 항목 설명
  - 하단 "리뷰 원칙" 섹션
- 위 수정 시 마크다운 테이블 자동 정렬(공백 포맷팅)이 함께 적용됨

## 고민 지점과 리뷰 포인트

- 실제 디렉토리는 이미 `.claude/skills/` 로 이동되어 있어, 문서가 가리키는 경로만 어긋난 상태였음. 본문 내용 수정 없이 경로 문자열만 교체
- 테이블 정렬은 의미 변경 없는 포맷팅이지만 diff 가 커 보일 수 있음

## 관련 이슈

- Closes #333