### PR TITLE
[TSK-111] 교선1 최소 이수 학점 폐지 정책 적용

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java
@@ -16,6 +16,7 @@ import kr.allcll.backend.domain.graduation.credit.CreditCriterion;
 import kr.allcll.backend.domain.graduation.credit.CreditCriterionRepository;
 import kr.allcll.backend.domain.graduation.credit.DoubleCreditCriterion;
 import kr.allcll.backend.domain.graduation.credit.DoubleCreditCriterionRepository;
+import kr.allcll.backend.domain.graduation.credit.GeneralElectivePolicy;
 import kr.allcll.backend.domain.user.User;
 import kr.allcll.backend.domain.user.UserRepository;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
@@ -29,6 +30,7 @@ public class GraduationChecker {
 
     private final CategoryCreditCalculator categoryCalculator;
     private final CertificationChecker certificationChecker;
+    private final GeneralElectivePolicy generalElectivePolicy;
 
     private final UserRepository userRepository;
     private final CreditCriterionRepository creditCriterionRepository;
@@ -40,7 +42,9 @@ public class GraduationChecker {
             .toList();
 
         // 사용자의 졸업 요건 기준 조회
-        List<CreditCriterion> creditCriteria = resolveCreditCriteria(userId);
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.USER_NOT_FOUND));
+        List<CreditCriterion> creditCriteria = resolveCreditCriteria(user);
 
         // 이수구분별 학점 계산
         List<GraduationCategory> categoryResults = categoryCalculator.calculateCategoryResults(
@@ -48,6 +52,7 @@ public class GraduationChecker {
             earnedCourses,
             creditCriteria
         );
+        applyGeneralElectiveRequiredCourseResult(user, earnedCourses, categoryResults);
 
         // 총 학점 정보 추출 (엑셀에서 직접 합산)
         TotalSummary totalSummary = summarizeTotalCredits(earnedCourses, categoryResults);
@@ -66,9 +71,7 @@ public class GraduationChecker {
         );
     }
 
