### PR TITLE
[TSK-127] SeatUtils 분기 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/seat/AdminSeatApi.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/AdminSeatApi.java
@@ -22,26 +22,29 @@ public class AdminSeatApi {
 
     @PostMapping("/api/admin/seat/start")
     public ResponseEntity<Void> getSeatPeriodically(HttpServletRequest request,
-        @RequestParam(required = false) String userId) {
+        @RequestParam(required = false) String userId,
+        @RequestParam SeatUtilsType seatUtilsType) {
         if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
             return ResponseEntity.status(401).build();
         }
 
         targetSubjectService.loadGeneralSubjects();
-        adminSeatService.getAllSeatPeriodically(userId);
+        adminSeatService.getAllSeatPeriodically(userId, seatUtilsType);
 
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/api/admin/season-seat/start")
     public ResponseEntity<Void> seasonSeatStart(HttpServletRequest request,
-        @RequestParam(required = false) String userId) {
+        @RequestParam(required = false) String userId,
+        @RequestParam SeatUtilsType seatUtilsType
+    ) {
         if (validator.isRateLimited(request) || validator.isUnauthorized(request)) {
             return ResponseEntity.status(401).build();
         }
 
         targetSubjectService.loadAllSubjects();
-        adminSeatService.getSeasonSeatPeriodically(userId);
+        adminSeatService.getSeasonSeatPeriodically(userId, seatUtilsType);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kr/allcll/backend/admin/seat/AdminSeatService.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/AdminSeatService.java
@@ -48,16 +48,16 @@ public class AdminSeatService {
     private final SubjectRepository subjectRepository;
     private final SeatPipelineMetrics seatPipelineMetrics;
 
-    public void getAllSeatPeriodically(String userId) {
+    public void getAllSeatPeriodically(String userId, SeatUtilsType seatUtilsType) {
         Credential credential = credentials.findByUserId(userId);
-        fetchPinSeat(credential);
-        fetchGeneralSeat(credential);
+        fetchPinSeat(credential, seatUtilsType);
+        fetchGeneralSeat(credential, seatUtilsType);
     }
 
-    public void getSeasonSeatPeriodically(String userId) {
+    public void getSeasonSeatPeriodically(String userId, SeatUtilsType seatUtilsType) {
         Credential credential = credentials.findByUserId(userId);
-        fetchPinSeat(credential);
-        fetchGeneralSeat(credential);
+        fetchPinSeat(credential, seatUtilsType);
+        fetchGeneralSeat(credential, seatUtilsType);
     }
 
     public void cancelSeatScheduling() {
@@ -77,73 +77,78 @@ public class AdminSeatService {
         return SeatStatusResponse.of(userIds.getFirst(), isActive);
     }
 
-    private void fetchPinSeat(Credential credential) {
+    private void fetchPinSeat(Credential credential, SeatUtilsType seatUtilsType) {
         int pinSubjectRequestPerSecondCount = sjptProperties.getPinSubjectRequestPerSecondCount();
         String prefixId = credential.makeUserIdPrefix();
         for (int i = 0; i < pinSubjectRequestPerSecondCount; i++) {
             seatScheduler.scheduleAtFixedRate(
                 prefixId + TokenProvider.create(),
-                () -> sendPinSubjectRequest(credential),
+                () -> sendPinSubjectRequest(credential, seatUtilsType),
                 Duration.ofSeconds(1)
             );
         }
     }
 
-    private void fetchGeneralSeat(Credential credential) {
+    private void fetchGeneralSeat(Credential credential, SeatUtilsType seatUtilsType) {
         int requestPerSecondCount = sjptProperties.getRequestPerSecondCount();
         int pinSubjectRequestPerSecondCount = sjptProperties.getPinSubjectRequestPerSecondCount();
         String prefixId = credential.makeUserIdPrefix();
         for (int i = 0; i < requestPerSecondCount - pinSubjectRequestPerSecondCount; i++) {
             seatScheduler.scheduleAtFixedRate(
                 prefixId + TokenProvider.create(),
-                () -> sendGeneralSubjectRequest(credential),
+                () -> sendGeneralSubjectRequest(credential, seatUtilsType),
                 Duration.ofSeconds(1)
             );
         }
     }
 
-    private void sendPinSubjectRequest(Credential credential) {
+    private void sendPinSubjectRequest(Credential credential, SeatUtilsType seatUtilsType) {
         CrawlerSubject crawlerSubject = targetSubjectStorage.getNextPinTarget();
         if (crawlerSubject == null) {
             return;
         }
-        crawlPinSeatAndBuffer(crawlerSubject, credential);
+        crawlPinSeatAndBuffer(crawlerSubject, credential, seatUtilsType);
     }
 
-    private void sendGeneralSubjectRequest(Credential credential) {
+    private void sendGeneralSubjectRequest(Credential credential, SeatUtilsType seatUtilsType) {
         CrawlerSubject crawlerSubject = targetSubjectStorage.getNextGeneralTarget();
-        crawlGeneralSeatAndBuffer(crawlerSubject, credential);
+        crawlGeneralSeatAndBuffer(crawlerSubject, credential, seatUtilsType);
     }
 
-    private void crawlPinSeatAndBuffer(CrawlerSubject pinSubject, Credential credential) {
+    private void crawlPinSeatAndBuffer(CrawlerSubject pinSubject, Credential credential, SeatUtilsType seatUtilsType) {
         try {
-            CrawlerSeat crawlerSeat = sendExternalSeatRequest(pinSubject, credential);
+            CrawlerSeat crawlerSeat = sendExternalSeatRequest(pinSubject, credential, seatUtilsType);
             recordCrawlingSuccess();
 
             batchService.savePinSeatBatch(crawlerSeat);
         } catch (CrawlerAllcllException e) {
             log.error(
                 "[핀 과목 여석] 외부 API 호출에 실패했습니다. 과목: "
-                    + pinSubject.getCuriNo() + "-"
-                    + pinSubject.getClassName());
+                + pinSubject.getCuriNo() + "-"
+                + pinSubject.getClassName());
         }
     }
 
-    private void crawlGeneralSeatAndBuffer(CrawlerSubject generalSubject, Credential credential) {
+    private void crawlGeneralSeatAndBuffer(CrawlerSubject generalSubject, Credential credential,
+        SeatUtilsType seatUtilsType) {
         try {
-            CrawlerSeat crawlerSeat = sendExternalSeatRequest(generalSubject, credential);
+            CrawlerSeat crawlerSeat = sendExternalSeatRequest(generalSubject, credential, seatUtilsType);
             recordCrawlingSuccess();
 
             batchService.saveGeneralSeatBatch(crawlerSeat);
         } catch (CrawlerAllcllException e) {
             log.error(
                 "[교양 과목 여석] 외부 API 호출에 실패했습니다. 과목: "
-                    + generalSubject.getCuriNo() + "-"
-                    + generalSubject.getClassName());
+                + generalSubject.getCuriNo() + "-"
+                + generalSubject.getClassName());
         }
     }
 
-    private CrawlerSeat sendExternalSeatRequest(CrawlerSubject crawlerSubject, Credential credential) {
+    private CrawlerSeat sendExternalSeatRequest(
+        CrawlerSubject crawlerSubject,
+        Credential credential,
+        SeatUtilsType seatUtilsType
+    ) {
         log.info("[AdminSeatService] [학교 서버] 요청 시도 과목: {}", crawlerSubject);
         SeatPayload requestPayload = SeatPayload.from(crawlerSubject);
         SeatResponse response = seatClient.execute(credential, requestPayload);
@@ -155,7 +160,7 @@ public class AdminSeatService {
         seatStorage.add(
             new SeatDto(
                 subject,
-                SeatUtils.getRemainSeat(renewedCrawlerSeat),
+                SeatUtils.getRemainSeat(renewedCrawlerSeat, seatUtilsType),
                 LocalDateTime.now()
             )
         );

--- a/src/main/java/kr/allcll/backend/admin/seat/SeatUtils.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/SeatUtils.java
@@ -1,10 +1,32 @@
 package kr.allcll.backend.admin.seat;
 
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
 import kr.allcll.crawler.seat.CrawlerSeat;
 
 public class SeatUtils {
 
-    public static Integer getRemainSeat(CrawlerSeat crawlerSeat) {
-        return Math.max(0, crawlerSeat.getTotLimitRcnt() - crawlerSeat.getTotRcnt());
+    public static Integer getRemainSeat(CrawlerSeat crawlerSeat, SeatUtilsType seatUtilsType) {
+        Integer remainSeat = getRawRemainSeat(crawlerSeat, seatUtilsType);
+        return Math.max(0, remainSeat);
+    }
+
+    private static Integer getRawRemainSeat(CrawlerSeat crawlerSeat, SeatUtilsType seatUtilsType) {
+        if (seatUtilsType == SeatUtilsType.TOTAL) {
+            return crawlerSeat.getTotLimitRcnt() - crawlerSeat.getTotRcnt();
+        }
+        if (seatUtilsType == SeatUtilsType.GRADE_4) {
+            return crawlerSeat.getTotLimitRcnt4() - crawlerSeat.getTotRcnt();
+        }
+        if (seatUtilsType == SeatUtilsType.GRADE_3) {
+            return crawlerSeat.getTotLimitRcnt3() - crawlerSeat.getTotRcnt();
+        }
+        if (seatUtilsType == SeatUtilsType.GRADE_2) {
+            return crawlerSeat.getTotLimitRcnt2() - crawlerSeat.getTotRcnt();
+        }
+        if (seatUtilsType == SeatUtilsType.GRADE_1) {
+            return crawlerSeat.getTotLimitRcnt1() - crawlerSeat.getTotRcnt();
+        }
+        throw new AllcllException(AllcllErrorCode.UNSUPPORTED_SEAT_LIMIT_TYPE);
     }
 }

--- a/src/main/java/kr/allcll/backend/admin/seat/SeatUtilsType.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/SeatUtilsType.java
@@ -1,0 +1,9 @@
+package kr.allcll.backend.admin.seat;
+
+public enum SeatUtilsType {
+    GRADE_4,
+    GRADE_3,
+    GRADE_2,
+    GRADE_1,
+    TOTAL,
+}

--- a/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/backend/support/exception/AllcllErrorCode.java
@@ -82,6 +82,7 @@ public enum AllcllErrorCode {
     /* ================= 시스템 / 인프라 에러 ================= */
     ASYNC_REQUEST_TIMEOUT(HttpStatus.INTERNAL_SERVER_ERROR, "요청 처리 중 시간이 초과되었습니다."),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생하였습니다."),
+    UNSUPPORTED_SEAT_LIMIT_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "지원하지 않는 여석 계산 기준입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/kr/allcll/backend/admin/seat/SeatUtilsTest.java
+++ b/src/test/java/kr/allcll/backend/admin/seat/SeatUtilsTest.java
@@ -1,0 +1,52 @@
+package kr.allcll.backend.admin.seat;
+
+import static kr.allcll.backend.fixture.CrawlerSeatFixture.createCrawlerSeatWithLimits;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import kr.allcll.crawler.seat.CrawlerSeat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SeatUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("seatLimitTypes")
+    @DisplayName("여석 계산 기준별 남은 여석을 반환한다.")
+    void getRemainSeat(SeatUtilsType seatUtilsType, int expectedRemainSeat) {
+        // given
+        CrawlerSeat crawlerSeat = createCrawlerSeatWithLimits(50, 40, 30, 20, 60, 10);
+
+        // when
+        Integer remainSeat = SeatUtils.getRemainSeat(crawlerSeat, seatUtilsType);
+
+        // then
+        assertThat(remainSeat).isEqualTo(expectedRemainSeat);
+    }
+
+    @Test
+    @DisplayName("수강 인원이 정원보다 많으면 남은 여석은 0이다.")
+    void getRemainSeatWhenRegisteredCountExceedsLimit() {
+        // given
+        CrawlerSeat crawlerSeat = createCrawlerSeatWithLimits(5, 5, 5, 5, 5, 6);
+
+        // when
+        Integer remainSeat = SeatUtils.getRemainSeat(crawlerSeat, SeatUtilsType.GRADE_4);
+
+        // then
+        assertThat(remainSeat).isZero();
+    }
+
+    private static Stream<Arguments> seatLimitTypes() {
+        return Stream.of(
+            Arguments.of(SeatUtilsType.GRADE_4, 40),
+            Arguments.of(SeatUtilsType.GRADE_3, 30),
+            Arguments.of(SeatUtilsType.GRADE_2, 20),
+            Arguments.of(SeatUtilsType.GRADE_1, 10),
+            Arguments.of(SeatUtilsType.TOTAL, 50)
+        );
+    }
+}

--- a/src/test/java/kr/allcll/backend/admin/seat/SeatUtilsTest.java
+++ b/src/test/java/kr/allcll/backend/admin/seat/SeatUtilsTest.java
@@ -2,8 +2,10 @@ package kr.allcll.backend.admin.seat;
 
 import static kr.allcll.backend.fixture.CrawlerSeatFixture.createCrawlerSeatWithLimits;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.stream.Stream;
+import kr.allcll.backend.support.exception.AllcllException;
 import kr.allcll.crawler.seat.CrawlerSeat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,6 +40,18 @@ class SeatUtilsTest {
 
         // then
         assertThat(remainSeat).isZero();
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 여석 계산 기준이면 예외가 발생한다.")
+    void getRemainSeatWithUnsupportedSeatUtilsType() {
+        // given
+        CrawlerSeat crawlerSeat = createCrawlerSeatWithLimits(50, 40, 30, 20, 60, 10);
+
+        // when & then
+        assertThatThrownBy(() -> SeatUtils.getRemainSeat(crawlerSeat, null))
+            .isInstanceOf(AllcllException.class)
+            .hasMessage("지원하지 않는 여석 계산 기준입니다.");
     }
 
     private static Stream<Arguments> seatLimitTypes() {

--- a/src/test/java/kr/allcll/backend/fixture/CrawlerSeatFixture.java
+++ b/src/test/java/kr/allcll/backend/fixture/CrawlerSeatFixture.java
@@ -13,4 +13,19 @@ public class CrawlerSeatFixture {
             "", "", "");
     }
 
+    public static CrawlerSeat createCrawlerSeatWithLimits(
+        Integer grade4Limit,
+        Integer grade3Limit,
+        Integer grade2Limit,
+        Integer grade1Limit,
+        Integer totalLimit,
+        Integer totalRegisteredCount
+    ) {
+        return new CrawlerSeat(null, null, "", null, grade1Limit,
+            null, "", grade4Limit, grade3Limit, grade2Limit, "",
+            null, null, totalRegisteredCount, "", null, null,
+            totalLimit, null, null, null, "",
+            "", "", "");
+    }
+
 }


### PR DESCRIPTION
## 작업 내용
오랜만에... 손코딩했습니다

- `/api/admin/seat/start`, `/api/admin/season-seat/start`에 `seatUtilsType` 파라미터를 추가했습니다.
- 이에 따라 `SeatUtilsType` enum을 추가했고, 이 분기에 따라 SeatUtils 로직 return값을 분기했습니다.
  - `GRADE_4` → `TOT_LIMIT_RCNT_4`
  - `GRADE_3` → `TOT_LIMIT_RCNT_3`
  - `GRADE_2` → `TOT_LIMIT_RCNT_2`
  - `GRADE_1` → `TOT_LIMIT_RCNT_1`
  - `TOTAL` → `TOT_LIMIT_RCNT`
- 지원하지 않는 여석 계산 기준은 `UNSUPPORTED_SEAT_LIMIT_TYPE` 예외로 처리했습니다.

## 고민 지점과 리뷰 포인트
- 테스트 부족해보이나요?

## 액션아이템
- [ ] 파라미터 추가에 따른 어드민 페이지 수정이 필요합니다!!!! ㅜㅜ 엔드포인트 최소한으로 변경하고 싶었으나, 이게 가장 적합해보였습니다...

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->

---

## Codex Review
- `src/main/java/kr/allcll/backend/admin/seat/AdminSeatService.java:54` -- "**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Reset cached seats when switching calculation modes**"

---
- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기