### PR TITLE
[TSK-140-1] SSE 스케줄러 및 batch 대기 시간 메트릭 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/support/batch/AbstractBatch.java
+++ b/src/main/java/kr/allcll/backend/support/batch/AbstractBatch.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
 import kr.allcll.backend.support.metrics.SeatPipelineMetrics;
 
 public abstract class AbstractBatch<T> {
@@ -12,6 +13,7 @@ public abstract class AbstractBatch<T> {
     private final Object lock;
     private final SeatPipelineMetrics seatPipelineMetrics;
     private final String type;
+    private final AtomicLong oldestPendingAtMillis;
 
     protected abstract int getFlushLimit();
 
@@ -22,11 +24,18 @@ public abstract class AbstractBatch<T> {
         this.lock = new Object();
         this.seatPipelineMetrics = seatPipelineMetrics;
         this.type = type;
+        this.oldestPendingAtMillis = new AtomicLong(0);
         this.seatPipelineMetrics.registerBatchQueueSize(type, queue);
+        this.seatPipelineMetrics.registerBatchOldestPendingAge(type, oldestPendingAtMillis);
     }
 
     public void add(T item) {
-        queue.add(item);
+        synchronized (lock) {
+            if (queue.isEmpty()) {
+                oldestPendingAtMillis.set(System.currentTimeMillis());
+            }
+            queue.add(item);
+        }
         if (queue.size() >= getFlushLimit()) {
             flush();
         }
@@ -42,6 +51,7 @@ public abstract class AbstractBatch<T> {
         List<T> batch;
         synchronized (lock) {
             batch = getAll();
+            oldestPendingAtMillis.set(0);
             if (batch.isEmpty()) {
                 return;
             }

--- a/src/main/java/kr/allcll/backend/support/metrics/SeatPipelineMetrics.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/SeatPipelineMetrics.java
@@ -21,12 +21,15 @@ public class SeatPipelineMetrics {
 
     private final MeterRegistry meterRegistry;
     private final AtomicLong seatCrawlerActive = new AtomicLong(0);
+    private final AtomicLong seatSseSchedulerActive = new AtomicLong(0);
     private final AtomicLong lastCrawledAtMillis = new AtomicLong(0);
     private final Map<String, AtomicLong> schedulerLastSuccessEpochSeconds = new ConcurrentHashMap<>();
 
     public SeatPipelineMetrics(MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;
         Gauge.builder("seat.crawler.active", seatCrawlerActive, AtomicLong::get)
+            .register(meterRegistry);
+        Gauge.builder("seat.sse.scheduler.active", seatSseSchedulerActive, AtomicLong::get)
             .register(meterRegistry);
         Gauge.builder("seat.last.crawled.age", lastCrawledAtMillis, this::getLastCrawledAgeSeconds)
             .baseUnit("seconds")
@@ -39,6 +42,14 @@ public class SeatPipelineMetrics {
 
     public void recordSeatCrawlerStopped() {
         seatCrawlerActive.set(0);
+    }
+
+    public void recordSeatSseSchedulerStarted() {
+        seatSseSchedulerActive.set(1);
+    }
+
+    public void recordSeatSseSchedulerStopped() {
+        seatSseSchedulerActive.set(0);
     }
 
     public void recordCrawlingSuccess(long epochMillis) {

--- a/src/main/java/kr/allcll/backend/support/metrics/SeatPipelineMetrics.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/SeatPipelineMetrics.java
@@ -62,6 +62,13 @@ public class SeatPipelineMetrics {
             .register(meterRegistry);
     }
 
+    public void registerBatchOldestPendingAge(String type, AtomicLong oldestPendingAtMillis) {
+        Gauge.builder("seat.batch.oldest.pending.age", oldestPendingAtMillis, this::getPendingAgeSeconds)
+            .tags(TYPE_TAG, type)
+            .baseUnit("seconds")
+            .register(meterRegistry);
+    }
+
     public void recordBatchFlush(String type, ThrowingRunnable runnable) {
         Timer.Sample sample = Timer.start(meterRegistry);
         try {
@@ -122,6 +129,14 @@ public class SeatPipelineMetrics {
             return TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
         }
         return (System.currentTimeMillis() - lastCrawledAt) / 1000.0;
+    }
+
+    private double getPendingAgeSeconds(AtomicLong oldestPendingAtMillis) {
+        long oldestPendingAt = oldestPendingAtMillis.get();
+        if (oldestPendingAt == 0) {
+            return 0;
+        }
+        return (System.currentTimeMillis() - oldestPendingAt) / 1000.0;
     }
 
     private void throwAsUnchecked(Exception e) {

--- a/src/main/java/kr/allcll/backend/support/scheduler/SchedulerService.java
+++ b/src/main/java/kr/allcll/backend/support/scheduler/SchedulerService.java
@@ -2,6 +2,7 @@ package kr.allcll.backend.support.scheduler;
 
 import kr.allcll.backend.domain.seat.GeneralSeatSender;
 import kr.allcll.backend.domain.seat.PinSeatSender;
+import kr.allcll.backend.support.metrics.SeatPipelineMetrics;
 import kr.allcll.backend.support.scheduler.dto.SeatSchedulerStatusResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,15 +13,18 @@ public class SchedulerService {
 
     private final GeneralSeatSender generalSeatSender;
     private final PinSeatSender pinSeatSender;
+    private final SeatPipelineMetrics seatPipelineMetrics;
 
     public void startScheduling() {
         generalSeatSender.send();
         pinSeatSender.send();
+        seatPipelineMetrics.recordSeatSseSchedulerStarted();
     }
 
     public void cancelScheduling() {
         generalSeatSender.cancel();
         pinSeatSender.cancel();
+        seatPipelineMetrics.recordSeatSseSchedulerStopped();
     }
 
     public SeatSchedulerStatusResponse getSeatSchedulerStatus() {

--- a/src/test/java/kr/allcll/backend/support/batch/AbstractBatchMetricsTest.java
+++ b/src/test/java/kr/allcll/backend/support/batch/AbstractBatchMetricsTest.java
@@ -2,8 +2,10 @@ package kr.allcll.backend.support.batch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import kr.allcll.backend.support.metrics.SeatPipelineMetrics;
@@ -28,6 +30,34 @@ class AbstractBatchMetricsTest {
             .gauge()
             .value();
         assertThat(queueSize).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("batch에 대기 항목이 있으면 가장 오래 대기한 시간 gauge가 증가하고 flush 후 초기화된다.")
+    void batchOldestPendingAgeGauge() {
+        // given
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        TestBatch batch = new TestBatch(new SeatPipelineMetrics(meterRegistry), "general");
+
+        // when
+        batch.add("seat");
+
+        // then
+        await()
+            .atMost(Duration.ofSeconds(2))
+            .untilAsserted(() -> assertThat(meterRegistry.get("seat.batch.oldest.pending.age")
+                .tag("type", "general")
+                .gauge()
+                .value()).isGreaterThanOrEqualTo(1.0));
+
+        // when
+        batch.flush();
+
+        // then
+        assertThat(meterRegistry.get("seat.batch.oldest.pending.age")
+            .tag("type", "general")
+            .gauge()
+            .value()).isZero();
     }
 
     @Test

--- a/src/test/java/kr/allcll/backend/support/metrics/SeatPipelineMetricsTest.java
+++ b/src/test/java/kr/allcll/backend/support/metrics/SeatPipelineMetricsTest.java
@@ -29,6 +29,26 @@ class SeatPipelineMetricsTest {
     }
 
     @Test
+    @DisplayName("SSE 스케줄러 시작과 중지에 따라 active gauge가 갱신된다.")
+    void seatSseSchedulerActiveGauge() {
+        // given
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        SeatPipelineMetrics seatPipelineMetrics = new SeatPipelineMetrics(meterRegistry);
+
+        // when
+        seatPipelineMetrics.recordSeatSseSchedulerStarted();
+
+        // then
+        assertThat(meterRegistry.get("seat.sse.scheduler.active").gauge().value()).isEqualTo(1.0);
+
+        // when
+        seatPipelineMetrics.recordSeatSseSchedulerStopped();
+
+        // then
+        assertThat(meterRegistry.get("seat.sse.scheduler.active").gauge().value()).isZero();
+    }
+
+    @Test
     @DisplayName("크롤링 성공 시 last crawled age gauge가 갱신된다.")
     void lastCrawledAgeGauge() {
         // given

--- a/src/test/java/kr/allcll/backend/support/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/kr/allcll/backend/support/scheduler/SchedulerServiceTest.java
@@ -1,0 +1,53 @@
+package kr.allcll.backend.support.scheduler;
+
+import static org.mockito.Mockito.verify;
+
+import kr.allcll.backend.domain.seat.GeneralSeatSender;
+import kr.allcll.backend.domain.seat.PinSeatSender;
+import kr.allcll.backend.support.metrics.SeatPipelineMetrics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SchedulerServiceTest {
+
+    @Mock
+    private GeneralSeatSender generalSeatSender;
+
+    @Mock
+    private PinSeatSender pinSeatSender;
+
+    @Mock
+    private SeatPipelineMetrics seatPipelineMetrics;
+
+    @InjectMocks
+    private SchedulerService schedulerService;
+
+    @Test
+    @DisplayName("SSE 스케줄러를 시작하면 활성 상태 메트릭을 기록한다.")
+    void startSchedulingRecordsActiveMetric() {
+        // when
+        schedulerService.startScheduling();
+
+        // then
+        verify(generalSeatSender).send();
+        verify(pinSeatSender).send();
+        verify(seatPipelineMetrics).recordSeatSseSchedulerStarted();
+    }
+
+    @Test
+    @DisplayName("SSE 스케줄러를 중지하면 활성 상태 메트릭을 기록한다.")
+    void cancelSchedulingRecordsInactiveMetric() {
+        // when
+        schedulerService.cancelScheduling();
+
+        // then
+        verify(generalSeatSender).cancel();
+        verify(pinSeatSender).cancel();
+        verify(seatPipelineMetrics).recordSeatSseSchedulerStopped();
+    }
+}


### PR DESCRIPTION
## 배경

모니터링 작업 연장 PR입니다!

SSE Scheduler와 batch 처리도 정상적으로 중지된 상태에서는 stale 또는 queue alert가 울리면 안 됩니다.

기존 `scheduler_task_last_success_timestamp`는 SSE Scheduler를 중지해도 마지막 성공 시각이 남아 있어,
단독으로 alert를 설정하면 정상 중지 상황에도 stale alert가 발생할 수 있습니다.

또한 `seat_batch_queue_size`는 batch가 flush limit에 도달하기 전까지 자연스럽게 증가하므로,
단순 queue size만으로는 DB 저장 지연을 안정적으로 판단하기 어렵습니다.

## 변경 사항

### SSE Scheduler 활성 상태 메트릭

`seat_sse_scheduler_active` gauge 메트릭을 추가했습니다.

- SSE Scheduler 시작 시 `1`
- SSE Scheduler 중지 시 `0`

이를 통해 SSE Scheduler가 실제 실행 중일 때만 stale alert를 발생시킬 수 있습니다.

### Batch 대기 시간 메트릭

`seat_batch_oldest_pending_age_seconds{type="general|pin"}` gauge 메트릭을 추가했습니다.

- batch queue가 비어 있으면 `0`
- 첫 항목이 queue에 들어온 뒤부터 대기 시간을 기록
- flush로 queue가 비워지면 `0`으로 초기화

이를 통해 queue 크기가 아니라, DB 저장 전 데이터가 실제로 얼마나 오래 정체됐는지 확인할 수 있습니다.

## 검증

- `SeatPipelineMetricsTest`
- `SchedulerServiceTest`
- `AbstractBatchMetricsTest`