### PR TITLE
[TSK-89] 2026-하계 수강신청 준비

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/GeneralSeatSender.java
@@ -16,7 +16,7 @@ public class GeneralSeatSender {
 
     private static final String EVENT_NAME = "nonMajorSeats";
     private static final int QUERY_LIMIT = 20;
-    private static final int SEASON_SEMESTER_QUERY_LIMIT = 40; // 2025-동계 전체 제공을 위한 쿼리 제한 수
+    private static final int SEASON_SEMESTER_QUERY_LIMIT = 40; // 2026-하계 전체 제공을 위한 쿼리 제한 수
     private static final Duration SENDING_PERIOD = Duration.ofSeconds(3);
 
     private final SseService sseService;
@@ -37,7 +37,7 @@ public class GeneralSeatSender {
         if (hasActiveSchedule()) {
             return;
         }
-        scheduledTaskHandler.scheduleAtFixedRate(getGeneralSeatTask(), SENDING_PERIOD);
+        scheduledTaskHandler.scheduleAtFixedRate(getAllSeatTaskAtSeasonSemester(), SENDING_PERIOD);
     }
 
     public boolean hasActiveSchedule() {


### PR DESCRIPTION
## 작업 내용
1. SeatUtils는 이미 전체학년 대상으로 되어있으므로 수정하지 않았습니다.
2. private static final int SEASON_SEMESTER_QUERY_LIMIT = 40; 도 변경하지 않았습니다. 사실 창의학기제 제외하면 과목이 32개이긴한데, 1일에서 4일 사이에 계절 강좌가 더 개설될까봐 그냥 40개로 냅뒀습니다. 어떠세요?
3. GeneralSeatSender에서 `scheduledTaskHandler.scheduleAtFixedRate(getAllSeatTaskAtSeasonSemester(), SENDING_PERIOD);`로, 스케줄링 메서드를 `getAllSeatTaskAtSeasonSemester()`로 변경해주었습니다.

## 고민 지점과 리뷰 포인트

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->