### PR TITLE
[TSK-100-2] 균형교양 자연과과학 이수영역 카운트 누락 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/balance/BalanceRequiredArea.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/balance/BalanceRequiredArea.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum BalanceRequiredArea {
     HISTORY_THOUGHT("역사와사상"),
-    NATURE_SCIENCE("자연과학"),
+    NATURE_SCIENCE("자연과과학"),
     ECONOMY_SOCIETY("경제와사회"),
     CULTURE_ARTS("문화와예술"),
     CONVERGENCE_AND_CREATIVITY("융합과창의");

--- a/src/test/java/kr/allcll/backend/domain/graduation/balance/BalanceRequiredAreaTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/balance/BalanceRequiredAreaTest.java
@@ -1,0 +1,55 @@
+package kr.allcll.backend.domain.graduation.balance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class BalanceRequiredAreaTest {
+
+    @Test
+    @DisplayName("선택영역 문자열은 ENUM으로 정상 변환된다.")
+    void fromSelectedAreaNatureScience() {
+        // given
+        String selectedArea = "자연과과학";
+
+        // when
+        BalanceRequiredArea result = BalanceRequiredArea.fromSelectedArea(selectedArea);
+
+        // then
+        assertThat(result).isEqualTo(BalanceRequiredArea.NATURE_SCIENCE);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "역사와사상, HISTORY_THOUGHT",
+        "경제와사회, ECONOMY_SOCIETY",
+        "문화와예술, CULTURE_ARTS",
+        "융합과창의, CONVERGENCE_AND_CREATIVITY",
+        "자연과 과학, NATURE_SCIENCE"
+    })
+    @DisplayName("성적표 선택영역 문자열은 공백을 제거한 편람 영역명으로 매칭된다.")
+    void fromSelectedAreaCanonicalNames(String selectedArea, BalanceRequiredArea expected) {
+        // when
+        BalanceRequiredArea result = BalanceRequiredArea.fromSelectedArea(selectedArea);
+
+        // then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "존재하지않는영역"})
+    @DisplayName("빈 값이나 균형교양 영역이 아닌 문자열은 null을 반환한다")
+    void fromSelectedAreaUnknown(String selectedArea) {
+        // when
+        BalanceRequiredArea result = BalanceRequiredArea.fromSelectedArea(selectedArea);
+
+        // then
+        assertThat(result).isNull();
+    }
+}


### PR DESCRIPTION
## 문제 상황

22~24학번 일부 학생들의 졸업요건 검사 결과에서 **균형교양 충족 영역 수가 실제보다 적게 계산되는 문제**가 발생했습니다.
대표적으로 자연과학 영역 과목을 이수했음에도 불구하고 해당 영역이 인정되지 않아, 실제로는 `2/2 충족`이어야 하는 결과가 `1/2 충족`으로 오판정되고 있었습니다.

---

## 원인

원인은 `BalanceRequiredArea`의 자연과학 영역명이 실제 성적표 데이터와 다르게 정의되어 있었기 때문입니다.

```diff
- NATURE_SCIENCE("자연과학")
+ NATURE_SCIENCE("자연과과학")
```

성적표 문자열 매칭은 `fromSelectedArea()`를 통해 수행되는데, 실제 업로드 데이터에는 `"자연과과학"`으로 저장되어 있어 매칭에 실패하고 있었습니다.

> => 그 결과 자연과학 영역 과목이 균형교양 영역으로 인정되지 않아 졸업요건 계산 결과가 잘못 산출되고 있었습니다.

---

## 작업 내용
**1. `BalanceRequiredArea`의 자연과학 영역명을 실제 성적표 데이터 기준으로 수정하였습니다.**
**2. `BalanceRequiredArea`에 대한 단위 테스트를 추가하였습니다.**

---

## 검증 **(검증은 현재 클로드로 구축중인 졸업요건 하네스 엔지니어링으로 테스트 해보았습니다.)**

운영 DB 복제본(성적 업로드 사용자 1,201명)을 대상으로 스냅샷 리플레이를 수행했습니다.

### 1. 기존 균형교양 관련 오류 재현을 확인
코드 수정 전 결과 기준으로 균형교양 관련하여 제보된 현상을 모두 재현합니다.

### 2. 코드 수정
원인 파악 후 코드를 수정합니다.

### 3. 오류 제보 사용자에 대한 검증
사용자 후기에 균형교양 관련 오류를 남긴 사용자 15명에 대해 졸업요건 하네스 구축 문서 기준 기대값(즉, 수강편람 내용이라 정답지라고 생각하시면 됩니다) 작성 후 바뀐 코드를 기준으로 다시 졸요건 검사를 돌립니다.

> 결과: 총 15개 케이스, 45개 검증 모두 PASS

### 3. 코드 수정 전 졸업요건결과와 수정 후 졸업요건결과의 Diff 검증
변경 대상은 모두 `22~24학번 + BALANCE_REQUIRED` 케이스에 한정되었으며, 다음 항목에 대한 영향은 확인되지 않았습니다.

> * 타 졸업요건 카테고리
> * 총 취득 학점
> * 최종 졸업 판정
> * 기존 해결된 신고 건

---

## 근거

> => 아래 근거는 졸업요건 하네스 엔지니어링 구축 관련한 내용이며, 좀 더 다듬어서 PR 및 사용법을 공유드릴 예정입니다~!

* `graduation-wiki@2026-07`

  * `cohort/2022/balance.md §2`
  * `cohort/2023/balance.md §2`
  * `cohort/2024/balance.md §2`
* 수강편람 `2026-1 p.52 §4`

추가 Diff 결과는 개인정보 포함으로 인해 커밋에서 제외했으며, 아래 파일에서 확인 가능합니다.

* `qa-snapshots/reports/B1-diff.txt`

---

## 리뷰 포인트
향후 편람 개정 등으로 영역명이 변경될 경우 동일한 방식으로 재발할 가능성이 있습니다.
이를 방지하기 위해 흠 로그를 추가해볼까요? 좋은 방식 있다면 말씀해주시면 감사하겠습니다!

---

## 이번 수정 범위 외 신고 건

**1. 창의소프트학부 제외 영역 특례 케이스**
- 현재 exclusions 스키마가 단과대학 단위만 지원하여 표현 불가
- 스키마 확장 이슈로 별도 대응 예정

**2. 폐지 과목 과거 영역 매핑 문제**
**3.  신고 내용이 현행 편람과 상충**
> -> 수강편람 내용 확인해보니 이 사용자는 잘못 인지하고 계신 것 같습니다!
