### PR TITLE
[TSK-135] 포털 로그인 실패 시 기존 유저로 인증되는 버그 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/user/AuthFacade.java
+++ b/src/main/java/kr/allcll/backend/domain/user/AuthFacade.java
@@ -6,8 +6,6 @@ import kr.allcll.backend.domain.graduation.check.cert.dto.GraduationCertInfo;
 import kr.allcll.backend.domain.user.dto.LoginRequest;
 import kr.allcll.backend.domain.user.dto.LoginResult;
 import kr.allcll.backend.domain.user.dto.UserInfo;
-import kr.allcll.backend.support.exception.AllcllErrorCode;
-import kr.allcll.backend.support.exception.AllcllException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
@@ -39,15 +37,8 @@ public class AuthFacade {
                 loginRequest.studentId(), exception.getMessage());
         }
 
-        User user;
-        try {
-            UserInfo userInfo = userFetcher.fetch(client);
-            user = userService.findOrCreate(userInfo);
-        } catch (Exception exception) {
-            log.error("[UserFetcher] 사용자 정보 조회 실패, 기존 유저 조회 시도 (학번: {}): {}",
-                loginRequest.studentId(), exception.getMessage());
-            user = userService.getByStudentId(loginRequest.studentId());
-        }
+        UserInfo userInfo = userFetcher.fetch(client);
+        User user = userService.findOrCreate(userInfo);
 
         try {
             GraduationCertInfo certInfo = graduationCertResolver.resolve(user, client);

--- a/src/main/java/kr/allcll/backend/domain/user/AuthService.java
+++ b/src/main/java/kr/allcll/backend/domain/user/AuthService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AuthService {
 
+    public static final String RESULT_OK = "var result = 'OK'";
     private final LoginProperties properties;
 
     public OkHttpClient login(LoginRequest loginRequest) {
@@ -47,7 +48,7 @@ public class AuthService {
                 .build();
 
             try (Response response = client.newCall(request).execute()) {
-                if (!response.isSuccessful()) {
+                if (!isSuccessful(response)) {
                     throw new AllcllException(AllcllErrorCode.SEJONG_LOGIN_FAIL);
                 }
                 return client;
@@ -55,5 +56,11 @@ public class AuthService {
         } catch (IOException exception) {
             throw new AllcllException(AllcllErrorCode.SEJONG_LOGIN_IO_ERROR, exception);
         }
+    }
+
+    private boolean isSuccessful(Response response) throws IOException {
+        // 세종대 포털은 로그인 실패에도 200을 반환하므로 응답 본문의 result 값으로 판단
+        String responseBody = response.body() != null ? response.body().string() : "";
+        return responseBody.contains(RESULT_OK);
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/user/AuthService.java
+++ b/src/main/java/kr/allcll/backend/domain/user/AuthService.java
@@ -59,6 +59,9 @@ public class AuthService {
     }
 
     private boolean isSuccessful(Response response) throws IOException {
+        if (!response.isSuccessful()) {
+            return false;
+        }
         // 세종대 포털은 로그인 실패에도 200을 반환하므로 응답 본문의 result 값으로 판단
         String responseBody = response.body() != null ? response.body().string() : "";
         return responseBody.contains(RESULT_OK);

--- a/src/main/java/kr/allcll/backend/domain/user/ToscAuthService.java
+++ b/src/main/java/kr/allcll/backend/domain/user/ToscAuthService.java
@@ -1,11 +1,9 @@
 package kr.allcll.backend.domain.user;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import kr.allcll.backend.client.LoginProperties;
 import kr.allcll.backend.domain.user.dto.LoginRequest;
-import kr.allcll.backend.domain.user.dto.ToscResponse;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
 import kr.allcll.backend.support.exception.AllcllException;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +13,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -24,7 +21,6 @@ import org.springframework.stereotype.Service;
 public class ToscAuthService {
 
     private final LoginProperties properties;
-    private final ObjectMapper objectMapper;
 
     public void loginTosc(LoginRequest loginRequest) {
         OkHttpClient client = new OkHttpClient();
@@ -43,21 +39,6 @@ public class ToscAuthService {
             if (!response.isSuccessful()) {
                 log.error("[TOSC] HTTP 요청 실패 (상태 코드: {}, 학번: {})",
                     response.code(), loginRequest.studentId());
-                throw new AllcllException(AllcllErrorCode.TOSC_LOGIN_FAIL);
-            }
-
-            ResponseBody responseBody = response.body();
-            if (responseBody == null) {
-                log.error("[TOSC] 응답 본문이 비어있음 (학번: {})", loginRequest.studentId());
-                throw new AllcllException(AllcllErrorCode.TOSC_LOGIN_FAIL);
-            }
-
-            String responseString = responseBody.string();
-            ToscResponse toscResponse = objectMapper.readValue(responseString, ToscResponse.class);
-
-            if (!toscResponse.success()) {
-                log.error("[TOSC] 로그인 실패 (학번: {}, 에러: {})",
-                    loginRequest.studentId(), toscResponse.getErrorMessage());
                 throw new AllcllException(AllcllErrorCode.TOSC_LOGIN_FAIL);
             }
         } catch (SocketTimeoutException exception) {

--- a/src/test/java/kr/allcll/backend/domain/user/ToscAuthServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/user/ToscAuthServiceTest.java
@@ -3,7 +3,6 @@ package kr.allcll.backend.domain.user;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
 import java.net.HttpCookie;
@@ -40,7 +39,7 @@ class ToscAuthServiceTest {
             "https://portal.sejong.ac.kr/englishInfo",
             "https://portal.sejong.ac.kr/codingInfo"
         );
-        toscAuthService = new ToscAuthService(properties, new ObjectMapper());
+        toscAuthService = new ToscAuthService(properties);
         portalCookieManager = new CookieManager();
         portalCookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
     }
@@ -51,8 +50,8 @@ class ToscAuthServiceTest {
     }
 
     @Test
-    @DisplayName("TOSC 로그인 실패 시에도 포털 세션 쿠키에 영향을 주지 않는다")
-    void toscLoginFailureDoesNotAffectPortalCookieJar() {
+    @DisplayName("TOSC HTTP 실패 시 예외를 던지고 포털 세션 쿠키에 영향을 주지 않는다")
+    void toscHttpFailureThrowsExceptionAndDoesNotAffectPortalCookieJar() {
         // given
         URI portalUri = URI.create("https://portal.sejong.ac.kr");
         HttpCookie sessionCookie = new HttpCookie("JSESSIONID", "portal-session-abc123");
@@ -65,12 +64,10 @@ class ToscAuthServiceTest {
         );
 
         toscServer.enqueue(new MockResponse()
-            .setResponseCode(200)
-            .addHeader("Set-Cookie", "TOSC_SESSION=tosc-session-xyz; Path=/; Domain=localhost")
-            .setBody("{\"success\": false, \"errors\": {\"password\": \"패스워드가 일치하지 않습니다.\"}}")
+            .setResponseCode(500)
         );
 
-        LoginRequest loginRequest = new LoginRequest("22011114", "wrong-password");
+        LoginRequest loginRequest = new LoginRequest("22011114", "correct-password");
 
         // when
         assertThatThrownBy(() -> toscAuthService.loginTosc(loginRequest))


### PR DESCRIPTION
# 작업 배경

기존 구현은 **세종대 포털이 로그인 실패 시 HTTP 비정상 상태 코드를 반환한다**는 가정을 기반으로 작성되어 있었습니다.

하지만 실제 확인 결과, 포털은 로그인 실패 시에도 HTTP 200을 반환하고 응답 본문에 에러 페이지를 내려주고 있었습니다.

- `AuthService`가 `response.isSuccessful()`(HTTP 상태 코드)만 검사하고 있어서, 잘못된 비밀번호로도 로그인 처리가 통과됨

> 잘못된 비밀번호 -> 포털 200 응답 -> AuthService 통과 -> UserFetcher 파싱 실패 -> getByStudentId 폴백 -> 비밀번호 검증 없이 기존 유저 세션 생성

이로 인해 이미 가입된 학번이면 비밀번호가 틀려도 로그인이 성공하는 문제가 발생했습니다.

# 해결 방법

포털 응답 본문에서 `var result = 'OK'` 문자열을 확인하여 실제 로그인 성공 여부를 판단하도록 변경했습니다. HTTP 상태 코드와 응답 본문을 함께 검사합니다.

이에 따라 `AuthFacade`의 `getByStudentId` 폴백도 제거했습니다. 포털 단계에서 로그인 실패가 확실히 차단되므로, UserFetcher 실패 시 비밀번호 미검증 유저를 반환하는 경로가 불필요해졌습니다.

`ToscAuthService`의 응답 본문 `success` 검증도 제거했습니다. TOSC 로그인은 대휴칼 서버에 인증을 위임하는 구조여서, 대휴칼 단계에서 로그인 실패를 차단하면 TOSC에서 발생하는 실패는 서버 장애로 범위가 좁혀지고, HTTP 상태 코드 검사만으로 충분합니다.

# 작업 내용

- `AuthService`
    - `isSuccessful()` 메서드 추출, HTTP 상태 코드 + 응답 본문 `var result = 'OK'` 이중 검사
- `AuthFacade`
    - UserFetcher 실패 시 `getByStudentId` 폴백 제거
- `ToscAuthService`
    - 응답 본문 `success` 필드 검증 및 `ObjectMapper` 의존 제거

# 검증

**포털에서 잘못된 비밀번호로 로그인 시도**

> 수정 전: HTTP 200 통과 -> UserFetcher 실패 -> 폴백으로 기존 유저 세션 생성 (로그인 성공)
> 수정 후: HTTP 200이지만 응답 본문에 `var result = 'OK'` 없음 -> `SEJONG_LOGIN_FAIL` 예외 (로그인 차단)

# 리뷰 포인트

`ToscAuthService`의 응답 본문 검증 제거가 적절한지 확인 부탁드립니다. 대휴칼 단계에서 인증 실패를 차단하므로 TOSC까지 도달한 시점에서는 서버 장애만 남는다는 판단입니다.

# 참고

`AuthFacade`의 `getByStudentId` 폴백은 정상 로그인 후 UserFetcher가 일시적으로 실패하는 경우(학생 정보 페이지 장애 등)를 위한 것이었으나, 비밀번호 검증 없이 세션을 생성하는 보안 위험이 있어 제거했습니다. 포털 로그인이 성공한 상태에서 UserFetcher가 실패하면 사용자에게 재시도를 안내하는 것이 더 안전합니다.


---

## Codex Review
- `src/main/java/kr/allcll/backend/domain/user/ToscAuthService.java:62` -- "이 부분 삭제하면 안될 것 같은데요!! 기존 검증은 유지해야 할 것 같아요."
- `src/main/java/kr/allcll/backend/domain/user/AuthService.java:65` -- "HTTP 200이랑 result = 'OK' 를 같이 검사해야하지 않을까요?!"

---
- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기