-    private List<CreditCriterion> resolveCreditCriteria(Long userId) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new AllcllException(AllcllErrorCode.USER_NOT_FOUND));
+    private List<CreditCriterion> resolveCreditCriteria(User user) {
         if (MajorType.DOUBLE.equals(user.getMajorType())) {
             return buildDoubleMajorCriteria(
                 user,
@@ -82,6 +85,30 @@ public class GraduationChecker {
                 user.getDeptNm(),
                 List.of(MajorType.ALL, MajorType.SINGLE)
             );
+    }
+
+    private void applyGeneralElectiveRequiredCourseResult(
+        User user,
+        List<CompletedCourse> earnedCourses,
+        List<GraduationCategory> categories
+    ) {
+        boolean requiredCoursesSatisfied = generalElectivePolicy.areRequiredCoursesSatisfied(user, earnedCourses);
+        for (int index = 0; index < categories.size(); index++) {
+            GraduationCategory category = categories.get(index);
+            if (category.categoryType() == CategoryType.GENERAL_ELECTIVE) {
+                categories.set(index, new GraduationCategory(
+                    category.majorScope(),
+                    category.categoryType(),
+                    category.earnedCredits(),
+                    category.requiredCredits(),
+                    category.remainingCredits(),
+                    category.earnedAreasCnt(),
+                    category.requiredAreasCnt(),
+                    category.earnedAreas(),
+                    category.satisfied() && requiredCoursesSatisfied
+                ));
+            }
+        }
     }
 
     private List<CreditCriterion> buildDoubleMajorCriteria(

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/GeneralElectivePolicy.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/GeneralElectivePolicy.java
@@ -1,0 +1,39 @@
+package kr.allcll.backend.domain.graduation.credit;
+
+import java.util.List;
+import java.util.Map;
+import kr.allcll.backend.domain.graduation.MajorType;
+import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
+import kr.allcll.backend.domain.graduation.credit.dto.RequiredCourseResponse;
+import kr.allcll.backend.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GeneralElectivePolicy {
+
+    private final CreditCriterionRepository creditCriterionRepository;
+    private final RequiredCourseResolver requiredCourseResolver;
+    private final UncompletedCourseFilter uncompletedCourseFilter;
+
+    public boolean areRequiredCoursesSatisfied(User user, List<CompletedCourse> earnedCourses) {
+        if (!hasEnabledCriterion(user)) {
+            return true;
+        }
+
+        Map<CategoryType, List<RequiredCourseResponse>> requiredCoursesByCategory = requiredCourseResolver
+            .resolveRequiredCourses(user.getAdmissionYear(), user.getDeptCd());
+        List<RequiredCourseResponse> requiredCourses = requiredCoursesByCategory
+            .getOrDefault(CategoryType.GENERAL_ELECTIVE, List.of());
+        return uncompletedCourseFilter.filterUncompletedRequiredCourses(requiredCourses, earnedCourses).isEmpty();
+    }
+
+    private boolean hasEnabledCriterion(User user) {
+        return creditCriterionRepository
+            .findByAdmissionYearAndMajorTypeAndDeptCd(user.getAdmissionYear(), MajorType.ALL, user.getDeptCd())
+            .stream()
+            .anyMatch(criterion -> criterion.getCategoryType() == CategoryType.GENERAL_ELECTIVE
+                && criterion.getEnabled());
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/NonMajorCategoryResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/NonMajorCategoryResolver.java
@@ -1,11 +1,6 @@
 package kr.allcll.backend.domain.graduation.credit;
 
-import static java.util.stream.Collectors.collectingAndThen;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
-
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import kr.allcll.backend.domain.graduation.MajorScope;
@@ -17,7 +12,6 @@ import kr.allcll.backend.domain.graduation.department.GraduationDepartmentInfo;
 import kr.allcll.backend.domain.graduation.department.GraduationDepartmentInfoRepository;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
 import kr.allcll.backend.support.exception.AllcllException;
-import kr.allcll.backend.support.graduation.KeyUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -27,11 +21,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class NonMajorCategoryResolver {
 
-    private static final String ALL_DEPT = "0";
-
     private final RequiredCourseResolver requiredCourseResolver;
     private final BalanceRequiredResolver balanceRequiredResolver;
-    private final RequiredCourseRepository requiredCourseRepository;
     private final CreditCriterionRepository creditCriterionRepository;
     private final GraduationDepartmentInfoRepository graduationDepartmentInfoRepository;
 
@@ -40,7 +31,7 @@ public class NonMajorCategoryResolver {
             creditCriterionRepository.findByAdmissionYearAndMajorTypeAndDeptCd(admissionYear, MajorType.ALL, deptCd);
 
         Map<CategoryType, List<RequiredCourseResponse>> requiredCoursesByCategory =
-            loadRequiredCourses(admissionYear, deptCd);
+            requiredCourseResolver.resolveRequiredCourses(admissionYear, deptCd);
 
         List<GraduationCategoryResponse> graduationCategoryResponses = new ArrayList<>();
         for (CreditCriterion creditCriterion : creditCriteria) {
@@ -65,40 +56,4 @@ public class NonMajorCategoryResolver {
         return graduationCategoryResponses;
     }
 
-    private Map<CategoryType, List<RequiredCourseResponse>> loadRequiredCourses(
-        Integer admissionYear,
-        String deptCd
-    ) {
-        List<RequiredCourse> requiredCourseCandidates =
-            requiredCourseRepository.findByAdmissionYearAndDepts(admissionYear, List.of(ALL_DEPT, deptCd));
-
-        Map<String, RequiredCourse> selectedByCourseKey = new LinkedHashMap<>();
-        for (RequiredCourse requiredCourse : requiredCourseCandidates) {
-            String courseKey = courseKeyOf(requiredCourse);
-
-            if (isWildcard(requiredCourse)) {
-                selectedByCourseKey.putIfAbsent(courseKey, requiredCourse);
-                continue;
-            }
-            selectedByCourseKey.put(courseKey, requiredCourse);
-        }
-
-        return selectedByCourseKey.values().stream()
-            .filter(RequiredCourse::getRequired)
-            .collect(groupingBy(
-                RequiredCourse::getCategoryType,
-                collectingAndThen(
-                    toList(),
-                    requiredCourseResolver::resolveDeprecatedCourses
-                )
-            ));
-    }
-
-    private boolean isWildcard(RequiredCourse course) {
-        return ALL_DEPT.equals(course.getDeptCd());
-    }
-
-    private String courseKeyOf(RequiredCourse course) {
-        return KeyUtils.generate(course.getCategoryType(), course.getCuriNm());
-    }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseResolver.java
@@ -1,9 +1,12 @@
 package kr.allcll.backend.domain.graduation.credit;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import kr.allcll.backend.domain.graduation.credit.dto.RequiredCourseResponse;
+import kr.allcll.backend.support.graduation.KeyUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -15,7 +18,37 @@ public class RequiredCourseResolver {
 
     private static final String DEPRECATED = "DEPRECATED";
     private static final String WILD_CARD_DEPT_NM = "ALL";
+    private static final String WILD_CARD_DEPT_CD = "0";
     private final RequiredCourseRepository requiredCourseRepository;
+
+    public Map<CategoryType, List<RequiredCourseResponse>> resolveRequiredCourses(
+        Integer admissionYear,
+        String deptCd
+    ) {
+        return resolveRequiredCourses(requiredCourseRepository.findByAdmissionYearAndDepts(
+            admissionYear,
+            List.of(WILD_CARD_DEPT_CD, deptCd)
+        ));
+    }
+
+    private Map<CategoryType, List<RequiredCourseResponse>> resolveRequiredCourses(List<RequiredCourse> courses) {
+        Map<String, RequiredCourse> selectedByCourseKey = new LinkedHashMap<>();
+        for (RequiredCourse course : courses) {
+            String courseKey = KeyUtils.generate(course.getCategoryType(), course.getCuriNm());
+            if (WILD_CARD_DEPT_CD.equals(course.getDeptCd())) {
+                selectedByCourseKey.putIfAbsent(courseKey, course);
+                continue;
+            }
+            selectedByCourseKey.put(courseKey, course);
+        }
+
+        return selectedByCourseKey.values().stream()
+            .filter(RequiredCourse::getRequired)
+            .collect(Collectors.groupingBy(
+                RequiredCourse::getCategoryType,
+                Collectors.collectingAndThen(Collectors.toList(), this::resolveDeprecatedCourses)
+            ));
+    }
 
     public boolean findRequiredCourseInGroup(
         String departmentName,

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/UncompletedCourseFilter.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/UncompletedCourseFilter.java
@@ -26,6 +26,13 @@ public class UncompletedCourseFilter {
             .toList();
     }
 
+    public List<RequiredCourseResponse> filterUncompletedRequiredCourses(
+        List<RequiredCourseResponse> requiredCourses,
+        List<CompletedCourse> earnedCourses
+    ) {
+        return filterCourses(requiredCourses, buildEarnedCuriNos(earnedCourses));
+    }
+
     private Set<String> buildEarnedCuriNos(List<CompletedCourse> earnedCourses) {
         Set<String> earnedCuriNos = earnedCourses.stream()
             .map(CompletedCourse::getCuriNo)

--- a/src/test/java/kr/allcll/backend/domain/graduation/credit/GeneralElectivePolicyTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/credit/GeneralElectivePolicyTest.java
@@ -1,0 +1,141 @@
+package kr.allcll.backend.domain.graduation.credit;
+
+import static kr.allcll.backend.fixture.CompletedCourseFixture.createCompletedCourse;
+import static kr.allcll.backend.fixture.GraduationDepartmentInfoFixture.createDepartmentInfo;
+import static kr.allcll.backend.fixture.UserFixture.singleMajorUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import kr.allcll.backend.domain.graduation.MajorScope;
+import kr.allcll.backend.domain.graduation.MajorType;
+import kr.allcll.backend.domain.graduation.certification.CodingTargetType;
+import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
+import kr.allcll.backend.domain.graduation.credit.dto.RequiredCourseResponse;
+import kr.allcll.backend.domain.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GeneralElectivePolicyTest {
+
+    @Mock
+    private CreditCriterionRepository creditCriterionRepository;
+
+    @Mock
+    private RequiredCourseResolver requiredCourseResolver;
+
+    @Mock
+    private CourseEquivalenceRepository courseEquivalenceRepository;
+
+    @Test
+    @DisplayName("활성화된 교선 기준의 지정 과목을 이수하지 않으면 통과하지 않는다")
+    void failsWhenEnabledGeneralElectiveHasUncompletedRequiredCourse() {
+        User user = user();
+        when(creditCriterionRepository.findByAdmissionYearAndMajorTypeAndDeptCd(2021, MajorType.ALL, "3220"))
+            .thenReturn(List.of(generalElectiveCriterion(true)));
+        when(requiredCourseResolver.resolveRequiredCourses(2021, "3220"))
+            .thenReturn(generalElectiveRequiredCourse());
+
+        assertThat(policy().areRequiredCoursesSatisfied(user, List.of())).isFalse();
+    }
+
+    @Test
+    @DisplayName("비활성화된 교선 기준은 지정 과목 검사를 적용하지 않는다")
+    void skipsRequiredCourseValidationWhenGeneralElectiveIsDisabled() {
+        User user = user();
+        when(creditCriterionRepository.findByAdmissionYearAndMajorTypeAndDeptCd(2021, MajorType.ALL, "3220"))
+            .thenReturn(List.of(generalElectiveCriterion(false)));
+
+        assertThat(policy().areRequiredCoursesSatisfied(user, List.of())).isTrue();
+        verify(requiredCourseResolver, never()).resolveRequiredCourses(2021, "3220");
+    }
+
+    @Test
+    @DisplayName("동일·대체 과목을 이수하면 교선 지정 과목을 이수한 것으로 인정한다")
+    void acceptsEquivalentCourse() {
+        User user = user();
+        when(creditCriterionRepository.findByAdmissionYearAndMajorTypeAndDeptCd(2021, MajorType.ALL, "3220"))
+            .thenReturn(List.of(generalElectiveCriterion(true)));
+        when(requiredCourseResolver.resolveRequiredCourses(2021, "3220"))
+            .thenReturn(generalElectiveRequiredCourse());
+        when(courseEquivalenceRepository.findSameGroupCuriNos(java.util.Set.of("ALT001")))
+            .thenReturn(List.of("REQ001", "ALT001"));
+        CompletedCourse equivalentCourse = createCompletedCourse("ALT001", "대체과목", CategoryType.GENERAL_ELECTIVE);
+
+        assertThat(policy().areRequiredCoursesSatisfied(user, List.of(equivalentCourse))).isTrue();
+    }
+
+    @Test
+    @DisplayName("18~20학번도 활성화된 교선 지정 과목을 이수해야 한다")
+    void appliesTo2018Through2020Cohorts() {
+        for (int admissionYear : List.of(2018, 2019, 2020)) {
+            User user = user(admissionYear);
+            when(creditCriterionRepository.findByAdmissionYearAndMajorTypeAndDeptCd(admissionYear, MajorType.ALL, "3220"))
+                .thenReturn(List.of(generalElectiveCriterion(admissionYear, true)));
+            when(requiredCourseResolver.resolveRequiredCourses(admissionYear, "3220"))
+                .thenReturn(generalElectiveRequiredCourse());
+
+            assertThat(policy().areRequiredCoursesSatisfied(user, List.of())).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("교선 기준이 없는 2022학번 이후에는 지정 과목 검사를 적용하지 않는다")
+    void skipsCohortsWithoutGeneralElectiveCriterion() {
+        User user = user(2022);
+        when(creditCriterionRepository.findByAdmissionYearAndMajorTypeAndDeptCd(2022, MajorType.ALL, "3220"))
+            .thenReturn(List.of());
+
+        assertThat(policy().areRequiredCoursesSatisfied(user, List.of())).isTrue();
+        verify(requiredCourseResolver, never()).resolveRequiredCourses(2022, "3220");
+    }
+
+    private GeneralElectivePolicy policy() {
+        return new GeneralElectivePolicy(
+            creditCriterionRepository,
+            requiredCourseResolver,
+            new UncompletedCourseFilter(courseEquivalenceRepository)
+        );
+    }
+
+    private User user() {
+        return user(2021);
+    }
+
+    private User user(int admissionYear) {
+        return singleMajorUser("21000000", admissionYear, createDepartmentInfo(admissionYear, CodingTargetType.NON_MAJOR));
+    }
+
+    private CreditCriterion generalElectiveCriterion(boolean enabled) {
+        return generalElectiveCriterion(2021, enabled);
+    }
+
+    private Map<CategoryType, List<RequiredCourseResponse>> generalElectiveRequiredCourse() {
+        return Map.of(
+            CategoryType.GENERAL_ELECTIVE,
+            List.of(RequiredCourseResponse.of("REQ001", "지정과목"))
+        );
+    }
+
+    private CreditCriterion generalElectiveCriterion(int admissionYear, boolean enabled) {
+        return new CreditCriterion(
+            admissionYear,
+            admissionYear % 100,
+            MajorType.ALL,
+            "3220",
+            "테스트학과",
+            MajorScope.PRIMARY,
+            CategoryType.GENERAL_ELECTIVE,
+            0,
+            enabled,
+            ""
+        );
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseResolverTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseResolverTest.java
@@ -1,0 +1,51 @@
+package kr.allcll.backend.domain.graduation.credit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import kr.allcll.backend.domain.graduation.credit.dto.RequiredCourseResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RequiredCourseResolverTest {
+
+    @Mock
+    private RequiredCourseRepository requiredCourseRepository;
+
+    @Test
+    @DisplayName("학과별 필수 제외 설정은 전역 필수 설정보다 우선한다")
+    void departmentExemptionOverridesGlobalRequiredCourse() {
+        when(requiredCourseRepository.findByAdmissionYearAndDepts(2021, List.of("0", "3220")))
+            .thenReturn(List.of(
+                requiredCourse("0", true),
+                requiredCourse("3220", false)
+            ));
+
+        List<RequiredCourseResponse> requiredCourses = new RequiredCourseResolver(requiredCourseRepository)
+            .resolveRequiredCourses(2021, "3220")
+            .getOrDefault(CategoryType.GENERAL_ELECTIVE, List.of());
+
+        assertThat(requiredCourses).isEmpty();
+    }
+
+    private RequiredCourse requiredCourse(String deptCd, boolean required) {
+        return new RequiredCourse(
+            2021,
+            21,
+            deptCd,
+            "테스트학과",
+            CategoryType.GENERAL_ELECTIVE,
+            "REQ001",
+            "지정과목",
+            null,
+            "GROUP",
+            required,
+            ""
+        );
+    }
+}


### PR DESCRIPTION
## 요약

교양선택 1영역(`GENERAL_ELECTIVE`)의 필수 이수 학점 폐지 정책을 졸업 판정에 반영합니다.

이 PR은 **교선 지정 필수 과목의 졸업 판정 반영 로직**을 추가합니다.  
교선 1영역 요구 학점을 `0`으로 만드는 것은 코드에서 덮어쓰지 않고, Google Sheets의 `credit_criteria`를 원천 데이터로 관리합니다.

> 현재 시트의 `GENERAL_ELECTIVE.required_credits`는 아직 변경되지 않았습니다.  
> 시트 수정 및 동기화 전까지는 기존 요구 학점이 그대로 적용됩니다.

## 변경 배경

기존 졸업 판정은 카테고리별 학점 충족 여부와 졸업인증만으로 계산했습니다.

```java
categories.stream().allMatch(GraduationCategory::satisfied)
    && certResult.isSatisfied();
```

따라서 기존 `GENERAL_ELECTIVE.satisfied`는 요구 학점과 이수 학점만으로 결정됐습니다.

`required_courses`는 졸업요건 조회 화면에서 미이수 과목을 보여 주는 데 사용됐지만, 실제 `isGraduatable` 졸업 판정에는 반영되지 않았습니다. 이 때문에 교선 지정 필수 과목을 이수하지 않아도 교선 학점만 충족하면 졸업 가능으로 판정될 수 있었습니다.

## 작업 내용

### 1. 교선 학점 기준

`CategoryCreditCalculator`는 기존처럼 Google Sheets에서 동기화된 `credit_criteria.required_credits`를 사용합니다.

시트 액션 아이템이 반영된 후 18~21학번의 `GENERAL_ELECTIVE.required_credits`가 `0`이면:

| 이수 교선 학점 | 요구 학점 | 학점 기준 결과 |
| --- | --- | --- |
| 0학점 | 0학점 | 충족 |
| 21학점 미만 | 0학점 | 충족 |
| 21학점 이상 | 0학점 | 충족 |

따라서 시트 반영 이후에는 교선 1영역의 “21학점 미달”만으로 졸업 불가가 되지 않습니다.

### 2. 교선 지정 필수 과목 기준

`GraduationChecker`는 카테고리 학점 계산 후 `GeneralElectivePolicy`를 호출합니다.

1. 현재 학생의 `GENERAL_ELECTIVE` 기준이 `enabled=true`인지 확인합니다.
2. 활성화된 경우 `required_courses`에서 교선 지정 필수 과목을 조회합니다.
3. 전역 과목(`deptCd=0`)과 학과별 과목이 중복되면 학과별 설정을 우선합니다.
4. 우선순위를 적용한 뒤 `required=true`인 과목만 필수 과목으로 간주합니다.
5. 동일·대체 과목을 포함해 이수 여부를 확인합니다.
6. 미이수 과목이 있으면 기존 `GENERAL_ELECTIVE.satisfied`를 `false`로 변경합니다.

```text
기존 교선 학점 충족 여부
AND
교선 지정 필수 과목 충족 여부
= GENERAL_ELECTIVE.satisfied
```

| 상황 | GENERAL_ELECTIVE.satisfied | 전체 졸업 판정 |
| --- | --- | --- |
| 요구 학점 0, 지정 과목 모두 이수 | `true` | 다른 요건 충족 시 가능 |
| 요구 학점 0, 지정 과목 미이수 | `false` | 불가 |
| 교선 전체 면제 학과 | 지정 과목 검사 제외 | 다른 요건 기준 |
| 시트 변경 전 기존 요구 학점 미달 | `false` | 기존과 동일하게 불가 |

### 3. 면제 학과 처리

호텔외식관광프랜차이즈경영학과, 글로벌조리학과, 호텔외식비즈니스학과의 교선 1영역 면제는 코드에 학과명을 하드코딩하지 않습니다.

해당 학과의 `credit_criteria`에서 `GENERAL_ELECTIVE.enabled=false`이면 `GeneralElectivePolicy`가 지정 과목 조회 및 검사를 건너뜁니다. 면제 여부의 기준은 시트입니다.

## 구현 변경

- `GeneralElectivePolicy`
  - 시트 동기화된 `credit_criteria.enabled`를 기준으로 지정 과목 검사 적용 여부를 결정합니다.
  - 기존 `RequiredCourseResolver`, `UncompletedCourseFilter`를 조합해 지정 과목 이수 여부를 반환합니다.

- `GraduationChecker`
  - 기존 카테고리 학점 계산 후 교선 지정 과목 판정을 기존 `GENERAL_ELECTIVE.satisfied`에 반영합니다.
  - 기존 `isGraduatable` 및 `is_satisfied` 저장 흐름을 그대로 사용합니다.

- `RequiredCourseResolver`
  - 전역(`deptCd=0`) 설정과 학과별 설정을 공통으로 해석합니다.
  - 같은 과목에 학과별 `required=false`가 있으면 전역 `required=true`를 정상적으로 덮어씁니다.

- `UncompletedCourseFilter`
  - 기존 동일·대체 과목 인정 로직을 교선 지정 과목 판정에도 재사용합니다.

- `NonMajorCategoryResolver`
  - 졸업요건 조회 화면도 같은 필수 과목 선택 규칙을 사용하도록 공통 Resolver를 재사용합니다.

## 논의 과정 및 제외한 변경

### 런타임 요구 학점 덮어쓰기 정책 제거

초기에는 `GeneralElectiveCreditPolicy`로 18~21학번 교선 요구 학점을 런타임에 `0`으로 바꾸는 방식을 검토했습니다.

하지만 요구 학점의 원천은 Google Sheets이며, 시트에서 `required_credits=0`으로 관리하는 편이 맞으므로 해당 런타임 덮어쓰기 정책은 제거했습니다. 요구 학점은 기존처럼 시트 동기화 데이터만 사용합니다.

### DB 마이그레이션 제외

학점 충족 여부와 지정 과목 충족 여부를 별도 컬럼으로 저장하는 방식은 적용하지 않았습니다.

기존 `GraduationCheckCategoryResult.isSatisfied`와 `GraduationCheck.isGraduatable`에 최종 결과를 저장합니다.

### 응답 DTO 확장 제거

초기에는 `creditSatisfied`, `requiredCoursesSatisfied`를 응답 DTO에 추가하는 방식을 검토했습니다.

하지만 기존 `GraduationCategory.satisfied`만으로 최종 판정 전달이 충분하므로 DTO와 응답 Mapper 변경은 제거했습니다. 기존 API 명세를 유지합니다.

### GENERAL_ELECTIVE 전용 Repository 조회 제거

초기에는 `categoryType=GENERAL_ELECTIVE` 조건의 전용 Repository 조회를 추가했습니다.

하지만 기존 `findByAdmissionYearAndDepts` 결과에서 `GENERAL_ELECTIVE`만 선택하면 충분하므로, 전용 Repository 쿼리와 3인자 Resolver 메서드는 제거했습니다.

## 검증

- `./gradlew compileJava -q` 통과
- `GeneralElectivePolicyTest` 통과
  - 18~21학번 지정 과목 미이수 시 불가
  - 지정 과목 이수 시 교선 학점이 0이어도 통과 가능한 정책 확인
  - 2022학번 이후 정책 미적용
  - `enabled=false` 면제 기준은 지정 과목 검사 제외
  - 동일·대체 과목 이수 인정
- `RequiredCourseResolverTest` 통과
  - 학과별 `required=false`가 전역 `required=true`를 덮어씀
- `GraduationCheckResponseMapperTest` 통과
- `git diff --check` 통과

## 액션 아이템

- [x] Google Sheets의 `credit_criteria`에서 18~21학번 `GENERAL_ELECTIVE.required_credits`를 `0`으로 변경
- [ ] 교선 1영역 면제 학과의 `GENERAL_ELECTIVE.enabled=false` 설정 확인
  - 호텔외식관광프랜차이즈경영학과
  - 글로벌조리학과
  - 호텔외식비즈니스학과
- [ ] 시트 동기화 API 실행 또는 기존 동기화 절차 완료
- [ ] 동기화 후 아래 시나리오 QA
  - 21학번 일반 학과: 교선 0학점 + 지정 과목 미이수 → 졸업 불가
  - 21학번 일반 학과: 지정 과목 이수 + 교선 21학점 미만 → 졸업 가능
  - 18·19·20학번 동일 정책 확인
  - 2022학번 이후 기존 정책 유지 확인
  - 교선 1영역 면제 학과는 지정 과목 미이수여도 통과
  - 동일·대체 과목 이수 시 지정 과목 이수로 인정

## 고민 지점 및 리뷰 포인트
제가 위키를 제대로 못쓰고 진행해서 그런지 몰라도 계속 구글 시트를 수정하면 되는걸 클래스를 추가해서 db 조회 값을 덮어쓰는 로직을 추가하는 등 과도하게 작업하더라고요... db 설계를 바꾼 적도 있고요.,,흠;; 
위의 `## 논의 과정 및 제외한 변경`이 제가 빠꾸먹인 ai 작업입니다.
위키 제대로 적용하고 한번 더 작업 후 pr 비교해보려합니다.

---

## Codex Review
- `src/main/java/kr/allcll/backend/domain/graduation/credit/GeneralElectivePolicy.java:37` -- "[Error Handling] `enabled` 플래그는 여기(지정 과목 검사 skip)에서만 읽히고, 학점 판정 경로인 `CategoryCreditCalculator`는 `enabled`를 참조하지 않습니다. 면제 학과 row가 `enabled=false`여도 `required_credits=21`이 남아 있으면 학점 미달로 여전히 졸업 불가가 됩니다. 면제 학과의 `required_credits=0` 확인을 액션 아이템에 추가하거나, 판정 경로에서 `enabled=false` 카테고리를 충족 처리하는 방안 검토가 필요해 보입니다."
- `src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java:95` -- "[Suggestion] 바로 위에서 `resolveCreditCriteria(user)`로 이미 criteria를 로드했는데(단, deptNm 키), policy 내부에서 같은 `credit_criteria`를 deptCd 키로 다시 조회합니다. 시트에서 dept_cd/dept_nm 매핑이 어긋나면 학점 기준은 적용되는데 지정 과목 검사만 조용히 skip되는 비대칭이 생길 수 있습니다. 로드된 `creditCriteria`에서 GENERAL_ELECTIVE criterion을 찾아 policy에 넘기면 조회 1회 절감 + 두 판정이 항상 같은 row를 보게 됩니다."

---
- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기