### PR TITLE
[TSK-128] 시트 기준 이수구분 재분류 로직 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/graduation/check/excel/CompletedCourse.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/excel/CompletedCourse.java
@@ -76,8 +76,7 @@ public class CompletedCourse extends BaseEntity {
         this.isEarned = isEarned;
     }
 
-    public CompletedCourse updateAcademicBasic() {
-        this.categoryType = CategoryType.ACADEMIC_BASIC;
-        return this;
+    public void reclassifyCategory(CategoryType categoryType) {
+        this.categoryType = categoryType;
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java
@@ -227,10 +227,14 @@ public class GraduationChecker {
         );
         for (CompletedCourse course : earnedCourses) {
             CategoryType sheetCategory = categoryByCuriNo.get(course.getCuriNo());
-            if (sheetCategory != null && sheetCategory != course.getCategoryType()) {
+            if (hasDifferentCategory(course, sheetCategory)) {
                 course.reclassifyCategory(sheetCategory);
             }
         }
+    }
+
+    private boolean hasDifferentCategory(CompletedCourse course, CategoryType sheetCategory) {
+        return sheetCategory != null && sheetCategory != course.getCategoryType();
     }
 
     private boolean canGraduate(

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java
@@ -17,6 +17,7 @@ import kr.allcll.backend.domain.graduation.credit.CreditCriterionRepository;
 import kr.allcll.backend.domain.graduation.credit.DoubleCreditCriterion;
 import kr.allcll.backend.domain.graduation.credit.DoubleCreditCriterionRepository;
 import kr.allcll.backend.domain.graduation.credit.GeneralElectivePolicy;
+import kr.allcll.backend.domain.graduation.credit.RequiredCourseResolver;
 import kr.allcll.backend.domain.user.User;
 import kr.allcll.backend.domain.user.UserRepository;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
@@ -31,6 +32,7 @@ public class GraduationChecker {
     private final CategoryCreditCalculator categoryCalculator;
     private final CertificationChecker certificationChecker;
     private final GeneralElectivePolicy generalElectivePolicy;
+    private final RequiredCourseResolver requiredCourseResolver;
 
     private final UserRepository userRepository;
     private final CreditCriterionRepository creditCriterionRepository;
@@ -45,6 +47,9 @@ public class GraduationChecker {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new AllcllException(AllcllErrorCode.USER_NOT_FOUND));
         List<CreditCriterion> creditCriteria = resolveCreditCriteria(user);
+
+        // required_courses 시트 기준으로 이수구분 재분류
+        reclassifyByRequiredCourses(earnedCourses, user);
 
         // 이수구분별 학점 계산
         List<GraduationCategory> categoryResults = categoryCalculator.calculateCategoryResults(
@@ -214,6 +219,18 @@ public class GraduationChecker {
         return completedCourses.stream()
             .mapToDouble(CompletedCourse::getCredits)
             .sum();
+    }
+
+    private void reclassifyByRequiredCourses(List<CompletedCourse> earnedCourses, User user) {
+        Map<String, CategoryType> categoryByCuriNo = requiredCourseResolver.buildCategoryByCuriNo(
+            user.getAdmissionYear(), user.getDeptCd()
+        );
+        for (CompletedCourse course : earnedCourses) {
+            CategoryType sheetCategory = categoryByCuriNo.get(course.getCuriNo());
+            if (sheetCategory != null && sheetCategory != course.getCategoryType()) {
+                course.reclassifyCategory(sheetCategory);
+            }
+        }
     }
 
     private boolean canGraduate(

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import kr.allcll.backend.domain.graduation.MajorScope;
 import kr.allcll.backend.domain.graduation.MajorType;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
 import kr.allcll.backend.domain.graduation.check.result.dto.CertResult;
@@ -222,15 +223,36 @@ public class GraduationChecker {
     }
 
     private void reclassifyByRequiredCourses(List<CompletedCourse> earnedCourses, User user) {
-        Map<String, CategoryType> categoryByCuriNo = requiredCourseResolver.buildCategoryByCuriNo(
+        Map<String, CategoryType> primaryMap = requiredCourseResolver.buildCategoryByCuriNo(
             user.getAdmissionYear(), user.getDeptCd()
         );
+        Map<String, CategoryType> secondaryMap = buildSecondaryCategoryMap(user);
+
         for (CompletedCourse course : earnedCourses) {
-            CategoryType sheetCategory = categoryByCuriNo.get(course.getCuriNo());
+            Map<String, CategoryType> targetMap = selectCategoryMap(course, primaryMap, secondaryMap);
+            CategoryType sheetCategory = targetMap.get(course.getCuriNo());
             if (hasDifferentCategory(course, sheetCategory)) {
                 course.reclassifyCategory(sheetCategory);
             }
         }
+    }
+
+    private Map<String, CategoryType> selectCategoryMap(
+        CompletedCourse course,
+        Map<String, CategoryType> primaryMap,
+        Map<String, CategoryType> secondaryMap
+    ) {
+        if (course.getMajorScope() == MajorScope.SECONDARY) {
+            return secondaryMap;
+        }
+        return primaryMap;
+    }
+
+    private Map<String, CategoryType> buildSecondaryCategoryMap(User user) {
+        if (!user.hasDoubleMajor()) {
+            return Map.of();
+        }
+        return requiredCourseResolver.buildCategoryByCuriNo(user.getAdmissionYear(), user.getDoubleDeptCd());
     }
 
     private boolean hasDifferentCategory(CompletedCourse course, CategoryType sheetCategory) {

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseResolver.java
@@ -1,7 +1,6 @@
 package kr.allcll.backend.domain.graduation.credit;
 
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -33,7 +32,7 @@ public class RequiredCourseResolver {
     }
 
     private Map<CategoryType, List<RequiredCourseResponse>> resolveRequiredCourses(List<RequiredCourse> courses) {
-        Map<String, RequiredCourse> selectedByCourseKey = new LinkedHashMap<>();
+        Map<String, RequiredCourse> selectedByCourseKey = new HashMap<>();
         for (RequiredCourse course : courses) {
             String courseKey = KeyUtils.generate(course.getCategoryType(), course.getCuriNm());
             if (WILD_CARD_DEPT_CD.equals(course.getDeptCd())) {
@@ -142,7 +141,8 @@ public class RequiredCourseResolver {
         if (isNotDeprecated(requiredCourse.getCuriNo())) {
             return RequiredCourseResponse.of(requiredCourse.getCuriNo(), requiredCourse.getCuriNm());
         }
-        return requiredCourseRepository.findCurrentCourseBySameCourseCode(requiredCourse.getSameCourseCode(), DEPRECATED)
+        return requiredCourseRepository.findCurrentCourseBySameCourseCode(requiredCourse.getSameCourseCode(),
+                DEPRECATED)
             .map(currentCourse -> RequiredCourseResponse.of(currentCourse.getCuriNo(), currentCourse.getCuriNm()))
             .orElseGet(() -> {
                 log.error(

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseResolver.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import kr.allcll.backend.domain.graduation.credit.dto.RequiredCourseResponse;
 import kr.allcll.backend.support.graduation.KeyUtils;
@@ -48,6 +49,17 @@ public class RequiredCourseResolver {
                 RequiredCourse::getCategoryType,
                 Collectors.collectingAndThen(Collectors.toList(), this::resolveDeprecatedCourses)
             ));
+    }
+
+    public Map<String, CategoryType> buildCategoryByCuriNo(Integer admissionYear, String deptCd) {
+        Map<CategoryType, List<RequiredCourseResponse>> resolved = resolveRequiredCourses(admissionYear, deptCd);
+        Map<String, CategoryType> categoryByCuriNo = new HashMap<>();
+        for (Entry<CategoryType, List<RequiredCourseResponse>> entry : resolved.entrySet()) {
+            for (RequiredCourseResponse course : entry.getValue()) {
+                categoryByCuriNo.put(course.curiNo(), entry.getKey());
+            }
+        }
+        return categoryByCuriNo;
     }
 
     public boolean findRequiredCourseInGroup(

--- a/src/main/java/kr/allcll/backend/domain/user/User.java
+++ b/src/main/java/kr/allcll/backend/domain/user/User.java
@@ -72,6 +72,10 @@ public class User extends BaseEntity {
         this.doubleDeptCd = null;
     }
 
+    public boolean hasDoubleMajor() {
+        return doubleDeptCd != null;
+    }
+
     public void updateDoubleMajorUser(
         UpdateUserRequest updateUserRequest,
         GraduationDepartmentInfo primaryDept,


### PR DESCRIPTION

# 작업 배경

기존 구현은 **사용자 엑셀(성적표)에 적힌 이수구분이 정확하다**는 가정을 기반으로 작성되어 있었습니다.

하지만 실제 데이터 확인 결과, 세종대 성적표의 이수구분과 required_courses 시트(수강편람 기준)의 이수구분이 다른 과목이 존재했습니다.

- 예: 학과별로 학문기초/전공기초 분류가 다르거나, 교양필수로 표기된 과목이 실제로는 학문기초인 경우

> EX) 반도체시스템공학과의 "공업수학1" 과목이 성적표에는 공통교양으로 기록되어 있지만, 수강편람(required_courses 시트) 기준으로는 기초교양로 분류되어야 하는 경우

이로 인해 이수구분별 학점 합산이 잘못 계산되어, 졸업요건 충족 여부가 실제와 다르게 판정되는 문제가 있었습니다.

# 해결 방법

졸업요건 검사 시, required_courses 시트 데이터를 기준으로 사용자의 이수 과목 이수구분을 재분류합니다.

성적표의 이수구분을 그대로 신뢰하는 대신, 시트에 해당 과목이 존재하면 시트의 이수구분으로 덮어씁니다. 성적표 기준은 학교 시스템의 분류이고, 시트는 수강편람을 사람이 읽고 적재한 정책 데이터이므로 졸업요건 판정에는 시트가 더 적합합니다.

# 작업 내용

- `CompletedCourse.java`
    - `updateAcademicBasic()` (학문기초 고정 변경) 을 `reclassifyCategory(CategoryType)` 으로 일반화하여 임의 이수구분으로 재분류 가능하게 변경
- `RequiredCourseResolver.java`
    - `buildCategoryByCuriNo(admissionYear, deptCd)` 메서드 추가 — 시트 기준 과목번호 -> 이수구분 맵 생성
- `GraduationChecker.java`
    - `reclassifyByRequiredCourses()` 메서드 추가 — 이수구분별 학점 계산 전에 시트 기준으로 재분류 수행

# 검증

**단위 테스트 및 기존 통합 테스트 통과 확인**

> 수정 전: 성적표 이수구분을 그대로 사용하여, 시트와 불일치하는 과목의 학점이 잘못된 카테고리에 합산됨
> 수정 후: 시트에 등록된 과목은 시트 기준 이수구분으로 재분류된 후 학점 계산에 반영됨

# 리뷰 포인트

시트에 없는 과목은 재분류하지 않고 성적표 이수구분을 유지하는데, 이 fallback 정책이 적절한지 확인 부탁드립니다.

# 참고

- `reclassifyCategory()`는 DB에 반영하지 않고 인메모리에서만 변경합니다. 졸업요건 검사 트랜잭션 내에서만 유효하며, 원본 성적 데이터는 보존됩니다.
- 기존 `updateAcademicBasic()`은 학문기초 한 가지 타입으로만 변경 가능했으나, 이번 변경으로 모든 CategoryType으로 재분류할 수 있게 일반화했습니다.

---

## Codex Review
- `src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java:224` -- "운영 데이터로 검증을 해보았는데요! "
- `src/main/java/kr/allcll/backend/domain/graduation/check/result/GraduationChecker.java:53` -- "> reclassifyCategory()는 DB에 반영하지 않고 인메모리에서만 변경합니다. 졸업요건 검사 트랜잭션 내에서만 유효하며, 원본 성적 데이터는 보존됩니다."

---
- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기