### PR TITLE
feat: SSO 로그인으로 크롤러 인증 정보 자동 발급

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+logs/
+.DS_Store
 
 ### STS ###
 .apt_generated

--- a/src/main/java/kr/allcll/backend/admin/session/AdminSessionApi.java
+++ b/src/main/java/kr/allcll/backend/admin/session/AdminSessionApi.java
@@ -6,6 +6,8 @@ import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.admin.session.dto.CredentialResponse;
 import kr.allcll.backend.admin.session.dto.SessionStatusResponse;
 import kr.allcll.backend.admin.session.dto.SetCredentialRequest;
+import kr.allcll.backend.admin.session.dto.SsoLoginRequest;
+import kr.allcll.backend.admin.session.dto.SsoLoginResponse;
 import kr.allcll.backend.admin.session.dto.UserSessionsStatusResponse;
 import kr.allcll.crawler.credential.Credentials;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,19 @@ public class AdminSessionApi {
         }
         sessionService.setCredential(setCredentialRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/api/admin/session/sso")
+    public ResponseEntity<SsoLoginResponse> registerBySso(HttpServletRequest request,
+        @RequestBody SsoLoginRequest ssoLoginRequest) {
+        if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
+            return ResponseEntity.status(401).build();
+        }
+        if (!ssoLoginRequest.hasCredential()) {
+            return ResponseEntity.badRequest().build();
+        }
+        String userId = sessionService.registerBySso(ssoLoginRequest.studentId(), ssoLoginRequest.password());
+        return ResponseEntity.ok(new SsoLoginResponse(userId));
     }
 
     @GetMapping("/api/admin/session")

--- a/src/main/java/kr/allcll/backend/admin/session/SessionService.java
+++ b/src/main/java/kr/allcll/backend/admin/session/SessionService.java
@@ -5,11 +5,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import kr.allcll.backend.admin.session.dto.CredentialResponse;
 import kr.allcll.backend.admin.session.dto.SessionStatusResponse;
 import kr.allcll.backend.admin.session.dto.SetCredentialRequest;
 import kr.allcll.backend.admin.session.dto.UserSessionStatusResponse;
 import kr.allcll.backend.admin.session.dto.UserSessionsStatusResponse;
+import kr.allcll.backend.admin.session.sso.SjptSsoClient;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
 import kr.allcll.crawler.client.SessionClient;
 import kr.allcll.crawler.client.payload.EmptyPayload;
 import kr.allcll.crawler.common.exception.CrawlerExternalRequestFailException;
