### PR TITLE
[TSK-88] 학기정보 크롤러 의존성 제거

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/basket/AdminBasketService.java
+++ b/src/main/java/kr/allcll/backend/admin/basket/AdminBasketService.java
@@ -1,11 +1,11 @@
 package kr.allcll.backend.admin.basket;
 
 import java.util.List;
+import kr.allcll.backend.support.semester.Semester;
 import kr.allcll.crawler.basket.CrawlerBasket;
 import kr.allcll.crawler.basket.CrawlerBasketRepository;
 import kr.allcll.crawler.client.BasketClient;
 import kr.allcll.crawler.client.payload.BasketPayload;
-import kr.allcll.crawler.common.entity.CrawlerSemester;
 import kr.allcll.crawler.credential.Credential;
 import kr.allcll.crawler.credential.Credentials;
 import kr.allcll.crawler.subject.CrawlerSubject;
@@ -26,7 +26,8 @@ public class AdminBasketService {
 
     public void fetchAndSaveBaskets(String userId) {
         Credential credential = credentials.findByUserId(userId);
-        List<CrawlerSubject> crawlerSubjects = crawlerSubjectRepository.findAllBySemesterAt(CrawlerSemester.now());
+        List<CrawlerSubject> crawlerSubjects = crawlerSubjectRepository
+            .findAllBySemesterAt(Semester.getCurrentSemester());
         for (CrawlerSubject crawlerSubject : crawlerSubjects) {
             List<CrawlerBasket> notDuplicatedCrawlerBaskets = fetchBaskets(crawlerSubject, credential);
             crawlerBasketRepository.saveAll(notDuplicatedCrawlerBaskets);

--- a/src/main/java/kr/allcll/backend/admin/preseat/AdminPreSeatService.java
+++ b/src/main/java/kr/allcll/backend/admin/preseat/AdminPreSeatService.java
@@ -3,10 +3,10 @@ package kr.allcll.backend.admin.preseat;
 import java.time.LocalDate;
 import java.util.List;
 import kr.allcll.backend.admin.preseat.dto.PreSeatResponse;
+import kr.allcll.backend.support.semester.Semester;
 import kr.allcll.crawler.client.SeatClient;
 import kr.allcll.crawler.client.model.SeatResponse;
 import kr.allcll.crawler.client.payload.SeatPayload;
-import kr.allcll.crawler.common.entity.CrawlerSemester;
 import kr.allcll.crawler.common.exception.CrawlerAllcllException;
 import kr.allcll.crawler.credential.Credential;
 import kr.allcll.crawler.credential.Credentials;
@@ -30,7 +30,8 @@ public class AdminPreSeatService {
 
     public void getAllPreSeat(String userId) {
         Credential credential = credentials.findByUserId(userId);
-        List<CrawlerSubject> crawlerSubjects = crawlerSubjectRepository.findAllBySemesterAt(CrawlerSemester.now());
+        List<CrawlerSubject> crawlerSubjects = crawlerSubjectRepository
+            .findAllBySemesterAt(Semester.getCurrentSemester());
         for (CrawlerSubject crawlerSubject : crawlerSubjects) {
             sendExternalPreSeatsRequest(crawlerSubject, credential);
         }

--- a/src/main/java/kr/allcll/backend/admin/subject/AdminSubjectService.java
+++ b/src/main/java/kr/allcll/backend/admin/subject/AdminSubjectService.java
@@ -1,7 +1,7 @@
 package kr.allcll.backend.admin.subject;
 
 import java.util.List;
-import kr.allcll.crawler.common.entity.CrawlerSemester;
+import kr.allcll.backend.support.semester.Semester;
 import kr.allcll.crawler.common.exception.CrawlerAllcllException;
 import kr.allcll.crawler.subject.CrawlerSubject;
 import kr.allcll.crawler.subject.CrawlerSubjectRepository;
@@ -23,7 +23,7 @@ public class AdminSubjectService {
         List<CrawlerSubject> allCrawlerSubjects = subjectFetcher.fetchSubjects(userId, year, semesterCode);
         log.info("[SubjectService] 현재 학사 정보 전체 과목 수: {}", allCrawlerSubjects.size());
         List<CrawlerSubject> existingCrawlerSubjects = crawlerSubjectRepository
-            .findAllBySemesterAtIncludingDeleted(CrawlerSemester.now());
+            .findAllBySemesterAtIncludingDeleted(Semester.getCurrentSemester());
         log.info("[SubjectService] 기존 과목 수: {}", existingCrawlerSubjects.size());
         SubjectSyncResult syncResult = SubjectSyncProcessor.process(allCrawlerSubjects, existingCrawlerSubjects);
         saveAddedSubjects(syncResult);
@@ -59,7 +59,7 @@ public class AdminSubjectService {
                     updatedSubject.getDeptCd(),
                     updatedSubject.getClassName(),
                     updatedSubject.getSmtCd(),
-                    CrawlerSemester.now()
+                    Semester.getCurrentSemester()
                 ).orElseThrow(() -> new CrawlerAllcllException("SUBJECT_NOT_FOUND", "과목이 존재하지 않습니다."));
                 existingSubject.updateFrom(updatedSubject);
             }

--- a/src/main/java/kr/allcll/backend/admin/subject/SubjectFilter.java
+++ b/src/main/java/kr/allcll/backend/admin/subject/SubjectFilter.java
@@ -1,7 +1,7 @@
 package kr.allcll.backend.admin.subject;
 
 import java.util.List;
-import kr.allcll.crawler.common.entity.CrawlerSemester;
+import kr.allcll.backend.support.semester.Semester;
 import kr.allcll.crawler.common.properties.SjptProperties;
 import kr.allcll.crawler.subject.CrawlerSubject;
 import kr.allcll.crawler.subject.CrawlerSubjectRepository;
@@ -33,7 +33,7 @@ public class SubjectFilter {
      */
     public List<CrawlerSubject> loadTargetGeneralSubject() {
         return crawlerSubjectRepository
-            .findAllByDeptCd(sjptProperties.getGeneralDeptCd(), CrawlerSemester.now())
+            .findAllByDeptCd(sjptProperties.getGeneralDeptCd(), Semester.getCurrentSemester())
             .stream()
             .filter(this::includeSubject)
             .filter(this::includeRemark)
@@ -44,7 +44,8 @@ public class SubjectFilter {
     계절 학기 때에 전체 과목을 실시간 제공하고 싶을 때에 사용합니다.
      */
     public List<CrawlerSubject> loadAllSubjectToTarget() {
-        List<CrawlerSubject> crawlerSubjects = crawlerSubjectRepository.findAllBySemesterAt(CrawlerSemester.now());
+        List<CrawlerSubject> crawlerSubjects = crawlerSubjectRepository
+            .findAllBySemesterAt(Semester.getCurrentSemester());
         return crawlerSubjects.stream()
             .filter(this::includeSubject)
             .toList();


### PR DESCRIPTION
## 작업 내용
크롤링 이후 크롤러 모듈의 CrawlerSemester를 가지고 오도록 되어있어 본 모듈에서 학기를 추가했음에도 불구하고 잘못된 학기정보가 저장됐습니다. 이에 본 모듈을 수정했습니다.

## 고민 지점과 리뷰 포인트
서브모듈에 올라온 피알도 함께 봐주세요.
이전에 왜 학기 정보가 잘 적용됐었죠...? 급 의문이 드네

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->