### PR TITLE
fix: remove general elective credit requirement

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/CategoryCreditCalculator.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/CategoryCreditCalculator.java
@@ -105,9 +105,7 @@ public class CategoryCreditCalculator {
             .mapToDouble(CompletedCourse::getCredits)
             .sum();
 
-        int requiredCredits = isGeneralElectiveCreditRequirementAbolished(criterion)
-            ? 0
-            : criterion.getRequiredCredits();
+        int requiredCredits = criterion.getRequiredCredits();
         double remainingCredits = calculateRemainingCredits(requiredCredits, earnedCredits);
         boolean isSatisfied = remainingCredits <= 0;
 
@@ -129,12 +127,6 @@ public class CategoryCreditCalculator {
             return MajorScope.PRIMARY.equals(criterionScope);
         }
         return course.getMajorScope() == criterionScope;
-    }
-
-    private boolean isGeneralElectiveCreditRequirementAbolished(CreditCriterion criterion) {
-        return criterion.getCategoryType() == CategoryType.GENERAL_ELECTIVE
-            && criterion.getAdmissionYear() >= 2018
-            && criterion.getAdmissionYear() <= 2021;
     }
 
     private void addBalanceRequiredIfNeeded(

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/CategoryCreditCalculator.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/CategoryCreditCalculator.java
@@ -105,7 +105,9 @@ public class CategoryCreditCalculator {
             .mapToDouble(CompletedCourse::getCredits)
             .sum();
 
-        int requiredCredits = criterion.getRequiredCredits();
+        int requiredCredits = isGeneralElectiveCreditRequirementAbolished(criterion)
+            ? 0
+            : criterion.getRequiredCredits();
         double remainingCredits = calculateRemainingCredits(requiredCredits, earnedCredits);
         boolean isSatisfied = remainingCredits <= 0;
 
@@ -127,6 +129,12 @@ public class CategoryCreditCalculator {
             return MajorScope.PRIMARY.equals(criterionScope);
         }
         return course.getMajorScope() == criterionScope;
+    }
+
+    private boolean isGeneralElectiveCreditRequirementAbolished(CreditCriterion criterion) {
+        return criterion.getCategoryType() == CategoryType.GENERAL_ELECTIVE
+            && criterion.getAdmissionYear() >= 2018
+            && criterion.getAdmissionYear() <= 2021;
     }
 
     private void addBalanceRequiredIfNeeded(

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java
@@ -16,6 +16,7 @@ import kr.allcll.backend.domain.graduation.credit.CreditCriterion;
 import kr.allcll.backend.domain.graduation.credit.CreditCriterionRepository;
 import kr.allcll.backend.domain.graduation.credit.DoubleCreditCriterion;
 import kr.allcll.backend.domain.graduation.credit.DoubleCreditCriterionRepository;
+import kr.allcll.backend.domain.graduation.credit.GeneralElectiveRequiredCourseChecker;
 import kr.allcll.backend.domain.user.User;
 import kr.allcll.backend.domain.user.UserRepository;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
@@ -29,6 +30,7 @@ public class GraduationChecker {
 
     private final CategoryCreditCalculator categoryCalculator;
     private final CertificationChecker certificationChecker;
+    private final GeneralElectiveRequiredCourseChecker generalElectiveRequiredCourseChecker;
 
     private final UserRepository userRepository;
     private final CreditCriterionRepository creditCriterionRepository;
@@ -40,7 +42,8 @@ public class GraduationChecker {
             .toList();
 
         // 사용자의 졸업 요건 기준 조회
-        List<CreditCriterion> creditCriteria = resolveCreditCriteria(userId);
+        User user = findUser(userId);
+        List<CreditCriterion> creditCriteria = resolveCreditCriteria(user);
 
         // 이수구분별 학점 계산
         List<GraduationCategory> categoryResults = categoryCalculator.calculateCategoryResults(
@@ -54,7 +57,11 @@ public class GraduationChecker {
 
         // 졸업인증제도 검사
         CertResult certResult = certificationChecker.checkAndUpdate(userId, earnedCourses);
-        boolean isGraduatable = canGraduate(categoryResults, certResult);
+        boolean isGraduatable = canGraduate(
+            categoryResults,
+            certResult,
+            generalElectiveRequiredCourseChecker.isSatisfied(user, earnedCourses)
+        );
 
         return new CheckResult(
             isGraduatable,
@@ -66,9 +73,12 @@ public class GraduationChecker {
         );
     }
 
-    private List<CreditCriterion> resolveCreditCriteria(Long userId) {
-        User user = userRepository.findById(userId)
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
             .orElseThrow(() -> new AllcllException(AllcllErrorCode.USER_NOT_FOUND));
+    }
+
+    private List<CreditCriterion> resolveCreditCriteria(User user) {
         if (MajorType.DOUBLE.equals(user.getMajorType())) {
             return buildDoubleMajorCriteria(
                 user,
@@ -191,9 +201,11 @@ public class GraduationChecker {
 
     private boolean canGraduate(
         List<GraduationCategory> categories,
-        CertResult certResult
+        CertResult certResult,
+        boolean isGeneralElectiveRequiredCourseSatisfied
     ) {
-        return categories.stream().allMatch(GraduationCategory::satisfied)
+        return isGeneralElectiveRequiredCourseSatisfied
+            && categories.stream().allMatch(GraduationCategory::satisfied)
             && certResult.isSatisfied();
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/GeneralElectiveRequiredCourseChecker.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/GeneralElectiveRequiredCourseChecker.java
@@ -1,0 +1,28 @@
+package kr.allcll.backend.domain.graduation.credit;
+
+import java.util.List;
+import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
+import kr.allcll.backend.domain.graduation.credit.dto.GraduationCategoryResponse;
+import kr.allcll.backend.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GeneralElectiveRequiredCourseChecker {
+
+    private final NonMajorCategoryResolver nonMajorCategoryResolver;
+    private final UncompletedCourseFilter uncompletedCourseFilter;
+
+    public boolean isSatisfied(User user, List<CompletedCourse> earnedCourses) {
+        List<GraduationCategoryResponse> generalElectiveCategories = nonMajorCategoryResolver
+            .resolve(user.getAdmissionYear(), user.getDeptCd())
+            .stream()
+            .filter(category -> category.categoryType() == CategoryType.GENERAL_ELECTIVE)
+            .toList();
+
+        return uncompletedCourseFilter.filterUncompletedCourses(generalElectiveCategories, earnedCourses)
+            .stream()
+            .allMatch(category -> category.requiredCourses().isEmpty());
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/result/CategoryCreditCalculatorTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/result/CategoryCreditCalculatorTest.java
@@ -1,0 +1,127 @@
+package kr.allcll.backend.domain.graduation.check.result;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import kr.allcll.backend.domain.graduation.MajorScope;
+import kr.allcll.backend.domain.graduation.MajorType;
+import kr.allcll.backend.domain.graduation.balance.BalanceRequiredRuleRepository;
+import kr.allcll.backend.domain.graduation.certification.CodingTargetType;
+import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
+import kr.allcll.backend.domain.graduation.check.result.dto.GraduationCategory;
+import kr.allcll.backend.domain.graduation.credit.AcademicBasicPolicy;
+import kr.allcll.backend.domain.graduation.credit.CategoryType;
+import kr.allcll.backend.domain.graduation.credit.CreditCriterion;
+import kr.allcll.backend.domain.graduation.department.GraduationDepartmentInfo;
+import kr.allcll.backend.domain.graduation.department.GraduationDepartmentInfoRepository;
+import kr.allcll.backend.domain.user.User;
+import kr.allcll.backend.domain.user.UserRepository;
+import kr.allcll.backend.fixture.GraduationDepartmentInfoFixture;
+import kr.allcll.backend.fixture.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryCreditCalculatorTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GraduationDepartmentInfoRepository graduationDepartmentInfoRepository;
+
+    @Mock
+    private BalanceRequiredRuleRepository balanceRequiredRuleRepository;
+
+    @Mock
+    private AcademicBasicPolicy academicBasicPolicy;
+
+    @InjectMocks
+    private CategoryCreditCalculator calculator;
+
+    @Test
+    @DisplayName("18~21학번 교양선택은 이수 학점과 관계없이 학점 요건을 적용하지 않는다")
+    void doesNotApplyGeneralElectiveCreditRequirementForAdmissionYears2018To2021() {
+        // given
+        int admissionYear = 2021;
+        GraduationDepartmentInfo department = GraduationDepartmentInfoFixture.createDepartmentInfo(
+            admissionYear,
+            CodingTargetType.NON_MAJOR
+        );
+        User user = UserFixture.singleMajorUser(admissionYear, department);
+        given(userRepository.findById(1L)).willReturn(java.util.Optional.of(user));
+        given(graduationDepartmentInfoRepository.findByAdmissionYearAndDeptNm(admissionYear, department.getDeptNm()))
+            .willReturn(java.util.Optional.of(department));
+        given(balanceRequiredRuleRepository.findByAdmissionYearAndDeptNm(admissionYear, department.getDeptNm()))
+            .willReturn(java.util.Optional.empty());
+        given(balanceRequiredRuleRepository.findByAdmissionYearAndDeptNm(admissionYear, "ALL"))
+            .willReturn(java.util.Optional.empty());
+
+        CreditCriterion criterion = criterion(admissionYear, CategoryType.GENERAL_ELECTIVE, 21);
+
+        // when
+        GraduationCategory result = calculator.calculateCategoryResults(1L, List.of(), List.of(criterion)).getFirst();
+
+        // then
+        assertThat(result)
+            .extracting(
+                GraduationCategory::requiredCredits,
+                GraduationCategory::remainingCredits,
+                GraduationCategory::satisfied
+            )
+            .containsExactly(0, 0.0, true);
+    }
+
+    @Test
+    @DisplayName("22학번 이후 교양선택은 기존 학점 요건을 유지한다")
+    void appliesGeneralElectiveCreditRequirementForAdmissionYearsAfter2021() {
+        // given
+        int admissionYear = 2022;
+        GraduationDepartmentInfo department = GraduationDepartmentInfoFixture.createDepartmentInfo(
+            admissionYear,
+            CodingTargetType.NON_MAJOR
+        );
+        User user = UserFixture.singleMajorUser(admissionYear, department);
+        given(userRepository.findById(1L)).willReturn(java.util.Optional.of(user));
+        given(graduationDepartmentInfoRepository.findByAdmissionYearAndDeptNm(admissionYear, department.getDeptNm()))
+            .willReturn(java.util.Optional.of(department));
+        given(balanceRequiredRuleRepository.findByAdmissionYearAndDeptNm(admissionYear, department.getDeptNm()))
+            .willReturn(java.util.Optional.empty());
+        given(balanceRequiredRuleRepository.findByAdmissionYearAndDeptNm(admissionYear, "ALL"))
+            .willReturn(java.util.Optional.empty());
+
+        CreditCriterion criterion = criterion(admissionYear, CategoryType.GENERAL_ELECTIVE, 21);
+
+        // when
+        GraduationCategory result = calculator.calculateCategoryResults(1L, List.of(), List.of(criterion)).getFirst();
+
+        // then
+        assertThat(result)
+            .extracting(
+                GraduationCategory::requiredCredits,
+                GraduationCategory::remainingCredits,
+                GraduationCategory::satisfied
+            )
+            .containsExactly(21, 21.0, false);
+    }
+
+    private CreditCriterion criterion(int admissionYear, CategoryType categoryType, int requiredCredits) {
+        return new CreditCriterion(
+            admissionYear,
+            admissionYear % 100,
+            MajorType.ALL,
+            "0",
+            "테스트학과",
+            MajorScope.PRIMARY,
+            categoryType,
+            requiredCredits,
+            true,
+            null
+        );
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/graduation/check/result/CategoryCreditCalculatorTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/check/result/CategoryCreditCalculatorTest.java
@@ -45,8 +45,8 @@ class CategoryCreditCalculatorTest {
     private CategoryCreditCalculator calculator;
 
     @Test
-    @DisplayName("18~21학번 교양선택은 이수 학점과 관계없이 학점 요건을 적용하지 않는다")
-    void doesNotApplyGeneralElectiveCreditRequirementForAdmissionYears2018To2021() {
+    @DisplayName("2021학번 교양선택도 시트에서 내려온 학점 요건을 적용한다")
+    void appliesGeneralElectiveCreditRequirementFromCriterionForAdmissionYear2021() {
         // given
         int admissionYear = 2021;
         GraduationDepartmentInfo department = GraduationDepartmentInfoFixture.createDepartmentInfo(
@@ -74,14 +74,14 @@ class CategoryCreditCalculatorTest {
                 GraduationCategory::remainingCredits,
                 GraduationCategory::satisfied
             )
-            .containsExactly(0, 0.0, true);
+            .containsExactly(21, 21.0, false);
     }
 
     @Test
-    @DisplayName("22학번 이후 교양선택은 기존 학점 요건을 유지한다")
-    void appliesGeneralElectiveCreditRequirementForAdmissionYearsAfter2021() {
+    @DisplayName("시트에서 교양선택 학점 요건을 0으로 내려주면 이수 학점과 관계없이 충족한다")
+    void satisfiesGeneralElectiveWhenCriterionRequiredCreditsIsZero() {
         // given
-        int admissionYear = 2022;
+        int admissionYear = 2021;
         GraduationDepartmentInfo department = GraduationDepartmentInfoFixture.createDepartmentInfo(
             admissionYear,
             CodingTargetType.NON_MAJOR
@@ -95,7 +95,7 @@ class CategoryCreditCalculatorTest {
         given(balanceRequiredRuleRepository.findByAdmissionYearAndDeptNm(admissionYear, "ALL"))
             .willReturn(java.util.Optional.empty());
 
-        CreditCriterion criterion = criterion(admissionYear, CategoryType.GENERAL_ELECTIVE, 21);
+        CreditCriterion criterion = criterion(admissionYear, CategoryType.GENERAL_ELECTIVE, 0);
 
         // when
         GraduationCategory result = calculator.calculateCategoryResults(1L, List.of(), List.of(criterion)).getFirst();
@@ -107,7 +107,7 @@ class CategoryCreditCalculatorTest {
                 GraduationCategory::remainingCredits,
                 GraduationCategory::satisfied
             )
-            .containsExactly(21, 21.0, false);
+            .containsExactly(0, 0.0, true);
     }
 
     private CreditCriterion criterion(int admissionYear, CategoryType categoryType, int requiredCredits) {

--- a/src/test/java/kr/allcll/backend/domain/graduation/credit/GeneralElectiveRequiredCourseCheckerIntegrationTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/credit/GeneralElectiveRequiredCourseCheckerIntegrationTest.java
@@ -1,0 +1,149 @@
+package kr.allcll.backend.domain.graduation.credit;
+
+import static kr.allcll.backend.fixture.CompletedCourseFixture.createCompletedCourse;
+import static kr.allcll.backend.fixture.GraduationDepartmentInfoFixture.createDepartmentInfo;
+import static kr.allcll.backend.fixture.UserFixture.singleMajorUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+import kr.allcll.backend.domain.graduation.MajorScope;
+import kr.allcll.backend.domain.graduation.MajorType;
+import kr.allcll.backend.domain.graduation.balance.BalanceRequiredResolver;
+import kr.allcll.backend.domain.graduation.certification.CodingTargetType;
+import kr.allcll.backend.domain.graduation.department.GraduationDepartmentInfo;
+import kr.allcll.backend.domain.graduation.department.GraduationDepartmentInfoRepository;
+import kr.allcll.backend.domain.user.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@DataJpaTest
+@Import({
+    GeneralElectiveRequiredCourseChecker.class,
+    NonMajorCategoryResolver.class,
+    RequiredCourseResolver.class,
+    UncompletedCourseFilter.class
+})
+class GeneralElectiveRequiredCourseCheckerIntegrationTest {
+
+    private static final int ADMISSION_YEAR = 2021;
+    private static final String REQUIRED_CURI_NO = "000001";
+    private static final String REQUIRED_CURI_NM = "세계사:인간과문명";
+
+    @Autowired
+    private GeneralElectiveRequiredCourseChecker checker;
+
+    @Autowired
+    private CreditCriterionRepository creditCriterionRepository;
+
+    @Autowired
+    private RequiredCourseRepository requiredCourseRepository;
+
+    @Autowired
+    private CourseEquivalenceRepository courseEquivalenceRepository;
+
+    @Autowired
+    private GraduationDepartmentInfoRepository graduationDepartmentInfoRepository;
+
+    @MockitoBean
+    private BalanceRequiredResolver balanceRequiredResolver;
+
+    @AfterEach
+    void clean() {
+        courseEquivalenceRepository.deleteAllInBatch();
+        requiredCourseRepository.deleteAllInBatch();
+        creditCriterionRepository.deleteAllInBatch();
+        graduationDepartmentInfoRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("교선 지정 과목을 이수하지 않으면 졸업요건을 충족하지 않는다")
+    void returnsFalseWhenGeneralElectiveRequiredCourseIsUncompleted() {
+        // given
+        User user = saveUserAndGeneralElectiveCriterion();
+        saveRequiredCourse("ALL", "0", true);
+
+        // when
+        boolean result = checker.isSatisfied(user, List.of());
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("교선 지정 과목 또는 동일과목을 이수하면 졸업요건을 충족한다")
+    void returnsTrueWhenGeneralElectiveRequiredCourseOrEquivalentIsCompleted() {
+        // given
+        User user = saveUserAndGeneralElectiveCriterion();
+        saveRequiredCourse("ALL", "0", true);
+        courseEquivalenceRepository.save(new CourseEquivalence("9717", REQUIRED_CURI_NO, REQUIRED_CURI_NM));
+        courseEquivalenceRepository.save(new CourseEquivalence("9717", "000002", "구 세계사"));
+
+        // when
+        boolean result = checker.isSatisfied(
+            user,
+            List.of(createCompletedCourse("000002", "구 세계사", CategoryType.GENERAL_ELECTIVE))
+        );
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("학과별 지정 해제는 전체 교선 지정 과목보다 우선한다")
+    void appliesDepartmentSpecificRequiredCourseOverride() {
+        // given
+        User user = saveUserAndGeneralElectiveCriterion();
+        saveRequiredCourse("ALL", "0", true);
+        saveRequiredCourse(user.getDeptNm(), user.getDeptCd(), false);
+
+        // when
+        boolean result = checker.isSatisfied(user, List.of());
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    private User saveUserAndGeneralElectiveCriterion() {
+        GraduationDepartmentInfo department = createDepartmentInfo(ADMISSION_YEAR, CodingTargetType.NON_MAJOR);
+        graduationDepartmentInfoRepository.save(department);
+        given(balanceRequiredResolver.resolve(ADMISSION_YEAR, department.getDeptCd(), department.getDeptGroup()))
+            .willReturn(Optional.empty());
+
+        creditCriterionRepository.save(new CreditCriterion(
+            ADMISSION_YEAR,
+            ADMISSION_YEAR % 100,
+            MajorType.ALL,
+            department.getDeptCd(),
+            department.getDeptNm(),
+            MajorScope.PRIMARY,
+            CategoryType.GENERAL_ELECTIVE,
+            21,
+            true,
+            null
+        ));
+        return singleMajorUser(ADMISSION_YEAR, department);
+    }
+
+    private void saveRequiredCourse(String deptNm, String deptCd, boolean required) {
+        requiredCourseRepository.save(new RequiredCourse(
+            ADMISSION_YEAR,
+            ADMISSION_YEAR % 100,
+            deptCd,
+            deptNm,
+            CategoryType.GENERAL_ELECTIVE,
+            REQUIRED_CURI_NO,
+            REQUIRED_CURI_NM,
+            null,
+            "9717",
+            required,
+            null
+        ));
+    }
+}


### PR DESCRIPTION
## 변경 사항

- 2018~2021학번 `GENERAL_ELECTIVE`의 필수 학점을 0으로 계산합니다.
- 2021학번 교선 0학점과 2022학번 기존 21학점 요건을 검증하는 재현 테스트를 추가했습니다.

## 배경

2025-2부터 교양선택(1영역) 필수이수학점이 폐지됐지만, 기존 시트 기준 21학점이 졸업판정에 계속 적용되고 있었습니다.

## 영향

18~21학번은 교양선택 학점 부족만으로 미충족 처리되지 않습니다. 학교 지정과목 검사는 변경하지 않습니다.

## 검증

- `./gradlew compileJava -q`
- `./gradlew :test --tests "kr.allcll.backend.domain.graduation.check.result.CategoryCreditCalculatorTest"`

전체 `:test`는 Google Sheets 자격증명 부재로 기존 Spring 컨텍스트 테스트가 실패합니다.