@@ -28,13 +32,38 @@ public class SessionService {
     private final Credentials credentials;
     private final CrawlerScheduledTaskHandler threadPoolTaskScheduler;
     private final SessionClient sessionClient;
+    private final SjptSsoClient sjptSsoClient;
 
     private final Map<String, LocalDateTime> sessionUpdatedTimes = new ConcurrentHashMap<>();
+
+    /**
+     * SSO 세션 수립이 진행 중인지 나타낸다. 여석 프로그램 권한을 강제 로그인으로 등록하므로, 두 번째 요청은 방금 만든 세션을 그대로 밀어낸다. 대기시켜 순서대로 실행하면 그 두 번째 등록이
+     * 실제로 일어나므로, 겹치는 요청은 기다리지 않고 거절한다.
+     */
+    private final AtomicBoolean ssoRegistrationInProgress = new AtomicBoolean();
 
     public void setCredential(SetCredentialRequest request) {
         Credential credential = request.toCredential();
         isSessionValid(credential);
         credentials.addCredential(credential);
+    }
+
+    /**
+     * 관리자 계정으로 로그인해 크롤러 인증 정보를 만들고 저장한다.
+     *
+     * @return 수립된 세션의 사용자 식별자. 어드민 화면이 이후 갱신 시작에 사용한다.
+     */
+    public String registerBySso(String studentId, String password) {
+        if (!ssoRegistrationInProgress.compareAndSet(false, true)) {
+            throw new AllcllException(AllcllErrorCode.SSO_REGISTRATION_IN_PROGRESS);
+        }
+        try {
+            Credential credential = sjptSsoClient.establishSession(studentId, password);
+            credentials.addCredential(credential);
+            return credential.getTokenU();
+        } finally {
+            ssoRegistrationInProgress.set(false);
+        }
     }
 
     public CredentialResponse getCredential(String userId) {

--- a/src/main/java/kr/allcll/backend/admin/session/dto/SsoLoginRequest.java
+++ b/src/main/java/kr/allcll/backend/admin/session/dto/SsoLoginRequest.java
@@ -1,0 +1,20 @@
+package kr.allcll.backend.admin.session.dto;
+
+public record SsoLoginRequest(
+    String studentId,
+    String password
+) {
+
+    public boolean hasCredential() {
+        return studentId != null && !studentId.isBlank()
+            && password != null && !password.isBlank();
+    }
+
+    /**
+     * record 가 자동으로 만드는 toString 은 모든 필드를 그대로 출력한다. 이 객체가 예외 메시지나 로그, Sentry 브레드크럼에 실리면 비밀번호가 평문으로 남으므로 직접 가린다.
+     */
+    @Override
+    public String toString() {
+        return "SsoLoginRequest{studentId=%s, password=[redacted]}".formatted(studentId);
+    }
+}

--- a/src/main/java/kr/allcll/backend/admin/session/dto/SsoLoginResponse.java
+++ b/src/main/java/kr/allcll/backend/admin/session/dto/SsoLoginResponse.java
@@ -1,0 +1,8 @@
+package kr.allcll.backend.admin.session.dto;
+
+/**
+ * @param userId 수립된 세션의 사용자 식별자. 어드민 화면이 이후 세션 갱신 시작과 크롤링 요청에 그대로 사용한다.
+ */
+public record SsoLoginResponse(String userId) {
+
+}

--- a/src/main/java/kr/allcll/backend/admin/session/sso/SjptCrawlerProgram.java
+++ b/src/main/java/kr/allcll/backend/admin/session/sso/SjptCrawlerProgram.java
@@ -1,0 +1,39 @@
+package kr.allcll.backend.admin.session.sso;
+
+/**
+ * 크롤러가 사용하는 수강신청 시스템 프로그램. 세션 수립 시 여기 있는 프로그램의 권한을 등록해두면, 세션이 살아 있는 동안 크롤러의 조회 네 종류가 모두 동작한다.
+ */
+public enum SjptCrawlerProgram {
+
+    /**
+     * 여석. 이 프로그램만 중복 사용 방지가 걸려 있어, 같은 계정으로 두 번째로 열면 먼저 열린 쪽이 자동 종료된다. 재로그인이나 복구 시 남아 있는 세션을 밀어내야 하므로 강제 로그인으로 등록한다.
+     */
+    SEAT("SELF_STUDSELF_SUB_30SELF_MENU_10SueReqLesnEGuide", true),
+
+    /**
+     * 관심과목. 조회 계열이라 중복 사용 방지가 없다.
+     */
+    BASKET("SELF_STUDSELF_SUB_30SELF_MENU_10SueReqLesnBasketGuide", false),
+
+    /**
+     * 과목·학과 조회. 조회 계열이라 중복 사용 방지가 없다.
+     */
+    SUBJECT("SELF_STUDSELF_SUB_30SELF_MENU_10SueOpenTimeQ", false),
+    ;
+
+    private final String programKey;
+    private final boolean forceLogin;
+
+    SjptCrawlerProgram(String programKey, boolean forceLogin) {
+        this.programKey = programKey;
+        this.forceLogin = forceLogin;
+    }
+
+    public String getProgramKey() {
+        return programKey;
+    }
+
+    public boolean isForceLogin() {
+        return forceLogin;
+    }
+}

--- a/src/main/java/kr/allcll/backend/admin/session/sso/SjptRunContext.java
+++ b/src/main/java/kr/allcll/backend/admin/session/sso/SjptRunContext.java
@@ -1,0 +1,81 @@
+package kr.allcll.backend.admin.session.sso;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.crawler.client.support.AddParamEncoder;
+
+/**
+ * 수강신청 시스템 요청의 addParam 값을 만든다.
+ * <p>
+ * 서버는 모든 요청에서 현재 세션 정보를 쿼리 파라미터 addParam 으로 받는다. 값은
+ * {@code base64(urlEncode(json))} 이며, 인코딩 규약은 크롤러의 {@link AddParamEncoder} 를 그대로 재사용한다(콜론과 쉼표는 인코딩하지 않는다).
+ * <p>
+ * 키 순서는 실제로 동작이 확인된 PoC 의 RunContext 와 동일하게 맞춘다. 서버가 순서를 따지지는 않을 것으로 보이나, 검증된 형태에서 벗어날 이유가 없다.
+ */
+public record SjptRunContext(
+    String userId,
+    String loginDt,
+    String runningSejong,
+    String programKey,
+    String systemKey,
+    Boolean forceLogin
+) {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String SYSTEM_KEY_SCHOOL = "SCH";
+
+    /**
+     * 사용자 정보 초기화(initUserInfo.do) 요청용. 아직 토큰을 모르는 시점이라 빈 값으로 보낸다.
+     */
+    public static SjptRunContext empty() {
+        return new SjptRunContext("", "", "", null, null, null);
+    }
+
+    /**
+     * 세션이 수립된 뒤의 일반 요청용(메뉴 로드 등).
+     */
+    public static SjptRunContext of(SjptUserInfoResponse userInfo) {
+        return new SjptRunContext(userInfo.userId(), userInfo.loginDt(), userInfo.runningSejong(), null, null, null);
+    }
+
+    /**
+     * 프로그램 role 등록(initUserRole.do) 요청용.
+     *
+     * @param forceLogin 강제 로그인 여부. 여석 프로그램은 중복 사용 방지가 걸려 있어 남아 있는 세션을 밀어내야 하므로 true 로 등록한다.
+     */
+    public SjptRunContext forProgram(String programKey, boolean forceLogin) {
+        return new SjptRunContext(userId, loginDt, runningSejong, programKey, SYSTEM_KEY_SCHOOL, forceLogin);
+    }
+
+    public String toAddParam() {
+        String encoded = AddParamEncoder.encode(toJson());
+        return Base64.getEncoder().encodeToString(encoded.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String toJson() {
+        Map<String, String> body = new LinkedHashMap<>();
+        if (forceLogin != null) {
+            body.put("pbForceLog", String.valueOf(forceLogin));
+        }
+        if (programKey != null) {
+            body.put("_runPgmKey", programKey);
+        }
+        if (systemKey != null) {
+            body.put("_runSysKey", systemKey);
+        }
+        body.put("_runIntgUsrNo", userId);
+        body.put("_runPgLoginDt", loginDt);
+        body.put("_runningSejong", runningSejong);
+        try {
+            return OBJECT_MAPPER.writeValueAsString(body);
+        } catch (JsonProcessingException exception) {
+            throw new AllcllException(AllcllErrorCode.SSO_USER_INFO_PARSE_FAIL, exception);
+        }
+    }
+}

--- a/src/main/java/kr/allcll/backend/admin/session/sso/SjptSsoClient.java
+++ b/src/main/java/kr/allcll/backend/admin/session/sso/SjptSsoClient.java
@@ -7,7 +7,9 @@ import java.net.HttpCookie;
 import java.time.Duration;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
 import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.backend.client.LoginProperties;
 import kr.allcll.crawler.credential.Credential;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.FormBody;
 import okhttp3.JavaNetCookieJar;
@@ -23,7 +25,7 @@ import org.springframework.stereotype.Component;
  * <p>
  * 브라우저가 수강신청 페이지에 진입할 때 서버 세션에 만들어 두는 상태를 코드로 재현한다. 순서를 지켜야 하며, 특히 메뉴 로드는 권한 등록의 선행 조건이다.
  * <pre>
- * 포털 로그인 -&gt; doSsoLogin -&gt; initUserInfo -&gt; 메뉴 로드 -&gt; 프로그램별 권한 등록
+ * 포털 로그인 -> doSsoLogin -> initUserInfo -> 메뉴 로드 -> 프로그램별 권한 등록
  * </pre>
  * 성공 판정은 응답 값 객체에 맡긴다. 이 시스템은 실패해도 HTTP 200 과 HTML 을 돌려주고 성공 응답에도 "실패", "error" 문자열이 들어 있어, 상태 코드나 본문 문자열로는 판정할 수
  * 없다(실계정 캡처로 확인).
@@ -32,9 +34,9 @@ import org.springframework.stereotype.Component;
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class SjptSsoClient {
 
-    private static final String PORTAL_LOGIN_URL = "https://portal.sejong.ac.kr/jsp/login/login_action.jsp";
     private static final String PORTAL_LOGIN_REFERER = "https://portal.sejong.ac.kr/jsp/login/loginSSL.jsp";
     private static final String PORTAL_REFERER = "https://portal.sejong.ac.kr/";
 
@@ -51,6 +53,8 @@ public class SjptSsoClient {
     private static final String MENU_REQUEST_BODY =
         "{\"dm_ReqLeftMenu\":{\"MENU_SYS_ID\":\"SELF_STUD\",\"SYSTEM_DIV\":\"SCH\",\"MENU_SYS_NM\":\"학부생학사정보\"}}";
     private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    private final LoginProperties loginProperties;
 
     /**
      * 로그인부터 권한 등록까지 수행하고 크롤러가 쓸 인증 정보를 만든다. 비밀번호는 이 메서드 밖으로 나가지 않는다.
@@ -91,7 +95,7 @@ public class SjptSsoClient {
             .add("password", password)
             .build();
         Request request = new Request.Builder()
-            .url(PORTAL_LOGIN_URL)
+            .url(loginProperties.portalLoginUrl())
             .post(form)
             .header("Referer", PORTAL_LOGIN_REFERER)
             .build();

--- a/src/main/java/kr/allcll/backend/admin/session/sso/SjptSsoClient.java
+++ b/src/main/java/kr/allcll/backend/admin/session/sso/SjptSsoClient.java
@@ -1,0 +1,149 @@
+package kr.allcll.backend.admin.session.sso;
+
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.HttpCookie;
+import java.time.Duration;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.crawler.credential.Credential;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.FormBody;
+import okhttp3.JavaNetCookieJar;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.springframework.stereotype.Component;
+
+/**
+ * 관리자 계정으로 수강신청 시스템에 로그인해 크롤러가 쓸 세션을 수립한다.
+ * <p>
+ * 브라우저가 수강신청 페이지에 진입할 때 서버 세션에 만들어 두는 상태를 코드로 재현한다. 순서를 지켜야 하며, 특히 메뉴 로드는 권한 등록의 선행 조건이다.
+ * <pre>
+ * 포털 로그인 -&gt; doSsoLogin -&gt; initUserInfo -&gt; 메뉴 로드 -&gt; 프로그램별 권한 등록
+ * </pre>
+ * 성공 판정은 응답 값 객체에 맡긴다. 이 시스템은 실패해도 HTTP 200 과 HTML 을 돌려주고 성공 응답에도 "실패", "error" 문자열이 들어 있어, 상태 코드나 본문 문자열로는 판정할 수
+ * 없다(실계정 캡처로 확인).
+ * <p>
+ * 비밀번호를 다루므로 요청·응답 본문을 로깅하는 클라이언트를 쓰면 안 된다. 크롤러의 loggingRestClient 를 주입하지 말 것.
+ */
+@Slf4j
+@Component
+public class SjptSsoClient {
+
+    private static final String PORTAL_LOGIN_URL = "https://portal.sejong.ac.kr/jsp/login/login_action.jsp";
+    private static final String PORTAL_LOGIN_REFERER = "https://portal.sejong.ac.kr/jsp/login/loginSSL.jsp";
+    private static final String PORTAL_REFERER = "https://portal.sejong.ac.kr/";
+
+    private static final String SJPT_BASE_URL = "https://sjpt.sejong.ac.kr";
+    private static final String SSO_LOGIN_URL = SJPT_BASE_URL + "/main/view/Login/doSsoLogin.do";
+    private static final String INIT_USER_INFO_URL = SJPT_BASE_URL + "/main/sys/UserInfo/initUserInfo.do";
+    private static final String LIST_MENU_URL = SJPT_BASE_URL + "/main/view/Menu/doListUserMenuListLeft.do";
+    private static final String INIT_USER_ROLE_URL = SJPT_BASE_URL + "/main/sys/UserRole/initUserRole.do";
+
+    private static final String SJPT_HOST = "sjpt.sejong.ac.kr";
+    private static final String SESSION_COOKIE_NAME = "JSESSIONID";
+
+    private static final MediaType JSON = MediaType.get("application/json; charset=\"UTF-8\"");
+    private static final String MENU_REQUEST_BODY =
+        "{\"dm_ReqLeftMenu\":{\"MENU_SYS_ID\":\"SELF_STUD\",\"SYSTEM_DIV\":\"SCH\",\"MENU_SYS_NM\":\"학부생학사정보\"}}";
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    /**
+     * 로그인부터 권한 등록까지 수행하고 크롤러가 쓸 인증 정보를 만든다. 비밀번호는 이 메서드 밖으로 나가지 않는다.
+     */
+    public Credential establishSession(String studentId, String password) {
+        CookieManager cookieManager = new CookieManager();
+        cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
+        OkHttpClient client = new OkHttpClient.Builder()
+            .cookieJar(new JavaNetCookieJar(cookieManager))
+            .connectTimeout(TIMEOUT)
+            .readTimeout(TIMEOUT)
+            .build();
+
+        loginToPortal(client, studentId, password);
+        call(client, SSO_LOGIN_URL, null, PORTAL_REFERER, null);
+        String jSessionId = extractSessionId(cookieManager);
+
+        SjptUserInfoResponse userInfo = SjptUserInfoResponse.from(
+            call(client, withAddParam(INIT_USER_INFO_URL, SjptRunContext.empty()), "",
+                SJPT_BASE_URL, "mf___subMainUserInfoInit")
+        );
+
+        SjptRunContext session = SjptRunContext.of(userInfo);
+        call(client, withAddParam(LIST_MENU_URL, session), MENU_REQUEST_BODY,
+            SJPT_BASE_URL, "mf_subUserMenuListLeft");
+
+        for (SjptCrawlerProgram program : SjptCrawlerProgram.values()) {
+            registerProgramRole(client, session, program);
+        }
+        log.info("수강신청 시스템 세션을 수립했습니다: userId={}", userInfo.userId());
+        return userInfo.toCredential(jSessionId);
+    }
+
+    private void loginToPortal(OkHttpClient client, String studentId, String password) {
+        RequestBody form = new FormBody.Builder()
+            .add("mainLogin", "Y")
+            .add("id", studentId)
+            .add("password", password)
+            .build();
+        Request request = new Request.Builder()
+            .url(PORTAL_LOGIN_URL)
+            .post(form)
+            .header("Referer", PORTAL_LOGIN_REFERER)
+            .build();
+        execute(client, request);
+    }
+
+    private void registerProgramRole(OkHttpClient client, SjptRunContext session, SjptCrawlerProgram program) {
+        SjptRunContext context = session.forProgram(program.getProgramKey(), program.isForceLogin());
+        String body = call(client, withAddParam(INIT_USER_ROLE_URL, context), context.toJson(), SJPT_BASE_URL,
+            "mf_tabMainCon_contents_" + program.getProgramKey() + "_body___subMainRoleInit");
+        SjptUserRoleResponse.from(body).validateRegisteredFor(program.getProgramKey());
+    }
+
+    private String call(OkHttpClient client, String url, String body, String referer, String submissionId) {
+        Request.Builder builder = new Request.Builder()
+            .url(url)
+            .header("Referer", referer);
+        if (body != null) {
+            builder.post(RequestBody.create(body, JSON))
+                .header("Accept", "application/json")
+                .header("Origin", SJPT_BASE_URL);
+        }
+        if (submissionId != null) {
+            builder.header("submissionid", submissionId);
+        }
+        return execute(client, builder.build());
+    }
+
+    private String execute(OkHttpClient client, Request request) {
+        try (Response response = client.newCall(request).execute()) {
+            if (response.body() == null) {
+                throw new AllcllException(AllcllErrorCode.SSO_SESSION_ESTABLISH_FAIL);
+            }
+            return response.body().string();
+        } catch (IOException exception) {
+            throw new AllcllException(AllcllErrorCode.SSO_SESSION_ESTABLISH_FAIL, exception);
+        }
+    }
+
+    /**
+     * 로그인 성공 여부는 본문으로 판정할 수 없으므로, 수강신청 시스템의 세션 쿠키가 발급되었는지로 확인한다.
+     */
+    private String extractSessionId(CookieManager cookieManager) {
+        return cookieManager.getCookieStore().getCookies().stream()
+            .filter(cookie -> SESSION_COOKIE_NAME.equals(cookie.getName()))
+            .filter(cookie -> cookie.getDomain() != null && cookie.getDomain().contains(SJPT_HOST))
+            .map(HttpCookie::getValue)
+            .findFirst()
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.SSO_SESSION_ESTABLISH_FAIL));
+    }
+
+    private String withAddParam(String url, SjptRunContext context) {
+        return url + "?addParam=" + context.toAddParam();
+    }
+}

--- a/src/main/java/kr/allcll/backend/admin/session/sso/SjptSsoClient.java
+++ b/src/main/java/kr/allcll/backend/admin/session/sso/SjptSsoClient.java
@@ -69,13 +69,13 @@ public class SjptSsoClient {
         String jSessionId = extractSessionId(cookieManager);
 
         SjptUserInfoResponse userInfo = SjptUserInfoResponse.from(
-            call(client, withAddParam(INIT_USER_INFO_URL, SjptRunContext.empty()), "",
-                SJPT_BASE_URL, "mf___subMainUserInfoInit")
+            verifyAuthenticated(call(client, withAddParam(INIT_USER_INFO_URL, SjptRunContext.empty()), "",
+                SJPT_BASE_URL, "mf___subMainUserInfoInit"))
         );
 
         SjptRunContext session = SjptRunContext.of(userInfo);
-        call(client, withAddParam(LIST_MENU_URL, session), MENU_REQUEST_BODY,
-            SJPT_BASE_URL, "mf_subUserMenuListLeft");
+        verifyAuthenticated(call(client, withAddParam(LIST_MENU_URL, session), MENU_REQUEST_BODY,
+            SJPT_BASE_URL, "mf_subUserMenuListLeft"));
 
         for (SjptCrawlerProgram program : SjptCrawlerProgram.values()) {
             registerProgramRole(client, session, program);
@@ -102,7 +102,21 @@ public class SjptSsoClient {
         SjptRunContext context = session.forProgram(program.getProgramKey(), program.isForceLogin());
         String body = call(client, withAddParam(INIT_USER_ROLE_URL, context), context.toJson(), SJPT_BASE_URL,
             "mf_tabMainCon_contents_" + program.getProgramKey() + "_body___subMainRoleInit");
-        SjptUserRoleResponse.from(body).validateRegisteredFor(program.getProgramKey());
+        SjptUserRoleResponse.from(verifyAuthenticated(body)).validateRegisteredFor(program.getProgramKey());
+    }
+
+    /**
+     * 잘못된 학번이나 비밀번호로도 포털과 수강신청 시스템은 200 과 세션 쿠키를 돌려준다. 인증되지 않았다는 사실은 이후 요청의 오류 봉투에서만 드러나므로 여기서 걸러낸다.
+     */
+    private String verifyAuthenticated(String responseBody) {
+        SjptSubmitError.find(responseBody).ifPresent(error -> {
+            if (error.isNotAuthenticated()) {
+                throw new AllcllException(AllcllErrorCode.SEJONG_LOGIN_FAIL);
+            }
+            log.warn("수강신청 시스템이 요청을 거절했습니다: type={}, message={}", error.errorType(), error.message());
+            throw new AllcllException(AllcllErrorCode.SSO_SESSION_ESTABLISH_FAIL);
+        });
+        return responseBody;
     }
 
     private String call(OkHttpClient client, String url, String body, String referer, String submissionId) {

--- a/src/main/java/kr/allcll/backend/admin/session/sso/SjptSubmitError.java
+++ b/src/main/java/kr/allcll/backend/admin/session/sso/SjptSubmitError.java
@@ -1,0 +1,42 @@
+package kr.allcll.backend.admin.session.sso;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+
+/**
+ * 수강신청 시스템이 요청을 거절할 때 돌려주는 오류 봉투.
+ * <p>
+ * 이 시스템은 실패해도 HTTP 200 을 주고, 성공 응답의 본문에도 "실패", "error" 같은 문자열이 섞여 있어 상태 코드나 문자열 포함 여부로는 판정할 수 없다. 대신 실패 응답에는 아래 형태가
+ * 실린다(실계정으로 잘못된 비밀번호를 넣어 확인).
+ * <pre>
+ * {"_SUBMIT_ERROR_":{"ERRMSG":"...","ERRTYPE":"LOGOUT","ERRCODE":"..."}}
+ * </pre>
+ * 인증되지 않은 요청은 ERRTYPE 이 LOGOUT 으로 온다. 서버가 미인증 상태를 로그아웃으로 취급하기 때문이다.
+ */
+public record SjptSubmitError(String errorType, String message) {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String ERROR_FIELD = "_SUBMIT_ERROR_";
+    private static final String NOT_AUTHENTICATED_TYPE = "LOGOUT";
+
+    public static Optional<SjptSubmitError> find(String responseBody) {
+        try {
+            JsonNode error = OBJECT_MAPPER.readTree(responseBody).path(ERROR_FIELD);
+            if (error.isMissingNode() || !error.isObject()) {
+                return Optional.empty();
+            }
+            return Optional.of(new SjptSubmitError(
+                error.path("ERRTYPE").asText(""),
+                error.path("ERRMSG").asText("")
+            ));
+        } catch (Exception exception) {
+            // JSON 이 아닌 응답에는 이 봉투가 실리지 않는다. 다른 단계에서 형식을 검사한다.
+            return Optional.empty();
+        }
+    }
+
+    public boolean isNotAuthenticated() {
+        return NOT_AUTHENTICATED_TYPE.equals(errorType);
+    }
+}

--- a/src/main/java/kr/allcll/backend/admin/session/sso/SjptUserInfoResponse.java
+++ b/src/main/java/kr/allcll/backend/admin/session/sso/SjptUserInfoResponse.java
@@ -1,0 +1,57 @@
+package kr.allcll.backend.admin.session.sso;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.crawler.credential.Credential;
+
+/**
+ * 수강신청 시스템의 initUserInfo.do 응답에서 크롤러 인증 정보에 필요한 값을 추출한다.
+ * <p>
+ * 응답은 데이터셋별로 나뉘어 있고, 필요한 값 셋이 서로 다른 데이터셋에 흩어져 있다.
+ * <pre>
+ * dm_UserInfo.INTG_USR_NO    -&gt; tokenU (_runIntgUsrNo)
+ * dm_UserInfo.RUNNING_SEJONG -&gt; tokenR (_runningSejong)
+ * dm_UserInfoGam.LOGIN_DT    -&gt; tokenL (_runPgLoginDt)
+ * </pre>
+ * tokenJ(JSESSIONID) 는 이 응답이 아니라 doSsoLogin.do 의 쿠키에서 나온다.
+ */
+public record SjptUserInfoResponse(
+    String userId,
+    String runningSejong,
+    String loginDt
+) {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public static SjptUserInfoResponse from(String responseBody) {
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(responseBody);
+            return new SjptUserInfoResponse(
+                readRequiredText(root, "dm_UserInfo", "INTG_USR_NO"),
+                readRequiredText(root, "dm_UserInfo", "RUNNING_SEJONG"),
+                readRequiredText(root, "dm_UserInfoGam", "LOGIN_DT")
+            );
+        } catch (JsonProcessingException exception) {
+            throw new AllcllException(AllcllErrorCode.SSO_USER_INFO_PARSE_FAIL, exception);
+        }
+    }
+
+    /**
+     * Credential.of 의 인자 순서는 (jSessionId, userId, runningSejong, loginDt) 로 tokenR 과 tokenL 이 J/U/R/L 표기 순서와
+     * 어긋난다. 두 값을 바꿔 넣어도 타입이 같아 컴파일 시점에 걸리지 않으므로, 변환은 이 메서드 한 곳에서만 한다.
+     */
+    public Credential toCredential(String jSessionId) {
+        return Credential.of(jSessionId, userId, runningSejong, loginDt);
+    }
+
+    private static String readRequiredText(JsonNode root, String dataSet, String field) {
+        JsonNode value = root.path(dataSet).path(field);
+        if (!value.isTextual() || value.asText().isBlank()) {
+            throw new AllcllException(AllcllErrorCode.SSO_USER_INFO_PARSE_FAIL);
+        }
+        return value.asText();
+    }
+}

--- a/src/main/java/kr/allcll/backend/admin/session/sso/SjptUserInfoResponse.java
+++ b/src/main/java/kr/allcll/backend/admin/session/sso/SjptUserInfoResponse.java
@@ -12,9 +12,9 @@ import kr.allcll.crawler.credential.Credential;
  * <p>
  * 응답은 데이터셋별로 나뉘어 있고, 필요한 값 셋이 서로 다른 데이터셋에 흩어져 있다.
  * <pre>
- * dm_UserInfo.INTG_USR_NO    -&gt; tokenU (_runIntgUsrNo)
- * dm_UserInfo.RUNNING_SEJONG -&gt; tokenR (_runningSejong)
- * dm_UserInfoGam.LOGIN_DT    -&gt; tokenL (_runPgLoginDt)
+ * dm_UserInfo.INTG_USR_NO          tokenU (_runIntgUsrNo)
+ * dm_UserInfo.RUNNING_SEJONG       tokenR (_runningSejong)
+ * dm_UserInfoGam.LOGIN_DT          tokenL (_runPgLoginDt)
  * </pre>
  * tokenJ(JSESSIONID) 는 이 응답이 아니라 doSsoLogin.do 의 쿠키에서 나온다.
  */

--- a/src/main/java/kr/allcll/backend/admin/session/sso/SjptUserRoleResponse.java
+++ b/src/main/java/kr/allcll/backend/admin/session/sso/SjptUserRoleResponse.java
@@ -1,0 +1,39 @@
+package kr.allcll.backend.admin.session.sso;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+
+/**
+ * 프로그램 role 등록(initUserRole.do) 응답.
+ * <p>
+ * 이 시스템은 실패해도 HTTP 200 과 HTML 을 돌려주고, 성공 응답의 본문에도 "실패", "error" 같은 문자열이 들어 있다(실계정 캡처로 확인). 따라서 상태 코드나 본문 문자열 포함
+ * 여부로는 성공을 판정할 수 없고, 응답이 요청한 프로그램 키를 그대로 돌려주는지로 판정한다.
+ */
+public record SjptUserRoleResponse(String programKey) {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public static SjptUserRoleResponse from(String responseBody) {
+        try {
+            JsonNode menuCode = OBJECT_MAPPER.readTree(responseBody).path("dm_UserRole").path("MENU_CD");
+            if (!menuCode.isTextual() || menuCode.asText().isBlank()) {
+                throw new AllcllException(AllcllErrorCode.SSO_PROGRAM_ROLE_REGISTER_FAIL);
+            }
+            return new SjptUserRoleResponse(menuCode.asText());
+        } catch (JsonProcessingException exception) {
+            throw new AllcllException(AllcllErrorCode.SSO_PROGRAM_ROLE_REGISTER_FAIL, exception);
+        }
+    }
+
+    /**
+     * 등록을 요청한 프로그램과 다른 프로그램이 돌아오면 권한이 붙지 않은 것으로 본다.
+     */
+    public void validateRegisteredFor(String requestedProgramKey) {
+        if (!programKey.equals(requestedProgramKey)) {
+            throw new AllcllException(AllcllErrorCode.SSO_PROGRAM_ROLE_REGISTER_FAIL);
+        }
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
@@ -70,6 +70,7 @@ public enum AllcllErrorCode {
     SEJONG_LOGIN_IO_ERROR(HttpStatus.BAD_GATEWAY, "세종포털 로그인 서버와 통신 중 오류가 발생했습니다."),
     TOSC_LOGIN_IO_ERROR(HttpStatus.BAD_GATEWAY, "TOSC 로그인 서버와 통신 중 오류가 발생했습니다."),
     USER_INFO_FETCH_IO_ERROR(HttpStatus.BAD_GATEWAY, "세종포털 사용자 정보 조회에 실패하였습니다."),
+    SSO_USER_INFO_PARSE_FAIL(HttpStatus.BAD_GATEWAY, "수강신청 시스템의 사용자 정보 응답을 해석하지 못했습니다."),
     ENGLISH_INFO_FETCH_FAIL(HttpStatus.BAD_GATEWAY, "영어 인증 정보를 불러오지 못했습니다."),
     CODING_INFO_FETCH_FAIL(HttpStatus.BAD_GATEWAY, "코딩 인증 정보를 불러오지 못했습니다."),
     CLASSIC_INFO_FETCH_FAIL(HttpStatus.BAD_GATEWAY, "고전독서 인증 정보를 불러오지 못했습니다."),

--- a/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
@@ -72,6 +72,7 @@ public enum AllcllErrorCode {
     USER_INFO_FETCH_IO_ERROR(HttpStatus.BAD_GATEWAY, "세종포털 사용자 정보 조회에 실패하였습니다."),
     SSO_USER_INFO_PARSE_FAIL(HttpStatus.BAD_GATEWAY, "수강신청 시스템의 사용자 정보 응답을 해석하지 못했습니다."),
     SSO_PROGRAM_ROLE_REGISTER_FAIL(HttpStatus.BAD_GATEWAY, "수강신청 시스템의 프로그램 권한 등록에 실패했습니다."),
+    SSO_SESSION_ESTABLISH_FAIL(HttpStatus.BAD_GATEWAY, "수강신청 시스템 세션 수립에 실패했습니다."),
     ENGLISH_INFO_FETCH_FAIL(HttpStatus.BAD_GATEWAY, "영어 인증 정보를 불러오지 못했습니다."),
     CODING_INFO_FETCH_FAIL(HttpStatus.BAD_GATEWAY, "코딩 인증 정보를 불러오지 못했습니다."),
     CLASSIC_INFO_FETCH_FAIL(HttpStatus.BAD_GATEWAY, "고전독서 인증 정보를 불러오지 못했습니다."),

--- a/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
@@ -57,6 +57,7 @@ public enum AllcllErrorCode {
     DUPLICATE_SCHEDULE(HttpStatus.CONFLICT, "이미 시간표에 등록된 일정입니다."),
     SEAT_CRAWLING_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "이미 다른 계정으로 여석 크롤링이 진행중입니다."),
     SEAT_CRAWLING_IN_MULTIPLE_ACCOUNTS(HttpStatus.CONFLICT, "두 개 이상의 계정으로 여석 크롤링이 진행중입니다."),
+    SSO_REGISTRATION_IN_PROGRESS(HttpStatus.CONFLICT, "이미 인증 정보 등록이 진행중입니다. 완료 후 다시 시도해주세요."),
 
     //500
     SEMESTER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "현재 학기 정보가 없습니다. 관리자에게 문의해주세요."),

--- a/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
@@ -71,6 +71,7 @@ public enum AllcllErrorCode {
     TOSC_LOGIN_IO_ERROR(HttpStatus.BAD_GATEWAY, "TOSC 로그인 서버와 통신 중 오류가 발생했습니다."),
     USER_INFO_FETCH_IO_ERROR(HttpStatus.BAD_GATEWAY, "세종포털 사용자 정보 조회에 실패하였습니다."),
     SSO_USER_INFO_PARSE_FAIL(HttpStatus.BAD_GATEWAY, "수강신청 시스템의 사용자 정보 응답을 해석하지 못했습니다."),
+    SSO_PROGRAM_ROLE_REGISTER_FAIL(HttpStatus.BAD_GATEWAY, "수강신청 시스템의 프로그램 권한 등록에 실패했습니다."),
     ENGLISH_INFO_FETCH_FAIL(HttpStatus.BAD_GATEWAY, "영어 인증 정보를 불러오지 못했습니다."),
     CODING_INFO_FETCH_FAIL(HttpStatus.BAD_GATEWAY, "코딩 인증 정보를 불러오지 못했습니다."),
     CLASSIC_INFO_FETCH_FAIL(HttpStatus.BAD_GATEWAY, "고전독서 인증 정보를 불러오지 못했습니다."),

--- a/src/main/java/kr/allcll/backend/support/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/allcll/backend/support/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,19 @@ import org.springframework.web.context.request.async.AsyncRequestTimeoutExceptio
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    /**
+     * 자격 증명을 본문으로 받는 경로. 예외 발생 시 본문을 그대로 로깅하면 비밀번호와 세션 토큰이 로그와 Sentry 에 남는다.
+     * <p>
+     * 주의: 크롤러 모듈의 {@code CrawlerGlobalExceptionHandler} 도 같은 컨텍스트에 스캔되어 본문을 로깅한다. 그쪽은 수정할 수 없으므로, 자격 증명을 다루는 코드는 크롤러 예외를 그대로
+     * 흘려보내지 말고 {@link AllcllException} 으로 변환해 이 핸들러가 처리하게 해야 한다.
+     */
+    private static final Set<String> CREDENTIAL_REQUEST_URIS = Set.of(
+        "/api/auth/login",
+        "/api/admin/session",
+        "/api/admin/session/sso"
+    );
+    private static final String MASKED_BODY = "[redacted]";
 
     private static final String LOG_FORMAT = """
         \n\t{
@@ -96,6 +110,9 @@ public class GlobalExceptionHandler {
     }
 
     private String getRequestBody(HttpServletRequest request) {
+        if (CREDENTIAL_REQUEST_URIS.contains(request.getRequestURI())) {
+            return MASKED_BODY;
+        }
         String contentType = request.getContentType();
         if (contentType != null && contentType.startsWith("multipart/")) {
             return "[multipart/form-data]";

--- a/src/test/java/kr/allcll/backend/admin/session/AdminSessionApiTest.java
+++ b/src/test/java/kr/allcll/backend/admin/session/AdminSessionApiTest.java
@@ -5,12 +5,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import kr.allcll.backend.admin.AdminRequestValidator;
 import kr.allcll.backend.admin.session.dto.SetCredentialRequest;
+import kr.allcll.backend.admin.session.dto.SsoLoginRequest;
 import kr.allcll.crawler.credential.Credentials;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -95,6 +97,49 @@ class AdminSessionApiTest {
             .andExpect(status().isBadRequest());
 
         verify(sessionService, never()).setCredential(any());
+    }
+
+    @Test
+    @DisplayName("SSO 로그인 요청은 세션을 수립하고 사용자 식별자를 반환한다.")
+    void registerBySso() throws Exception {
+        SsoLoginRequest request = new SsoLoginRequest("21011138", "pw");
+        when(validator.isRateLimited(any(HttpServletRequest.class))).thenReturn(false);
+        when(validator.isUnauthorized(any(HttpServletRequest.class))).thenReturn(false);
+        when(sessionService.registerBySso("21011138", "pw")).thenReturn("21011138");
+
+        mockMvc.perform(post("/api/admin/session/sso")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.userId").value("21011138"));
+    }
+
+    @Test
+    @DisplayName("학번이나 비밀번호가 없는 SSO 요청은 400을 반환하고 서비스가 호출되지 않는다.")
+    void registerBySso_missingCredential() throws Exception {
+        when(validator.isRateLimited(any(HttpServletRequest.class))).thenReturn(false);
+        when(validator.isUnauthorized(any(HttpServletRequest.class))).thenReturn(false);
+
+        mockMvc.perform(post("/api/admin/session/sso")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"studentId\":\"21011138\"}"))
+            .andExpect(status().isBadRequest());
+
+        verify(sessionService, never()).registerBySso(any(), any());
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 SSO 요청은 401을 반환하고 서비스가 호출되지 않는다.")
+    void registerBySso_unauthorized() throws Exception {
+        SsoLoginRequest request = new SsoLoginRequest("21011138", "pw");
+        when(validator.isUnauthorized(any(HttpServletRequest.class))).thenReturn(true);
+
+        mockMvc.perform(post("/api/admin/session/sso")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized());
+
+        verify(sessionService, never()).registerBySso(any(), any());
     }
 
     @Test

--- a/src/test/java/kr/allcll/backend/admin/session/SessionServiceSsoTest.java
+++ b/src/test/java/kr/allcll/backend/admin/session/SessionServiceSsoTest.java
@@ -1,0 +1,121 @@
+package kr.allcll.backend.admin.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import kr.allcll.backend.admin.session.sso.SjptSsoClient;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.crawler.client.SessionClient;
+import kr.allcll.crawler.common.schedule.CrawlerScheduledTaskHandler;
+import kr.allcll.crawler.credential.Credential;
+import kr.allcll.crawler.credential.Credentials;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SessionServiceSsoTest {
+
+    private static final String STUDENT_ID = "21011138";
+    private static final String PASSWORD = "pw";
+
+    private final Credentials credentials = mock(Credentials.class);
+    private final CrawlerScheduledTaskHandler threadPoolTaskScheduler = mock(CrawlerScheduledTaskHandler.class);
+    private final SessionClient sessionClient = mock(SessionClient.class);
+    private final SjptSsoClient sjptSsoClient = mock(SjptSsoClient.class);
+    private final SessionService sessionService = new SessionService(
+        credentials, threadPoolTaskScheduler, sessionClient, sjptSsoClient
+    );
+
+    @Test
+    @DisplayName("세션을 수립하면 인증 정보를 저장하고 사용자 식별자를 돌려준다.")
+    void registerCredentialFromEstablishedSession() {
+        // given
+        Credential credential = Credential.of("tokenJ", "21011138", "tokenR", "tokenL");
+        when(sjptSsoClient.establishSession(STUDENT_ID, PASSWORD)).thenReturn(credential);
+
+        // when
+        String userId = sessionService.registerBySso(STUDENT_ID, PASSWORD);
+
+        // then
+        assertThat(userId).isEqualTo("21011138");
+        verify(credentials).addCredential(credential);
+    }
+
+    @Test
+    @DisplayName("등록이 진행 중이면 겹치는 요청을 기다리지 않고 거절한다.")
+    void rejectOverlappingRegistration() throws Exception {
+        // given
+        // 여석 권한을 강제 로그인으로 등록하므로, 두 번째 등록은 방금 만든 세션을 밀어낸다.
+        // 대기시켜 순서대로 실행하면 그 등록이 실제로 일어나므로 즉시 거절해야 한다.
+        CountDownLatch established = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        when(sjptSsoClient.establishSession(anyString(), anyString())).thenAnswer(invocation -> {
+            established.countDown();
+            release.await(5, TimeUnit.SECONDS);
+            return Credential.of("tokenJ", "21011138", "tokenR", "tokenL");
+        });
+
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        Thread first = new Thread(() -> sessionService.registerBySso(STUDENT_ID, PASSWORD));
+        first.start();
+        assertThat(established.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // when
+        try {
+            sessionService.registerBySso(STUDENT_ID, PASSWORD);
+        } catch (Exception exception) {
+            failure.set(exception);
+        }
+        release.countDown();
+        first.join(5_000);
+
+        // then
+        assertThat(failure.get())
+            .isInstanceOf(AllcllException.class)
+            .hasMessage(AllcllErrorCode.SSO_REGISTRATION_IN_PROGRESS.getMessage());
+        verify(sjptSsoClient, times(1)).establishSession(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("세션 수립에 실패해도 다음 등록 시도를 막지 않는다.")
+    void releaseGuardOnFailure() {
+        // given
+        when(sjptSsoClient.establishSession(anyString(), anyString()))
+            .thenThrow(new AllcllException(AllcllErrorCode.SSO_SESSION_ESTABLISH_FAIL))
+            .thenReturn(Credential.of("tokenJ", "21011138", "tokenR", "tokenL"));
+
+        // when
+        assertThatThrownBy(() -> sessionService.registerBySso(STUDENT_ID, PASSWORD))
+            .isInstanceOf(AllcllException.class);
+        String userId = sessionService.registerBySso(STUDENT_ID, PASSWORD);
+
+        // then
+        assertThat(userId).isEqualTo("21011138");
+        verify(sjptSsoClient, times(2)).establishSession(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("세션 수립에 실패하면 인증 정보를 저장하지 않는다.")
+    void doNotStoreCredentialOnFailure() {
+        // given
+        when(sjptSsoClient.establishSession(anyString(), anyString()))
+            .thenThrow(new AllcllException(AllcllErrorCode.SSO_SESSION_ESTABLISH_FAIL));
+
+        // when
+        assertThatThrownBy(() -> sessionService.registerBySso(STUDENT_ID, PASSWORD))
+            .isInstanceOf(AllcllException.class);
+
+        // then
+        verify(credentials, never()).addCredential(any(Credential.class));
+    }
+}

--- a/src/test/java/kr/allcll/backend/admin/session/dto/SsoLoginRequestTest.java
+++ b/src/test/java/kr/allcll/backend/admin/session/dto/SsoLoginRequestTest.java
@@ -1,0 +1,36 @@
+package kr.allcll.backend.admin.session.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SsoLoginRequestTest {
+
+    private static final String PASSWORD = "sup3r-secret-pw";
+
+    @Test
+    @DisplayName("문자열로 변환해도 비밀번호가 드러나지 않는다.")
+    void hidePasswordOnToString() {
+        // given
+        SsoLoginRequest request = new SsoLoginRequest("21011138", PASSWORD);
+
+        // when
+        String printed = request.toString();
+
+        // then
+        assertThat(printed).doesNotContain(PASSWORD);
+        assertThat(printed).contains("21011138");
+    }
+
+    @Test
+    @DisplayName("학번과 비밀번호가 모두 있어야 유효한 요청이다.")
+    void requireBothStudentIdAndPassword() {
+        // when & then
+        assertThat(new SsoLoginRequest("21011138", PASSWORD).hasCredential()).isTrue();
+        assertThat(new SsoLoginRequest(null, PASSWORD).hasCredential()).isFalse();
+        assertThat(new SsoLoginRequest("21011138", null).hasCredential()).isFalse();
+        assertThat(new SsoLoginRequest("", PASSWORD).hasCredential()).isFalse();
+        assertThat(new SsoLoginRequest("21011138", " ").hasCredential()).isFalse();
+    }
+}

--- a/src/test/java/kr/allcll/backend/admin/session/sso/SjptCrawlerProgramTest.java
+++ b/src/test/java/kr/allcll/backend/admin/session/sso/SjptCrawlerProgramTest.java
@@ -1,0 +1,41 @@
+package kr.allcll.backend.admin.session.sso;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SjptCrawlerProgramTest {
+
+    @Test
+    @DisplayName("중복 사용 방지가 걸린 여석만 강제 로그인으로 권한을 등록한다.")
+    void forceLoginOnlyForSeat() {
+        // when & then
+        assertThat(SjptCrawlerProgram.SEAT.isForceLogin()).isTrue();
+        assertThat(SjptCrawlerProgram.BASKET.isForceLogin()).isFalse();
+        assertThat(SjptCrawlerProgram.SUBJECT.isForceLogin()).isFalse();
+    }
+
+    @Test
+    @DisplayName("프로그램 키는 서로 겹치지 않는다.")
+    void haveDistinctProgramKeys() {
+        // when
+        long distinct = Arrays.stream(SjptCrawlerProgram.values())
+            .map(SjptCrawlerProgram::getProgramKey)
+            .distinct()
+            .count();
+
+        // then
+        assertThat(distinct).isEqualTo(SjptCrawlerProgram.values().length);
+    }
+
+    @Test
+    @DisplayName("크롤러가 쓰는 프로그램은 모두 학사 시스템의 수강신청 메뉴에 속한다.")
+    void belongToCourseRegistrationMenu() {
+        // when & then
+        assertThat(SjptCrawlerProgram.values())
+            .allSatisfy(program -> assertThat(program.getProgramKey())
+                .startsWith("SELF_STUDSELF_SUB_30SELF_MENU_10"));
+    }
+}

--- a/src/test/java/kr/allcll/backend/admin/session/sso/SjptRunContextTest.java
+++ b/src/test/java/kr/allcll/backend/admin/session/sso/SjptRunContextTest.java
@@ -1,0 +1,124 @@
+package kr.allcll.backend.admin.session.sso;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * addParam 은 base64(urlEncode(json)) 이다. 인코딩기 자체를 인코딩기로 검증하면 순환이 되므로, 디코딩해 원래 JSON 이 나오는지와 크롤러의 인코딩 규약(콜론과 쉼표를 인코딩하지
+ * 않는다)이 지켜지는지를 각각 확인한다.
+ */
+class SjptRunContextTest {
+
+    private static final String USER_ID = "22011794";
+    private static final String LOGIN_DT = "20260722165501";
+    private static final String RUNNING_SEJONG = "6d760f74-d762-4f3d-b902-03dfe9e3ada2";
+    private static final String SEAT_PROGRAM_KEY = "SELF_STUDSELF_SUB_30SELF_MENU_10SueReqLesnEGuide";
+
+    @Test
+    @DisplayName("초기화 요청용 컨텍스트는 토큰 세 개를 빈 값으로만 담는다.")
+    void buildEmptyContext() {
+        // when
+        String json = SjptRunContext.empty().toJson();
+
+        // then
+        assertThat(json).isEqualTo("{\"_runIntgUsrNo\":\"\",\"_runPgLoginDt\":\"\",\"_runningSejong\":\"\"}");
+    }
+
+    @Test
+    @DisplayName("세션 수립 후 컨텍스트는 토큰 세 개만 담고 프로그램 정보는 넣지 않는다.")
+    void buildSessionContext() {
+        // given
+        SjptUserInfoResponse userInfo = new SjptUserInfoResponse(USER_ID, RUNNING_SEJONG, LOGIN_DT);
+
+        // when
+        String json = SjptRunContext.of(userInfo).toJson();
+
+        // then
+        assertThat(json).isEqualTo(
+            "{\"_runIntgUsrNo\":\"%s\",\"_runPgLoginDt\":\"%s\",\"_runningSejong\":\"%s\"}"
+                .formatted(USER_ID, LOGIN_DT, RUNNING_SEJONG)
+        );
+    }
+
+    @Test
+    @DisplayName("role 등록용 컨텍스트는 강제 로그인 여부와 프로그램 키를 앞쪽에 담는다.")
+    void buildProgramContext() {
+        // given
+        SjptRunContext session = SjptRunContext.of(new SjptUserInfoResponse(USER_ID, RUNNING_SEJONG, LOGIN_DT));
+
+        // when
+        String json = session.forProgram(SEAT_PROGRAM_KEY, true).toJson();
+
+        // then
+        assertThat(json).startsWith("{\"pbForceLog\":\"true\",\"_runPgmKey\":\"%s\",\"_runSysKey\":\"SCH\","
+            .formatted(SEAT_PROGRAM_KEY));
+        assertThat(json).endsWith("\"_runningSejong\":\"%s\"}".formatted(RUNNING_SEJONG));
+    }
+
+    @Test
+    @DisplayName("강제 로그인 여부는 JSON 불리언이 아니라 문자열로 보낸다.")
+    void sendForceLoginAsString() {
+        // given
+        SjptRunContext session = SjptRunContext.of(new SjptUserInfoResponse(USER_ID, RUNNING_SEJONG, LOGIN_DT));
+
+        // when
+        String json = session.forProgram(SEAT_PROGRAM_KEY, false).toJson();
+
+        // then
+        assertThat(json).contains("\"pbForceLog\":\"false\"");
+        assertThat(json).doesNotContain("\"pbForceLog\":false");
+    }
+
+    @Test
+    @DisplayName("role 등록 JSON 이 실서버에서 동작을 확인한 형태와 정확히 일치한다.")
+    void matchVerifiedProgramJson() {
+        // given
+        // 아래 문자열은 실계정으로 초기화-메뉴-role 등록 시퀀스를 실행해 200 응답과
+        // dm_UserRole.MENU_CD 일치를 확인한 PoC RunContext.toJson() 의 출력이다.
+        String verified = "{\"pbForceLog\":\"true\","
+            + "\"_runPgmKey\":\"SELF_STUDSELF_SUB_30SELF_MENU_10SueReqLesnEGuide\","
+            + "\"_runSysKey\":\"SCH\","
+            + "\"_runIntgUsrNo\":\"22011794\","
+            + "\"_runPgLoginDt\":\"20260722165501\","
+            + "\"_runningSejong\":\"6d760f74-d762-4f3d-b902-03dfe9e3ada2\"}";
+        SjptRunContext session = SjptRunContext.of(new SjptUserInfoResponse(USER_ID, RUNNING_SEJONG, LOGIN_DT));
+
+        // when
+        String json = session.forProgram(SEAT_PROGRAM_KEY, true).toJson();
+
+        // then
+        assertThat(json).isEqualTo(verified);
+    }
+
+    @Test
+    @DisplayName("addParam 을 되돌리면 원래 JSON 이 나온다.")
+    void addParamRoundTrip() {
+        // given
+        SjptRunContext context = SjptRunContext.of(new SjptUserInfoResponse(USER_ID, RUNNING_SEJONG, LOGIN_DT));
+
+        // when
+        String urlEncoded = new String(Base64.getDecoder().decode(context.toAddParam()), StandardCharsets.UTF_8);
+
+        // then
+        assertThat(URLDecoder.decode(urlEncoded, StandardCharsets.UTF_8)).isEqualTo(context.toJson());
+    }
+
+    @Test
+    @DisplayName("크롤러 규약대로 콜론과 쉼표는 인코딩하지 않는다.")
+    void keepColonAndCommaUnencoded() {
+        // given
+        SjptRunContext context = SjptRunContext.of(new SjptUserInfoResponse(USER_ID, RUNNING_SEJONG, LOGIN_DT));
+
+        // when
+        String urlEncoded = new String(Base64.getDecoder().decode(context.toAddParam()), StandardCharsets.UTF_8);
+
+        // then
+        assertThat(urlEncoded).contains(":").contains(",");
+        assertThat(urlEncoded).doesNotContain("%3A").doesNotContain("%2C");
+    }
+}

--- a/src/test/java/kr/allcll/backend/admin/session/sso/SjptSubmitErrorTest.java
+++ b/src/test/java/kr/allcll/backend/admin/session/sso/SjptSubmitErrorTest.java
@@ -1,0 +1,75 @@
+package kr.allcll.backend.admin.session.sso;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 오류 봉투의 형태와 ERRTYPE 값은 실계정에 잘못된 비밀번호를 넣어 확인했다.
+ */
+class SjptSubmitErrorTest {
+
+    private static final String NOT_AUTHENTICATED_RESPONSE = """
+        {
+          "_SUBMIT_ERROR_": {
+            "ERRMSG": "로그인후 지정된 시간동안 사용하지 않아 자동로그아웃 처리 되었습니다.",
+            "ERRTYPE": "LOGOUT",
+            "ERRCODE": "로그인후 지정된 시간동안 사용하지 않아 자동로그아웃 처리 되었습니다."
+          }
+        }
+        """;
+
+    @Test
+    @DisplayName("인증되지 않은 요청은 로그아웃 유형의 오류로 돌아온다.")
+    void detectNotAuthenticated() {
+        // when
+        SjptSubmitError error = SjptSubmitError.find(NOT_AUTHENTICATED_RESPONSE).orElseThrow();
+
+        // then
+        assertThat(error.errorType()).isEqualTo("LOGOUT");
+        assertThat(error.isNotAuthenticated()).isTrue();
+    }
+
+    @Test
+    @DisplayName("다른 유형의 오류는 인증 실패로 보지 않는다.")
+    void distinguishOtherErrorType() {
+        // given
+        String response = "{\"_SUBMIT_ERROR_\":{\"ERRMSG\":\"처리 중 오류\",\"ERRTYPE\":\"SYSTEM\"}}";
+
+        // when
+        SjptSubmitError error = SjptSubmitError.find(response).orElseThrow();
+
+        // then
+        assertThat(error.isNotAuthenticated()).isFalse();
+        assertThat(error.message()).isEqualTo("처리 중 오류");
+    }
+
+    @Test
+    @DisplayName("정상 응답에는 오류 봉투가 없다.")
+    void findNothingInSuccessResponse() {
+        // given
+        String response = "{\"dm_UserInfo\":{\"INTG_USR_NO\":\"22011794\"}}";
+
+        // when & then
+        assertThat(SjptSubmitError.find(response)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("성공 응답 본문에 실패 관련 문자열이 섞여 있어도 오류로 보지 않는다.")
+    void ignoreFailureWordsInSuccessResponse() {
+        // given
+        // 포털 로그인 성공 응답에도 '실패', 'Error' 문자열이 들어 있다(실계정 캡처로 확인).
+        String response = "{\"dm_UserInfo\":{\"MESSAGE\":\"로그인 실패 시 Error 페이지로 이동\"}}";
+
+        // when & then
+        assertThat(SjptSubmitError.find(response)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("JSON 이 아닌 응답에서는 오류 봉투를 찾지 않는다.")
+    void findNothingInHtmlResponse() {
+        // when & then
+        assertThat(SjptSubmitError.find("<html><body>로그인 처리</body></html>")).isEmpty();
+    }
+}

--- a/src/test/java/kr/allcll/backend/admin/session/sso/SjptUserInfoResponseTest.java
+++ b/src/test/java/kr/allcll/backend/admin/session/sso/SjptUserInfoResponseTest.java
@@ -1,0 +1,114 @@
+package kr.allcll.backend.admin.session.sso;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.crawler.credential.Credential;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 픽스처의 데이터셋·필드 이름은 실서버에 대해 동작이 확인된 PoC(chemistryx/sjpt-rest-client-poc) 의 RunContext.from() 에서 그대로 가져왔다. 이 테스트는 어느 필드가 어느 토큰이
+ * 되는지의 매핑만 검증하며, 필드 이름 자체가 실제 응답과 다를 가능성은 실계정 응답 캡처로만 확인할 수 있다.
+ */
+class SjptUserInfoResponseTest {
+
+    private static final String USER_ID = "22011794";
+    private static final String RUNNING_SEJONG = "6d760f74-d762-4f3d-b902-03dfe9e3ada2";
+    private static final String LOGIN_DT = "20260722165501";
+
+    private static final String RESPONSE = """
+        {
+          "dm_UserInfo": {
+            "INTG_USR_NO": "%s",
+            "RUNNING_SEJONG": "%s"
+          },
+          "dm_UserInfoGam": {
+            "LOGIN_DT": "%s"
+          },
+          "dm_UserInfoSch": {
+            "ORGN_CLSF_CD": "SCH"
+          }
+        }
+        """.formatted(USER_ID, RUNNING_SEJONG, LOGIN_DT);
+
+    @Test
+    @DisplayName("사용자 정보 응답에서 토큰 세 개를 각각의 데이터셋에서 추출한다.")
+    void parseTokensFromResponse() {
+        // when
+        SjptUserInfoResponse response = SjptUserInfoResponse.from(RESPONSE);
+
+        // then
+        assertThat(response.userId()).isEqualTo(USER_ID);
+        assertThat(response.runningSejong()).isEqualTo(RUNNING_SEJONG);
+        assertThat(response.loginDt()).isEqualTo(LOGIN_DT);
+    }
+
+    @Test
+    @DisplayName("인증 정보로 변환할 때 runningSejong 과 loginDt 가 자리를 바꾸지 않는다.")
+    void convertToCredentialWithoutTransposingTokens() {
+        // given
+        SjptUserInfoResponse response = SjptUserInfoResponse.from(RESPONSE);
+
+        // when
+        Credential credential = response.toCredential("JSESSIONID-VALUE");
+
+        // then
+        assertThat(credential.getTokenJ()).isEqualTo("JSESSIONID-VALUE");
+        assertThat(credential.getTokenU()).isEqualTo(USER_ID);
+        assertThat(credential.getTokenR()).isEqualTo(RUNNING_SEJONG);
+        assertThat(credential.getTokenL()).isEqualTo(LOGIN_DT);
+    }
+
+    @Test
+    @DisplayName("필요한 데이터셋이 없으면 파싱 실패로 처리한다.")
+    void rejectResponseWithoutRequiredDataSet() {
+        // given
+        String withoutGam = """
+            {
+              "dm_UserInfo": {
+                "INTG_USR_NO": "22011794",
+                "RUNNING_SEJONG": "running-sejong"
+              }
+            }
+            """;
+
+        // when & then
+        assertThatThrownBy(() -> SjptUserInfoResponse.from(withoutGam))
+            .isInstanceOf(AllcllException.class)
+            .hasMessage(AllcllErrorCode.SSO_USER_INFO_PARSE_FAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("필드가 빈 문자열이면 파싱 실패로 처리한다.")
+    void rejectResponseWithBlankField() {
+        // given
+        String blankUserId = """
+            {
+              "dm_UserInfo": {
+                "INTG_USR_NO": "",
+                "RUNNING_SEJONG": "running-sejong"
+              },
+              "dm_UserInfoGam": {
+                "LOGIN_DT": "20260722165501"
+              }
+            }
+            """;
+
+        // when & then
+        assertThatThrownBy(() -> SjptUserInfoResponse.from(blankUserId))
+            .isInstanceOf(AllcllException.class)
+            .hasMessage(AllcllErrorCode.SSO_USER_INFO_PARSE_FAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("JSON 이 아닌 응답이면 파싱 실패로 처리한다.")
+    void rejectNonJsonResponse() {
+        // when & then
+        assertThatThrownBy(() -> SjptUserInfoResponse.from("<html>login page</html>"))
+            .isInstanceOf(AllcllException.class)
+            .hasMessage(AllcllErrorCode.SSO_USER_INFO_PARSE_FAIL.getMessage());
+    }
+}

--- a/src/test/java/kr/allcll/backend/admin/session/sso/SjptUserRoleResponseTest.java
+++ b/src/test/java/kr/allcll/backend/admin/session/sso/SjptUserRoleResponseTest.java
@@ -1,0 +1,95 @@
+package kr.allcll.backend.admin.session.sso;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 응답의 데이터셋·필드 이름은 실계정으로 initUserRole.do 를 호출해 확인한 구조를 따른다. 세 프로그램(여석/관심과목/과목조회) 모두 dm_UserRole.MENU_CD 로 요청한 키를 그대로
+ * 돌려주는 것을 확인했다.
+ */
+class SjptUserRoleResponseTest {
+
+    private static final String SEAT_PROGRAM_KEY = "SELF_STUDSELF_SUB_30SELF_MENU_10SueReqLesnEGuide";
+    private static final String BASKET_PROGRAM_KEY = "SELF_STUDSELF_SUB_30SELF_MENU_10SueReqLesnBasketGuide";
+
+    @Test
+    @DisplayName("등록한 프로그램 키를 응답에서 읽는다.")
+    void readRegisteredProgramKey() {
+        // given
+        String response = roleResponse(SEAT_PROGRAM_KEY);
+
+        // when
+        SjptUserRoleResponse parsed = SjptUserRoleResponse.from(response);
+
+        // then
+        assertThat(parsed.programKey()).isEqualTo(SEAT_PROGRAM_KEY);
+    }
+
+    @Test
+    @DisplayName("요청한 프로그램이 그대로 돌아오면 등록에 성공한 것으로 본다.")
+    void acceptResponseForRequestedProgram() {
+        // given
+        SjptUserRoleResponse parsed = SjptUserRoleResponse.from(roleResponse(SEAT_PROGRAM_KEY));
+
+        // when & then
+        assertThatCode(() -> parsed.validateRegisteredFor(SEAT_PROGRAM_KEY)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("다른 프로그램이 돌아오면 등록 실패로 처리한다.")
+    void rejectResponseForDifferentProgram() {
+        // given
+        SjptUserRoleResponse parsed = SjptUserRoleResponse.from(roleResponse(BASKET_PROGRAM_KEY));
+
+        // when & then
+        assertThatThrownBy(() -> parsed.validateRegisteredFor(SEAT_PROGRAM_KEY))
+            .isInstanceOf(AllcllException.class)
+            .hasMessage(AllcllErrorCode.SSO_PROGRAM_ROLE_REGISTER_FAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("권한 정보가 없는 응답은 등록 실패로 처리한다.")
+    void rejectResponseWithoutUserRole() {
+        // given
+        String withoutRole = "{\"dm_UserInfo\":{\"INTG_USR_NO\":\"22011794\"}}";
+
+        // when & then
+        assertThatThrownBy(() -> SjptUserRoleResponse.from(withoutRole))
+            .isInstanceOf(AllcllException.class)
+            .hasMessage(AllcllErrorCode.SSO_PROGRAM_ROLE_REGISTER_FAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("성공을 가장한 HTML 응답은 등록 실패로 처리한다.")
+    void rejectHtmlResponse() {
+        // given
+        // 이 시스템은 실패해도 200 과 HTML 을 돌려주고 본문에 '실패' 같은 문자열이 섞여 있다.
+        String html = "<html><body>오류가 발생했습니다</body></html>";
+
+        // when & then
+        assertThatThrownBy(() -> SjptUserRoleResponse.from(html))
+            .isInstanceOf(AllcllException.class)
+            .hasMessage(AllcllErrorCode.SSO_PROGRAM_ROLE_REGISTER_FAIL.getMessage());
+    }
+
+    private String roleResponse(String programKey) {
+        return """
+            {
+              "dm_UserRole": {
+                "MENU_CD": "%s",
+                "MENU_LEVEL": 4,
+                "PG_LOGIN_DT": "20260722165501"
+              },
+              "dm_UserInfo": {
+                "INTG_USR_NO": "22011794"
+              }
+            }
+            """.formatted(programKey);
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/kr/allcll/backend/support/exception/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package kr.allcll.backend.support.exception;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -7,17 +8,113 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.sentry.IScope;
 import io.sentry.ScopeCallback;
 import io.sentry.Sentry;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 class GlobalExceptionHandlerTest {
 
+    private static final String PASSWORD = "sup3r-secret-pw";
+
     private final GlobalExceptionHandler exceptionHandler = new GlobalExceptionHandler();
+    private final ListAppender<ILoggingEvent> logs = new ListAppender<>();
+    private Logger handlerLogger;
+
+    @BeforeEach
+    void attachLogAppender() {
+        handlerLogger = (Logger) LoggerFactory.getLogger(GlobalExceptionHandler.class);
+        logs.start();
+        handlerLogger.addAppender(logs);
+    }
+
+    @AfterEach
+    void detachLogAppender() {
+        handlerLogger.detachAppender(logs);
+        logs.stop();
+    }
+
+    @Test
+    @DisplayName("포털 로그인이 실패해도 비밀번호가 로그에 남지 않는다")
+    void doesNotLogPasswordOnPortalLoginFailure() {
+        // Given
+        MockHttpServletRequest request = credentialRequest(
+            "/api/auth/login",
+            "{\"studentId\":\"21011138\",\"password\":\"" + PASSWORD + "\"}"
+        );
+
+        // When
+        exceptionHandler.handleException(request, new IllegalStateException("boom"));
+
+        // Then
+        assertThat(capturedLogs()).doesNotContain(PASSWORD);
+    }
+
+    @Test
+    @DisplayName("SSO 로그인이 실패해도 비밀번호가 로그에 남지 않는다")
+    void doesNotLogPasswordOnSsoLoginFailure() {
+        // Given
+        MockHttpServletRequest request = credentialRequest(
+            "/api/admin/session/sso",
+            "{\"id\":\"21011138\",\"password\":\"" + PASSWORD + "\"}"
+        );
+
+        // When
+        exceptionHandler.handleException(request, new IllegalStateException("boom"));
+
+        // Then
+        assertThat(capturedLogs()).doesNotContain(PASSWORD);
+    }
+
+    @Test
+    @DisplayName("자격 증명 요청도 어떤 경로에서 실패했는지는 로그에 남는다")
+    void stillLogsRequestUriForCredentialRequest() {
+        // Given
+        MockHttpServletRequest request = credentialRequest("/api/auth/login", "{\"password\":\"" + PASSWORD + "\"}");
+
+        // When
+        exceptionHandler.handleException(request, new IllegalStateException("boom"));
+
+        // Then
+        assertThat(capturedLogs()).contains("/api/auth/login");
+    }
+
+    @Test
+    @DisplayName("자격 증명과 무관한 요청은 기존대로 본문을 로그에 남긴다")
+    void keepsLoggingBodyForOrdinaryRequest() {
+        // Given
+        MockHttpServletRequest request = credentialRequest("/api/admin/subjects", "{\"year\":\"2026\"}");
+
+        // When
+        exceptionHandler.handleException(request, new IllegalStateException("boom"));
+
+        // Then
+        assertThat(capturedLogs()).contains("2026");
+    }
+
+    private MockHttpServletRequest credentialRequest(String uri, String body) {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", uri);
+        request.setContentType("application/json");
+        request.setContent(body.getBytes(StandardCharsets.UTF_8));
+        return request;
+    }
+
+    private String capturedLogs() {
+        return logs.list.stream()
+            .map(ILoggingEvent::getFormattedMessage)
+            .collect(Collectors.joining(System.lineSeparator()));
+    }
 
     @Test
     @DisplayName("4xx AllcllException은 Sentry로 전송하지 않는다")


### PR DESCRIPTION
## 작업 내용
기존 크롤러 인증 정보 주입 방식(토큰 4종 수동 입력)을 개선하여 학번, 비밀번호 입력만으로 계정 정보를 설정할 수 있도록 기능을 추가했습니다.

- `POST /api/admin/session/sso {studentId, password}` 추가
-  포털 로그인 → doSsoLogin → initUserInfo → 메뉴 로드 → 프로그램 권한 등록 순으로 브라우저가 만드는 세션 상태를 재현하고, Credential 정보를 저장합니다.
- 기존 방식(토큰 4종) `POST /api/admin/session` 은 fallback으로 유지했습니다.
- 잘못된 비밀번호는 SEJONG_LOGIN_FAIL(401)로 구분해 반환합니다.
- 추가로 자격 증명을 본문으로 받는 경로(`/api/auth/login`, `/api/admin/session`, `/api/admin/session/sso`)의 경우 예외 로깅 시 본문을 마스킹하도록 수정했습니다.

학생 로그인(`/api/auth/login`)과 크롤러 서브모듈은 건드리지 않았습니다.



## 고민 지점과 리뷰 포인트
- 기존 서비스 영향성 고려해서 기존 로그인 로직과 통합은 진행하지 않았는데, 지켜본 후 통합하는 것도 고려해봐도 좋을 것 같습니다.
- 프로그램 Role이나 URL 상수 같은 것들이 기존 코드와 중복되는 부분이 존재하는데, 형태가 좀 달라서 일단 따로 빼두었습니다. (e.g., `rtUrl` 존재 유무)
- SSO 로그인 실패의 경우 HTTP 상태 코드로 넘어오는게 아니라서 부득이하게 별도 로직으로 구분하였는데, 더 좋은 방법이 있다면 알려주시면 감사하겠습니다.

Generated w/ Claude Code