### PR TITLE
[AI] 리뷰 수집 -> 리뷰어 매칭 workflow 수정

### DIFF
--- a/.github/workflows/codex-review-assign.yml
+++ b/.github/workflows/codex-review-assign.yml
@@ -2,8 +2,8 @@ name: Codex 리뷰 후 리뷰어 배정
 
 on:
   pull_request:
-    types: [edited]
-    branches: [main]
+    types: [ edited ]
+    branches: [ main ]
 
 permissions:
   pull-requests: write
@@ -12,11 +12,12 @@ permissions:
 jobs:
   assign-reviewers:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: 체크박스 확인
         id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body')
@@ -30,8 +31,6 @@ jobs:
       - name: 기존 리뷰어 확인
         if: steps.check.outputs.checked == 'true'
         id: existing
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           REVIEWERS=$(gh pr view "$PR_NUMBER" --json reviewRequests -q '.reviewRequests[].login')
@@ -44,8 +43,6 @@ jobs:
 
       - name: 리뷰어 배정
         if: steps.check.outputs.checked == 'true' && steps.existing.outputs.already_assigned == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           PR_AUTHOR=${{ github.event.pull_request.user.login }}

--- a/.github/workflows/codex-review-collect.yml
+++ b/.github/workflows/codex-review-collect.yml
@@ -2,8 +2,16 @@ name: Codex 리뷰 수집
 
 on:
   pull_request:
-    types: [opened]
-    branches: [main]
+    types: [ opened ]
+    branches: [ main ]
+  pull_request_review_comment:
+    types: [ created ]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Codex 리뷰를 다시 수집할 PR 번호
+        required: true
+        type: string
 
 permissions:
   pull-requests: write
@@ -14,10 +22,23 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      GH_REPO: ${{ github.repository }}
     steps:
+      - name: PR 컨텍스트 설정
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ inputs.pr_number }}"
+            PR_AUTHOR=$(gh pr view "$PR_NUMBER" --json author -q '.author.login')
+          else
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          fi
+
+          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
+          echo "PR_AUTHOR=$PR_AUTHOR" >> "$GITHUB_ENV"
+
       - name: Codex 리뷰 대기
+        if: github.event_name == 'pull_request'
         run: sleep 30
 
       - name: 리뷰 스레드 수집
@@ -75,6 +96,11 @@ jobs:
         run: |
           CURRENT_BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body')
 
+          if echo "$CURRENT_BODY" | grep -q '## Codex Review'; then
+            echo "Codex Review 섹션이 이미 있어 추가하지 않습니다."
+            exit 0
+          fi
+
           CODEX_SECTION=$(printf '\n\n---\n\n## Codex Review\n%s\n\n---\n- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기\n' "$REVIEWS")
 
           NEW_BODY="${CURRENT_BODY}${CODEX_SECTION}"
@@ -82,7 +108,7 @@ jobs:
           gh pr edit "$PR_NUMBER" --body "$NEW_BODY"
 
       - name: Codex 리뷰 없음 -- 즉시 리뷰어 배정
-        if: steps.collect.outputs.has_reviews == 'false'
+        if: github.event_name == 'pull_request' && steps.collect.outputs.has_reviews == 'false'
         run: |
           REVIEWERS='["boyekim","goldm0ng","haeyoon1","2Jin1031"]'
           FILTERED=$(echo "$REVIEWERS" | jq --arg author "$PR_AUTHOR" '[.[] | select(. != $author)]')


### PR DESCRIPTION
## 작업 내용

Codex 리뷰 수집/리뷰어 배정 workflow의 실행 실패가 잦게 발생했습니다.

-> Codex 리뷰 수집/리뷰어 배정 workflow의 실행 실패와 타이밍 문제를 개선했습니다.

- `gh pr view`, `gh pr edit` 실행 시 repo context를 알 수 있도록 `GH_REPO: ${{ github.repository }}` 추가
- Codex 리뷰가 30초보다 늦게 달리는 경우를 처리하기 위해 `pull_request_review_comment.created` 이벤트 추가
- 필요 시 사람이 직접 Codex 리뷰 수집을 재실행할 수 있도록 `workflow_dispatch` 추가
- 수동 실행 시 PR 번호를 입력받아 해당 PR의 Codex 리뷰를 다시 수집하도록 변경
- 이미 `## Codex Review` 섹션이 있는 경우 중복으로 PR 본문에 추가하지 않도록 방어 로직 추가

## 왜 변경했나요?

기존 `codex-review-assign.yml`은 checkout 없이 `gh pr view "$PR_NUMBER"`를 실행하면서 repo 정보를 못 찾아 아래 에러로 실패했습니다.

```text
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

또한 `codex-review-collect.yml`은 PR 생성 후 30초만 기다린 뒤 Codex 리뷰를 수집했습니다. Codex 리뷰가 30초보다 늦게 달리면 workflow가 리뷰 없음으로 판단해 체크박스가 PR 본문에 붙지 않는 문제가 있었습니다.

## 사용 방법

1. PR을 생성합니다.
2. Codex가 PR에 리뷰 코멘트를 남기면 `Codex 리뷰 수집` workflow가 자동으로 다시 실행됩니다.
3. Codex 리뷰가 있으면 PR 본문에 아래 체크박스가 자동으로 추가됩니다.

```md
- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기
```

4. 로컬에서 `/apply-codex`를 실행해 Codex 리뷰를 반영합니다.
5. 반영이 끝나면 PR 본문에서 체크박스를 체크합니다.

```md
- [x] `/apply-codex` 커맨드를 로컬에서 실행하기
```

6. PR 본문 저장 시 `Codex 리뷰 후 리뷰어 배정` workflow가 실행되고, 기존 리뷰어가 없으면 리뷰어를 자동 배정합니다.

### 수동 재수집

Codex 리뷰가 자동 수집되지 않았거나 다시 수집해야 하면:

```text
Actions
-> Codex 리뷰 수집
-> Run workflow
-> pr_number에 PR 번호 입력
-> Run workflow
```

## 검증

- `.github/workflows/codex-review-assign.yml` YAML 파싱 확인
- `.github/workflows/codex-review-collect.yml` YAML 파싱 확인

## 참고

리뷰어 자동 배정 단계는 GitHub API 정책상 리뷰어 후보가 repository collaborator가 아니거나 리뷰 요청이 불가능한 상태면 실패할 수 있습니다.

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->