### PR TITLE
[TSK-100-1] 여러 동일과목 그룹에 속한 과목의 졸업요건 검사 오류 해결

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/AcademicBasicPolicy.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/AcademicBasicPolicy.java
@@ -46,13 +46,12 @@ public class AcademicBasicPolicy {
         String departmentName,
         String curiNo
     ) {
-        return courseEquivalenceRepository.findSameCourseCodeByCuriNo(curiNo)
-            .map(sameCourseCode -> requiredCourseResolver.findRequiredCourseInGroup(
+        return courseEquivalenceRepository.findSameCourseCodesByCuriNo(curiNo).stream()
+            .anyMatch(sameCourseCode -> requiredCourseResolver.findRequiredCourseInGroup(
                 departmentName,
                 admissionYear,
                 CategoryType.ACADEMIC_BASIC,
                 sameCourseCode
-            ))
-            .orElse(false);
+            ));
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/CourseEquivalenceRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/CourseEquivalenceRepository.java
@@ -1,7 +1,6 @@
 package kr.allcll.backend.domain.graduation.credit;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,8 +15,8 @@ public interface CourseEquivalenceRepository extends JpaRepository<CourseEquival
     List<String> findSameGroupCuriNos(Set<String> curiNos);
 
     @Query("""
-        select e.sameCourseCode from CourseEquivalence e
+        select distinct e.sameCourseCode from CourseEquivalence e
         where e.curiNo = :curiNo
     """)
-    Optional<String> findSameCourseCodeByCuriNo(String curiNo);
+    List<String> findSameCourseCodesByCuriNo(String curiNo);
 }

--- a/src/test/java/kr/allcll/backend/domain/graduation/credit/AcademicBasicPolicyTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/credit/AcademicBasicPolicyTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import java.util.List;
-import java.util.Optional;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -82,14 +81,60 @@ class AcademicBasicPolicyTest {
                 CategoryType.ACADEMIC_BASIC
             )
         ).willReturn(List.of());
-        given(courseEquivalenceRepository.findSameCourseCodeByCuriNo(curiNo))
-            .willReturn(Optional.of(sameCourseCode));
+        given(courseEquivalenceRepository.findSameCourseCodesByCuriNo(curiNo))
+            .willReturn(List.of(sameCourseCode));
         given(
             requiredCourseResolver.findRequiredCourseInGroup(
                 departmentName,
                 admissionYear,
                 CategoryType.ACADEMIC_BASIC,
                 sameCourseCode
+            )
+        ).willReturn(true);
+
+        // when
+        boolean result = academicBasicPolicy.isRecentMajorAcademicBasic(course, criterion);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("여러 동일과목 그룹에 속한 과목은 그중 하나라도 필수과목을 포함하면 true를 반환한다")
+    void returnTrueWhenAnyOfMultipleGroupsMatchesRequiredCourse() {
+        // given
+        String curiNo = "009960";
+        String firstGroupCode = "1";
+        String secondGroupCode = "2";
+        String departmentName = "컴퓨터공학과";
+        String curiNm = "Capstone디자인(산학협력프로젝트)";
+        Integer admissionYear = 2021;
+        CompletedCourse course = createCompletedCourse(curiNo, curiNm, CategoryType.ACADEMIC_BASIC);
+        CreditCriterion criterion = createAcademicBasicCriterion(departmentName, admissionYear);
+
+        given(
+            requiredCourseResolver.findRequiredCourseNames(
+                departmentName,
+                admissionYear,
+                CategoryType.ACADEMIC_BASIC
+            )
+        ).willReturn(List.of());
+        given(courseEquivalenceRepository.findSameCourseCodesByCuriNo(curiNo))
+            .willReturn(List.of(firstGroupCode, secondGroupCode));
+        given(
+            requiredCourseResolver.findRequiredCourseInGroup(
+                departmentName,
+                admissionYear,
+                CategoryType.ACADEMIC_BASIC,
+                firstGroupCode
+            )
+        ).willReturn(false);
+        given(
+            requiredCourseResolver.findRequiredCourseInGroup(
+                departmentName,
+                admissionYear,
+                CategoryType.ACADEMIC_BASIC,
+                secondGroupCode
             )
         ).willReturn(true);
 
@@ -117,8 +162,8 @@ class AcademicBasicPolicyTest {
                 CategoryType.ACADEMIC_BASIC
             )
         ).willReturn(List.of());
