### PR TITLE
fix: review-pr 커맨드 인자 파싱 오류 수정

### DIFF
--- a/docs/agent-harness/commands/review-pr.md
+++ b/docs/agent-harness/commands/review-pr.md
@@ -11,13 +11,25 @@ PR 번호를 받아 코드 리뷰를 수행합니다.
 /review-pr 91 request-changes  # PR #91 강제 변경 요청
 ```
 
+## 인자 파싱
+
+`$ARGUMENTS`에서 첫 번째 토큰은 PR 번호, 두 번째 토큰은 리뷰 모드(approve/comment/request-changes)로 분리한다.
+
+```bash
+PR_NUMBER=$(echo "$ARGUMENTS" | awk '{print $1}')
+MODE=$(echo "$ARGUMENTS" | awk '{print $2}')
+```
+
+- `PR_NUMBER`가 비어있으면 현재 브랜치의 PR을 자동 탐색
+- `MODE`가 비어있으면 3단계에서 자동 판단
+
 ## 실행 순서
 
 ### 1. PR 정보 수집
 
 ```bash
-gh pr view $ARGUMENTS --repo allcll/allcll-backend
-gh pr diff $ARGUMENTS --repo allcll/allcll-backend
+gh pr view $PR_NUMBER --repo allcll/allcll-backend
+gh pr diff $PR_NUMBER --repo allcll/allcll-backend
 ```
 
 ### 2. 변경 사항 분석
@@ -48,9 +60,22 @@ gh pr diff $ARGUMENTS --repo allcll/allcll-backend
 ### 4. 리뷰 제출
 
 ```bash
+# MODE 값에 따라 플래그 결정
 gh pr review $PR_NUMBER \
   --repo allcll/allcll-backend \
-  --{approve|comment|request-changes} \
+  --approve \
+  --body "리뷰 본문"
+
+# 또는
+gh pr review $PR_NUMBER \
+  --repo allcll/allcll-backend \
+  --comment \
+  --body "리뷰 본문"
+
+# 또는
+gh pr review $PR_NUMBER \
+  --repo allcll/allcll-backend \
+  --request-changes \
   --body "리뷰 본문"
 ```
 


### PR DESCRIPTION
## Summary

Codex 리뷰에서 지적된 `review-pr` 커맨드의 gh CLI 실행 오류 2건을 수정합니다.

### 문제

`/review-pr 91 approve` 형태로 실행하면 `$ARGUMENTS`가 `91 approve`로 치환되어:
1. `gh pr view 91 approve` → `accepts at most 1 arg(s), received 2` 에러
2. `--{approve|comment|request-changes}` → 유효하지 않은 gh 플래그

### 수정 내용

- **인자 파싱 단계 추가**: `$ARGUMENTS`에서 PR 번호와 리뷰 모드를 분리
- **실제 gh 플래그로 명시**: placeholder 문법 대신 `--approve`, `--comment`, `--request-changes` 각각 표기

### 관련 리뷰 코멘트

- https://github.com/allcll/allcll-backend/pull/341#discussion_r3294658807
- https://github.com/allcll/allcll-backend/pull/341#discussion_r3294658812

## Test plan

- [x] `gh pr view 341 approve` 실행 시 에러 확인 (수정 전)
- [x] 인자 파싱 후 `gh pr view 341` 만 전달되는 구조 확인 (수정 후)