### PR TITLE
[TSK-90] 운영 서버 모니터링 배포 설정 추가

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -87,6 +87,13 @@ jobs:
       - name: Test with Gradle Wrapper
         run: ./gradlew build
 
+      - name: Validate Observability Secrets
+        run: |
+          if [ -z "${GRAFANA_ADMIN_PASSWORD}" ]; then
+            echo "GRAFANA_ADMIN_PASSWORD secret is required."
+            exit 1
+          fi
+
       - name: Copy JAR to Local
         run: |
           mkdir -p ${{ secrets.APP_DIR }}
@@ -119,11 +126,6 @@ jobs:
 
       - name: Deploy Observability
         run: |
-          if [ -z "${GRAFANA_ADMIN_PASSWORD}" ]; then
-            echo "GRAFANA_ADMIN_PASSWORD secret is required."
-            exit 1
-          fi
-
           mkdir -p ${{ secrets.APP_DIR }}/observability
           cp -R observability/. ${{ secrets.APP_DIR }}/observability/
           printf 'GRAFANA_ADMIN_PASSWORD=%s\n' "${GRAFANA_ADMIN_PASSWORD}" > ${{ secrets.APP_DIR }}/observability/.env

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -17,6 +17,7 @@ jobs:
       GOOGLE_ACCOUNT_JSON: ${{ secrets.GOOGLE_ACCOUNT_JSON }}
       GOOGLE_SHEETS_CREDENTIALS_LOCATION: file:/opt/secrets/google-service-account.json
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
 
     defaults:
       run:
@@ -115,3 +116,18 @@ jobs:
           -Dlogging.file.path=${{ secrets.APP_DIR }}/logs \
           -DEMAIL_PASSWORD="${EMAIL_PASSWORD}" \
           -jar ${{ secrets.APP_DIR }}/server.jar & 
+
+      - name: Deploy Observability
+        run: |
+          if [ -z "${GRAFANA_ADMIN_PASSWORD}" ]; then
+            echo "GRAFANA_ADMIN_PASSWORD secret is required."
+            exit 1
+          fi
+
+          mkdir -p ${{ secrets.APP_DIR }}/observability
+          cp -R observability/. ${{ secrets.APP_DIR }}/observability/
+          printf 'GRAFANA_ADMIN_PASSWORD=%s\n' "${GRAFANA_ADMIN_PASSWORD}" > ${{ secrets.APP_DIR }}/observability/.env
+          chmod 600 ${{ secrets.APP_DIR }}/observability/.env
+
+          cd ${{ secrets.APP_DIR }}/observability
+          docker compose -f compose.prod.yml up -d

--- a/observability/compose.prod.yml
+++ b/observability/compose.prod.yml
@@ -1,0 +1,38 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: allcll-prometheus
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:9090:9090"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=90d"
+      - "--storage.tsdb.retention.size=6GB"
+    volumes:
+      - ./prometheus/prometheus.prod.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:11.2.2
+    container_name: allcll-grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/observability/grafana/provisioning/datasources/prometheus.yml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true

--- a/observability/prometheus/prometheus.prod.yml
+++ b/observability/prometheus/prometheus.prod.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: allcll-backend-prod
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - host.docker.internal:8081
+        labels:
+          env: prod


### PR DESCRIPTION
## 작업 내용

- 운영 서버에서 Prometheus/Grafana를 Docker Compose로 실행할 수 있도록 `compose.prod.yml`을 추가했습니다.
- Prometheus 운영 scrape 설정을 `prometheus.prod.yml`로 분리했습니다.
  - `job_name: allcll-backend-prod`
  - `env: prod`
- Prometheus/Grafana 데이터를 Docker volume에 저장해 컨테이너 재시작 후에도 유지되도록 했습니다.
- Grafana 관리자 비밀번호를 `GRAFANA_ADMIN_PASSWORD` secret으로 주입하도록 설정했습니다.
- prod 배포 workflow에 observability 배포 단계를 추가했습니다.
- Grafana datasource에 고정 `uid`를 추가했습니다.

## 참고

- Prometheus는 `127.0.0.1:9090`으로 바인딩해 서버 내부에서만 접근하도록 했습니다.
- Grafana는 외부 접속을 위해 `3000:3000`으로 열어두었습니다.
- Prometheus retention은 `90d`, size limit은 `6GB`로 설정했습니다.

---

## Codex Review
- `observability/compose.prod.yml:24` -- "[Security] 이 매핑은 Grafana를 모든 호스트 인터페이스의 3000 포트에 직접 공개하지만, 이 구성에는 HTTPS나 신뢰할 수 있는 reverse proxy가 없습니다. PR 설명대로 외부에서 이 포트에 접속하면 관리자 로그인 정보, 세션, 조회한 메트릭이 평문 HTTP 구간을 지나게 됩니다. `127.0.0.1:3000:3000`으로 제한하고 TLS를 종료하는 reverse proxy/VPN을 통해 노출하거나, 외부 TLS 종단과 보안그룹의 허용 대상이 제한되어 있음을 배포 구성으로 함께 보장해 주세요. Grafana 공식 문서도 웹 UI의 로그인 정보와 메트릭을 암호화하려면 HTTPS 설정이 중요하다고 명시합니다: https://grafana.com/docs/grafana/latest/setup-grafana/set-up-https/"
- `.github/workflows/deploy-to-prod.yml:122` -- "[Error Handling] 필수 secret 검증이 `Stop Existing Application`과 `Run Application` 뒤에 있어서, secret이 누락된 배포는 GitHub Actions상 실패하지만 새 `server.jar`는 이미 운영에서 실행됩니다. 즉 실패 상태와 실제 배포 버전이 어긋나고, secret을 보완해 재시도하면 애플리케이션을 한 번 더 중단하게 됩니다. 이 검증은 운영 프로세스를 변경하기 전(최소한 기존 앱 종료 전)으로 옮겨 부분 배포를 막아 주세요."

---
- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기