-        given(courseEquivalenceRepository.findSameCourseCodeByCuriNo(curiNo))
-            .willReturn(Optional.of(sameCourseCode));
+        given(courseEquivalenceRepository.findSameCourseCodesByCuriNo(curiNo))
+            .willReturn(List.of(sameCourseCode));
         given(
             requiredCourseResolver.findRequiredCourseInGroup(
                 departmentName,
@@ -146,8 +191,8 @@ class AcademicBasicPolicyTest {
 
         given(requiredCourseResolver.findRequiredCourseNames(departmentName, admissionYear, CategoryType.ACADEMIC_BASIC))
             .willReturn(List.of());
-        given(courseEquivalenceRepository.findSameCourseCodeByCuriNo(curiNo))
-            .willReturn(Optional.empty());
+        given(courseEquivalenceRepository.findSameCourseCodesByCuriNo(curiNo))
+            .willReturn(List.of());
 
         // when
         boolean result = academicBasicPolicy.isRecentMajorAcademicBasic(course, criterion);


### PR DESCRIPTION
# 작업 배경

기존 구현은 **하나의 과목(`curi_no`)은 하나의 동일교과 그룹(`group_code`)에만 속한다**는 가정을 기반으로 작성되어 있었습니다.

하지만 실제 학사 데이터 확인 결과, 하나의 과목이 여러 동일교과 그룹에 속하는 사례가 존재했습니다.

* 전체 약 7,500건 중 37건 존재

> EX) `009960 Capstone디자인(산학협력프로젝트)` → 3개 그룹 소속

이로 인해 동일교과 그룹을 단건 조회하던 `findSameCourseCodeByCuriNo()` 호출 시 `IncorrectResultSizeDataAccessException`이 발생했고, 해당 과목이 포함된 학생의 졸업요건 검사(`POST /api/graduation/check`)가 500 에러로 실패하고 있었습니다.

실제 사용자 문의 사례인 `007330 확률및통계(전기)`에서도 동일 현상이 재현되었습니다.

# 해결 방법
동일교과 그룹 조회를 다건 조회로 변경하고, 조회된 그룹 중 하나라도 필수과목을 포함하는 경우 인정하도록 수정했습니다.

단순히 첫 번째 그룹만 조회하는 방식(LIMIT 1)을 사용할 경우, 조회된 그룹에는 필수과목이 없지만 다른 동일교과 그룹에는 필수과목이 존재하는 상황에서 실제로는 인정 대상인 학생이 잘못 불인정 처리될 수 있습니다.

동일교과 그룹은 특정 과목이 여러 과목과 서로 대체 인정 가능한 관계임을 표현하는 데이터이므로, 여러 그룹 중 하나라도 필수과목과 연결되어 있다면 해당 과목은 필수과목 이수로 인정하는 것이 데이터 의미와 학사 정책에 더 부합한다고 판단했습니다.

# 작업 내용

* `CourseEquivalenceRepository`

  * `findSameCourseCodeByCuriNo()` 단건 조회(`Optional`)를 `findSameCourseCodesByCuriNo()` 다건 조회(`List`)로 변경
* `AcademicBasicPolicy`

  * 동일교과 그룹 중 하나라도 필수과목을 포함하면 인정하도록 OR(`anyMatch`) 판정으로 변경
* `AcademicBasicPolicyTest`

  * 변경된 시그니처 반영 및 다중 동일교과 그룹 케이스 테스트 추가
  
# 검증

**1. 다중 그룹 소속 과목이 특정 그룹에서만 필수과목으로 지정되어 있어도 정상 인정되는지 단위 테스트 추가
2. 실제 문의 사례와 동일한 성적 데이터(`007330`, `전기`)로 로컬 E2E 검증 수행**

> 수정 전: 운영 로그와 동일한 예외 재현
> 수정 후: 졸업요건 검사 정상 완료 확인

# 리뷰 포인트
여러 동일교과 그룹 중 **하나라도** 필수과목을 포함하면 인정하는 현재 판정 정책이 적절한지 검토 부탁드립니다!

# 참고

초기에는 `RequiredCourseRepository.findCurrentCourseBySameCourseCode()` 역시 동일한 문제 가능성을 의심했으나, 해당 쿼리는 `ORDER BY admission_year DESC LIMIT 1` 방어 로직이 적용되어 있음을 확인했습니다. 또한 실제 데이터로 검증한 결과, 예외 없이 최신 과목 1건이 정상 선택되는 것을 확인했습니다.
