### PR TITLE
[TSK-132] 예체능 학과의 부가 전공들을 정규화

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/user/UserFetcher.java
+++ b/src/main/java/kr/allcll/backend/domain/user/UserFetcher.java
@@ -64,7 +64,7 @@ public class UserFetcher {
             switch (label) {
                 case "학번" -> studentId = value;
                 case "이름" -> name = value;
-                case "학과명" -> dept = value;
+                case "학과명" -> dept = value.replaceAll("\\s+", "");
             }
         }
 

--- a/src/main/java/kr/allcll/backend/domain/user/dto/UserInfo.java
+++ b/src/main/java/kr/allcll/backend/domain/user/dto/UserInfo.java
@@ -11,6 +11,9 @@ public record UserInfo(
 
     private static final String FILM_ART_DEPARTMENT = "영화예술학과";
     private static final String PAINTING_DEPARTMENT = "회화과";
+    private static final String MUSIC_DEPARTMENT = "음악과";
+    private static final String PHYSICAL_EDUCATION_DEPARTMENT = "체육학과";
+    private static final String DANCE_DEPARTMENT = "무용과";
 
     public UserInfo {
         deptNm = normalizeDeptNm(deptNm);
@@ -25,12 +28,18 @@ public record UserInfo(
     }
 
     private static String normalizeDeptNm(String deptNm) {
-        if ("연기예술".equals(deptNm) || "연출제작".equals(deptNm)) {
-            return FILM_ART_DEPARTMENT;
+        if (deptNm == null) {
+            return null;
         }
-        if ("서양화".equals(deptNm) || "한국화".equals(deptNm)) {
-            return PAINTING_DEPARTMENT;
-        }
-        return deptNm;
+        return switch (deptNm) {
+            case "연기예술", "연출제작" -> FILM_ART_DEPARTMENT;
+            case "서양화", "한국화" -> PAINTING_DEPARTMENT;
+            case "성악", "피아노", "플루트", "클라리넷", "바이올린", "비올라", "첼로" ->
+                MUSIC_DEPARTMENT;
+            case "골프", "태권도", "축구", "리듬체조", "에어로빅체조", "사격", "수영", "양궁" ->
+                PHYSICAL_EDUCATION_DEPARTMENT;
+            case "발레", "한국무용", "현대무용" -> DANCE_DEPARTMENT;
+            default -> deptNm;
+        };
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/user/dto/UserInfo.java
+++ b/src/main/java/kr/allcll/backend/domain/user/dto/UserInfo.java
@@ -28,16 +28,11 @@ public record UserInfo(
     }
 
     private static String normalizeDeptNm(String deptNm) {
-        if (deptNm == null) {
-            return null;
-        }
         return switch (deptNm) {
             case "연기예술", "연출제작" -> FILM_ART_DEPARTMENT;
             case "서양화", "한국화" -> PAINTING_DEPARTMENT;
-            case "성악", "피아노", "플루트", "클라리넷", "바이올린", "비올라", "첼로" ->
-                MUSIC_DEPARTMENT;
-            case "골프", "태권도", "축구", "리듬체조", "에어로빅체조", "사격", "수영", "양궁" ->
-                PHYSICAL_EDUCATION_DEPARTMENT;
+            case "성악", "피아노", "플루트", "클라리넷", "바이올린", "비올라", "첼로" -> MUSIC_DEPARTMENT;
+            case "골프", "태권도", "축구", "리듬체조", "에어로빅체조", "사격", "수영", "양궁" -> PHYSICAL_EDUCATION_DEPARTMENT;
             case "발레", "한국무용", "현대무용" -> DANCE_DEPARTMENT;
             default -> deptNm;
         };

--- a/src/main/java/kr/allcll/backend/domain/user/dto/UserInfo.java
+++ b/src/main/java/kr/allcll/backend/domain/user/dto/UserInfo.java
@@ -10,6 +10,7 @@ public record UserInfo(
 ) {
 
     private static final String FILM_ART_DEPARTMENT = "영화예술학과";
+    private static final String PAINTING_DEPARTMENT = "회화과";
 
     public UserInfo {
         deptNm = normalizeDeptNm(deptNm);
@@ -26,6 +27,9 @@ public record UserInfo(
     private static String normalizeDeptNm(String deptNm) {
         if ("연기예술".equals(deptNm) || "연출제작".equals(deptNm)) {
             return FILM_ART_DEPARTMENT;
+        }
+        if ("서양화".equals(deptNm) || "한국화".equals(deptNm)) {
+            return PAINTING_DEPARTMENT;
         }
         return deptNm;
     }

--- a/src/main/java/kr/allcll/backend/domain/user/dto/UserInfo.java
+++ b/src/main/java/kr/allcll/backend/domain/user/dto/UserInfo.java
@@ -9,11 +9,24 @@ public record UserInfo(
     String deptNm
 ) {
 
+    private static final String FILM_ART_DEPARTMENT = "영화예술학과";
+
+    public UserInfo {
+        deptNm = normalizeDeptNm(deptNm);
+    }
+
     public static UserInfo of(String studentId, String name, String deptNm) {
         return new UserInfo(
             studentId,
             name,
             deptNm
         );
+    }
+
+    private static String normalizeDeptNm(String deptNm) {
+        if ("연기예술".equals(deptNm) || "연출제작".equals(deptNm)) {
+            return FILM_ART_DEPARTMENT;
+        }
+        return deptNm;
     }
 }

--- a/src/test/java/kr/allcll/backend/domain/user/dto/UserInfoTest.java
+++ b/src/test/java/kr/allcll/backend/domain/user/dto/UserInfoTest.java
@@ -24,6 +24,21 @@ class UserInfoTest {
         assertThat(userInfo.deptNm()).isEqualTo("영화예술학과");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"서양화", "한국화"})
+    @DisplayName("회화과의 세부 전공명은 회화과로 정규화한다.")
+    void normalizePaintingDepartment(String deptNm) {
+        // given
+        String studentId = "22012731";
+        String name = "홍길동";
+
+        // when
+        UserInfo userInfo = UserInfo.of(studentId, name, deptNm);
+
+        // then
+        assertThat(userInfo.deptNm()).isEqualTo("회화과");
+    }
+
     @Test
     @DisplayName("일반 학과명은 변경하지 않는다.")
     void preserveDepartmentName() {

--- a/src/test/java/kr/allcll/backend/domain/user/dto/UserInfoTest.java
+++ b/src/test/java/kr/allcll/backend/domain/user/dto/UserInfoTest.java
@@ -1,0 +1,39 @@
+package kr.allcll.backend.domain.user.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UserInfoTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"연기예술", "연출제작"})
+    @DisplayName("영화예술학과의 세부 전공명은 영화예술학과로 정규화한다.")
+    void normalizeFilmArtDepartment(String deptNm) {
+        // given
+        String studentId = "22012731";
+        String name = "홍길동";
+
+        // when
+        UserInfo userInfo = UserInfo.of(studentId, name, deptNm);
+
+        // then
+        assertThat(userInfo.deptNm()).isEqualTo("영화예술학과");
+    }
+
+    @Test
+    @DisplayName("일반 학과명은 변경하지 않는다.")
+    void preserveDepartmentName() {
+        // given
+        String deptNm = "컴퓨터공학과";
+
+        // when
+        UserInfo userInfo = UserInfo.of("22012731", "홍길동", deptNm);
+
+        // then
+        assertThat(userInfo.deptNm()).isEqualTo(deptNm);
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/user/dto/UserInfoTest.java
+++ b/src/test/java/kr/allcll/backend/domain/user/dto/UserInfoTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class UserInfoTest {
@@ -37,6 +38,40 @@ class UserInfoTest {
 
         // then
         assertThat(userInfo.deptNm()).isEqualTo("회화과");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "성악, 음악과",
+        "피아노, 음악과",
+        "플루트, 음악과",
+        "클라리넷, 음악과",
+        "바이올린, 음악과",
+        "비올라, 음악과",
+        "첼로, 음악과",
+        "골프, 체육학과",
+        "태권도, 체육학과",
+        "축구, 체육학과",
+        "리듬체조, 체육학과",
+        "에어로빅체조, 체육학과",
+        "사격, 체육학과",
+        "수영, 체육학과",
+        "양궁, 체육학과",
+        "발레, 무용과",
+        "한국무용, 무용과",
+        "현대무용, 무용과"
+    })
+    @DisplayName("세부 전공명은 상위 학과명으로 정규화한다.")
+    void normalizeDepartment(String deptNm, String expectedDeptNm) {
+        // given
+        String studentId = "22012731";
+        String name = "홍길동";
+
+        // when
+        UserInfo userInfo = UserInfo.of(studentId, name, deptNm);
+
+        // then
+        assertThat(userInfo.deptNm()).isEqualTo(expectedDeptNm);
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
영화예술학과 학우분들은 연기예술/연출제작으로 나뉜다는 사용자 제보를 받았습니다.
따라서 연기예술/연출제작 입력을 영화예술학과로 정규화합니다.
구글시트에 값 추가를 하는게 아니고 이렇게 진행한 이유는, 다음과 같습니다.
- 구글시트에는 수강편람의 학과 모음 페이지를 기준으로 학과 적재를 진행했습니다.
<img width="513" height="731" alt="image" src="https://github.com/user-attachments/assets/cfc9f4a8-fcc2-4050-b6ba-22904c433381" />

- 여기에 연기예술/연출제작 이 존재하지 않습니다.
- 27학번부터도 적재해야하는데, 이 분기를 기억하고 계속 추가하기는 어렵습니다.
- 그 관리포인트를 제하기 위해 코드단에서 보정하도록 진행했습니다.

## 고민 지점과 리뷰 포인트
생각해보니까 사용자 학과를 조회해왔을때, '연기 예술' 혹은 '연출 제작' 처럼 중간에 띄어쓰기 있는 경우 보정이 없네요. 이를 최초에 대휴칼 응답 받은시점에 추가하는게 나아보이나요?

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->

---

## Codex Review
- `src/main/java/kr/allcll/backend/domain/user/dto/UserInfo.java:27` -- "PR 본문 질문과 관련하여, '연기 예술', '연출 제작'과 같이 중간 띄어쓰기나 앞뒤 공백이 포함된 입력에 대응하려면 비교 전 공백 제거를 고려해보실 수 있습니다."
- `src/test/java/kr/allcll/backend/domain/user/dto/UserInfoTest.java:20` -- "`null` 입력 및 띄어쓰기가 포함된 학과명(예: `'연기 예술'`, `'연출 제작'`)에 대한 정규화 테스트 케이스도 추가하면 엣지 케이스 검증이 더욱 강화될 것 같습니다."

---
- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기