### PR TITLE
[TSK-141] Loki 도입 전 민감 로그 노출 제거

### DIFF
--- a/src/main/java/kr/allcll/backend/domain/seat/PinSeatSender.java
+++ b/src/main/java/kr/allcll/backend/domain/seat/PinSeatSender.java
@@ -46,11 +46,11 @@ public class PinSeatSender {
     private Runnable getPinSeatTask() {
         return () -> {
             List<String> tokens = sseService.getConnectedTokens();
-            log.info("[PinSeatSender] 현재 연결된 토큰 수: {}, 토큰 목록: {}", tokens.size(), tokens);
+            log.info("[PinSeatSender] 현재 연결된 토큰 수: {}", tokens.size());
             Map<String, List<SeatDto>> pinSeatsByToken = seatService.getPinSeatsByTokens(tokens);
             tokens.forEach(token -> {
                 List<SeatDto> pinSeats = pinSeatsByToken.getOrDefault(token, List.of());
-                log.debug("[PinSeatSender] token: {}, 핀 과목 수: {}", token, pinSeats.size());
+                log.debug("[PinSeatSender] 핀 과목 전송 준비. pinSeatCount={}", pinSeats.size());
                 sseService.propagate(token, PIN_EVENT_NAME, PinSeatsResponse.from(pinSeats));
             });
         };

--- a/src/main/java/kr/allcll/backend/domain/user/AuthFacade.java
+++ b/src/main/java/kr/allcll/backend/domain/user/AuthFacade.java
@@ -33,8 +33,8 @@ public class AuthFacade {
             toscAuthService.loginTosc(loginRequest);
         } catch (Exception exception) {
             toscLoginFailed = true;
-            log.error("[TOSC] 로그인 실패, TOSC 정보 업데이트 불가 (학번: {}): {}",
-                loginRequest.studentId(), exception.getMessage());
+            log.error("[TOSC] 로그인 실패로 TOSC 정보 업데이트를 건너뜁니다. exceptionType={}",
+                exception.getClass().getSimpleName());
         }
 
         UserInfo userInfo = userFetcher.fetch(client);
@@ -44,8 +44,8 @@ public class AuthFacade {
             GraduationCertInfo certInfo = graduationCertResolver.resolve(user, client);
             graduationCertService.createOrUpdate(user, certInfo);
         } catch (Exception exception) {
-            log.error("[GraduationCert] 인증 정보 저장 중 오류 발생 (유저 ID: {}): {}",
-                user.getId(), exception.getMessage());
+            log.error("[GraduationCert] 인증 정보 저장 실패. exceptionType={}",
+                exception.getClass().getSimpleName());
         }
 
         return new LoginResult(user.getId(), toscLoginFailed);

--- a/src/main/java/kr/allcll/backend/support/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/allcll/backend/support/exception/GlobalExceptionHandler.java
@@ -3,27 +3,20 @@ package kr.allcll.backend.support.exception;
 import io.sentry.Sentry;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
+import org.springframework.web.servlet.HandlerMapping;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    private static final String LOG_FORMAT = """
-        \n\t{
-            "RequestURI": "{} {}",
-            "RequestBody": {},
-            "ErrorMessage": "{}"
-        \t}
-        """;
+    private static final String LOG_FORMAT =
+        "Request failed: method={} route={} status={} errorCode={} exceptionType={}";
 
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handleAllcllException(HttpServletRequest request, AllcllException exception) {
@@ -32,8 +25,8 @@ public class GlobalExceptionHandler {
         if (errorCode.getHttpStatus().is5xxServerError()) {
             captureException(request, exception, errorCode);
         }
-        log.warn(LOG_FORMAT, request.getMethod(), request.getRequestURI(), getRequestBody(request),
-            exception.getMessage());
+        log.warn(LOG_FORMAT, request.getMethod(), routeTemplate(request), errorCode.getHttpStatus().value(),
+            errorCode.name(), exception.getClass().getSimpleName());
         return ErrorResponse.of(errorCode);
     }
 
@@ -42,8 +35,8 @@ public class GlobalExceptionHandler {
         ServletException exception) {
         final AllcllErrorCode errorCode = AllcllErrorCode.NOT_FOUND_API;
 
-        log.info(LOG_FORMAT, request.getMethod(), request.getRequestURI(), getRequestBody(request),
-            exception.getMessage());
+        log.info(LOG_FORMAT, request.getMethod(), routeTemplate(request), errorCode.getHttpStatus().value(),
+            errorCode.name(), exception.getClass().getSimpleName());
         return ErrorResponse.of(errorCode);
     }
 
@@ -54,8 +47,8 @@ public class GlobalExceptionHandler {
     ) {
         final AllcllErrorCode errorCode = AllcllErrorCode.INVALID_REQUEST_VALUE;
 
-        log.info(LOG_FORMAT, request.getMethod(), request.getRequestURI(), getRequestBody(request),
-            exception.getMessage());
+        log.info(LOG_FORMAT, request.getMethod(), routeTemplate(request), errorCode.getHttpStatus().value(),
+            errorCode.name(), exception.getClass().getSimpleName());
         return ErrorResponse.of(errorCode);
     }
 
@@ -64,7 +57,8 @@ public class GlobalExceptionHandler {
         final AllcllErrorCode errorCode = AllcllErrorCode.ASYNC_REQUEST_TIMEOUT;
 
         if (request.getHeader("ALLCLL-SSE-CONNECT") != null) {
-            log.info("SSE connection timed out (normal close) - {} {}", request.getMethod(), request.getRequestURI());
+            log.info("SSE connection timed out (normal close): method={} route={} status={} errorCode={}",
+                request.getMethod(), routeTemplate(request), errorCode.getHttpStatus().value(), errorCode.name());
             return ResponseEntity.noContent().build();
         }
         return ErrorResponse.of(errorCode);
@@ -75,8 +69,8 @@ public class GlobalExceptionHandler {
         final AllcllErrorCode errorCode = AllcllErrorCode.SERVER_ERROR;
 
         captureException(request, exception, errorCode);
-        log.error(LOG_FORMAT, request.getMethod(), request.getRequestURI(), getRequestBody(request),
-            exception.getMessage(), exception);
+        log.error(LOG_FORMAT, request.getMethod(), routeTemplate(request), errorCode.getHttpStatus().value(),
+            errorCode.name(), exception.getClass().getSimpleName());
         return ErrorResponse.of(errorCode);
     }
 
@@ -87,7 +81,7 @@ public class GlobalExceptionHandler {
     ) {
         Sentry.withScope(scope -> {
             scope.setTag("method", request.getMethod());
-            scope.setTag("path", request.getRequestURI());
+            scope.setTag("path", routeTemplate(request));
             scope.setTag("status", String.valueOf(errorCode.getHttpStatus().value()));
             scope.setTag("errorCode", errorCode.name());
             scope.setTag("exceptionType", exception.getClass().getSimpleName());
@@ -95,16 +89,11 @@ public class GlobalExceptionHandler {
         });
     }
 
-    private String getRequestBody(HttpServletRequest request) {
-        String contentType = request.getContentType();
-        if (contentType != null && contentType.startsWith("multipart/")) {
-            return "[multipart/form-data]";
+    private String routeTemplate(HttpServletRequest request) {
+        Object pattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        if (pattern instanceof String routeTemplate) {
+            return routeTemplate;
         }
-        try (BufferedReader reader = request.getReader()) {
-            return reader.lines().collect(Collectors.joining(System.lineSeparator() + "\t"));
-        } catch (IOException | java.io.UncheckedIOException e) {
-            log.error("Failed to read request body", e);
-            return "";
-        }
+        return "[unmatched]";
     }
 }

--- a/src/main/java/kr/allcll/backend/support/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/allcll/backend/support/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -44,6 +45,18 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
         HttpServletRequest request,
         MethodArgumentNotValidException exception
+    ) {
+        final AllcllErrorCode errorCode = AllcllErrorCode.INVALID_REQUEST_VALUE;
+
+        log.info(LOG_FORMAT, request.getMethod(), routeTemplate(request), errorCode.getHttpStatus().value(),
+            errorCode.name(), exception.getClass().getSimpleName());
+        return ErrorResponse.of(errorCode);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+        HttpServletRequest request,
+        HttpMessageNotReadableException exception
     ) {
         final AllcllErrorCode errorCode = AllcllErrorCode.INVALID_REQUEST_VALUE;
 

--- a/src/main/java/kr/allcll/backend/support/sse/SseEmitterStorage.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseEmitterStorage.java
@@ -26,19 +26,19 @@ public class SseEmitterStorage {
 
     public void add(String token, SseEmitter sseEmitter) {
         emitters.put(token, sseEmitter);
-        log.info("[SSE] 새로운 연결이 추가되었습니다. token: {}, 현재 연결 수: {}", token, emitters.size());
+        log.info("[SSE] 새로운 연결이 추가되었습니다. 현재 연결 수: {}", emitters.size());
         sseEmitter.onTimeout(() -> {
             emitters.remove(token, sseEmitter);
-            log.info("[SSE-onTimeout] 연결이 타임아웃으로 종료되었습니다. token: {}, 현재 연결 수: {}", token, emitters.size());
+            log.info("[SSE-onTimeout] 연결이 타임아웃으로 종료되었습니다. 현재 연결 수: {}", emitters.size());
         });
         sseEmitter.onError(e -> {
             emitters.remove(token, sseEmitter);
-            log.info("[SSE-onError] 연결이 에러로 종료되었습니다. token: {}, error: {}, 현재 연결 수: {}", token, e.getMessage(),
-                emitters.size());
+            log.info("[SSE-onError] 연결이 에러로 종료되었습니다. exceptionType={}, 현재 연결 수: {}",
+                e.getClass().getSimpleName(), emitters.size());
         });
         sseEmitter.onCompletion(() -> {
             emitters.remove(token, sseEmitter);
-            log.info("[SSE-onCompletion] 연결이 정상 완료되었습니다. token: {}, 현재 연결 수: {}", token, emitters.size());
+            log.info("[SSE-onCompletion] 연결이 정상 완료되었습니다. 현재 연결 수: {}", emitters.size());
         });
     }
 

--- a/src/main/java/kr/allcll/backend/support/sse/SseService.java
+++ b/src/main/java/kr/allcll/backend/support/sse/SseService.java
@@ -58,10 +58,9 @@ public class SseService {
             emitter -> {
                 SseEventBuilder eventBuilder = SseEventBuilderFactory.create(eventName, data);
                 sendEventAsync(emitter, eventName, eventBuilder);
-                log.debug("[SSE-propagate] 이벤트 전송 요청. token: {}, eventName: {}", token, eventName);
+                log.debug("[SSE-propagate] 이벤트 전송 요청. eventName={}", eventName);
             },
-            () -> log.warn("[SSE-propagate] 이벤트 전송 요청 실패 - Emitter가 Map에 없음. token: {}, eventName: {}", token,
-                eventName)
+            () -> log.warn("[SSE-propagate] 이벤트 전송 요청 실패 - Emitter가 Map에 없음. eventName={}", eventName)
         );
     }
 
@@ -90,7 +89,7 @@ public class SseService {
         try {
             seatPipelineMetrics.recordSseSend(() -> sseEmitter.send(eventBuilder));
         } catch (Exception e) {
-            log.warn("전송 실패 - SSE 연결이 끊겼습니다.: {}", e.getMessage());
+            log.warn("전송 실패 - SSE 연결이 끊겼습니다. exceptionType={}", e.getClass().getSimpleName());
             SseErrorHandler.handle(e);
         }
     }

--- a/src/test/java/kr/allcll/backend/support/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/kr/allcll/backend/support/exception/GlobalExceptionHandlerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.servlet.HandlerMapping;
 
 class GlobalExceptionHandlerTest {
 
@@ -105,6 +106,7 @@ class GlobalExceptionHandlerTest {
         request.addHeader("Authorization", "Bearer secret");
         request.setCookies(new jakarta.servlet.http.Cookie("accessToken", "secret"));
         request.setContent("{\"password\":\"secret\"}".getBytes());
+        request.setAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, "/api/test");
         return request;
     }
 }

--- a/src/test/java/kr/allcll/backend/support/logging/SensitiveLogMaskingTest.java
+++ b/src/test/java/kr/allcll/backend/support/logging/SensitiveLogMaskingTest.java
@@ -1,0 +1,208 @@
+package kr.allcll.backend.support.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import kr.allcll.backend.domain.graduation.check.cert.GraduationCertResolver;
+import kr.allcll.backend.domain.graduation.check.cert.GraduationCertService;
+import kr.allcll.backend.domain.seat.PinSeatSender;
+import kr.allcll.backend.domain.seat.SeatService;
+import kr.allcll.backend.domain.user.AuthFacade;
+import kr.allcll.backend.domain.user.AuthService;
+import kr.allcll.backend.domain.user.ToscAuthService;
+import kr.allcll.backend.domain.user.User;
+import kr.allcll.backend.domain.user.UserFetcher;
+import kr.allcll.backend.domain.user.UserService;
+import kr.allcll.backend.domain.user.dto.LoginRequest;
+import kr.allcll.backend.domain.user.dto.UserInfo;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.backend.support.exception.GlobalExceptionHandler;
+import kr.allcll.backend.support.metrics.SeatPipelineMetrics;
+import kr.allcll.backend.support.scheduler.ScheduledTaskHandler;
+import kr.allcll.backend.support.sse.SseEmitterStorage;
+import kr.allcll.backend.support.sse.SseService;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class SensitiveLogMaskingTest {
+
+    private final List<LoggerCapture> loggerCaptures = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        loggerCaptures.forEach(LoggerCapture::close);
+    }
+
+    @Test
+    @DisplayName("예외 로그에 요청 본문, query string, raw URI를 남기지 않는다")
+    void globalExceptionHandlerDoesNotLogRequestSensitiveValues() {
+        // given
+        String studentId = "24000001";
+        String password = "password-secret";
+        String token = "query-token-secret";
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/admin/graduation/" + studentId);
+        request.setAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, "/api/admin/graduation/{studentId}");
+        request.setQueryString("token=" + token);
+        request.setContent(("{\"studentId\":\"" + studentId + "\",\"password\":\"" + password + "\"}").getBytes());
+        LoggerCapture capture = capture(GlobalExceptionHandler.class);
+
+        // when
+        new GlobalExceptionHandler().handleAllcllException(
+            request,
+            new AllcllException(AllcllErrorCode.INVALID_REQUEST_VALUE)
+        );
+
+        // then
+        assertThat(capture.messages())
+            .contains("method=POST", "route=/api/admin/graduation/{studentId}", "status=400",
+                "errorCode=INVALID_REQUEST_VALUE");
+        assertThat(capture.messages()).doesNotContain(studentId, password, token);
+    }
+
+    @Test
+    @DisplayName("SSE 로그에 token과 token 목록을 남기지 않는다")
+    void sseComponentsDoNotLogTokens() {
+        // given
+        String token = "sse-token-secret";
+        SseEmitterStorage storage = new SseEmitterStorage();
+        CallbackSseEmitter emitter = new CallbackSseEmitter();
+        LoggerCapture storageCapture = capture(SseEmitterStorage.class);
+        LoggerCapture serviceCapture = capture(SseService.class);
+        storage.add(token, emitter);
+        SseService sseService = new SseService(storage, new SeatPipelineMetrics(new SimpleMeterRegistry()));
+
+        // when
+        emitter.triggerError(new IllegalStateException(token));
+        sseService.propagate(token, "pinSeats", "data");
+
+        // then
+        assertThat(storageCapture.messages()).doesNotContain(token);
+        assertThat(serviceCapture.messages()).contains("eventName=pinSeats").doesNotContain(token);
+    }
+
+    @Test
+    @DisplayName("핀 여석 전송 로그에 token 목록을 남기지 않는다")
+    void pinSeatSenderDoesNotLogTokens() {
+        // given
+        String token = "pin-token-secret";
+        SseService sseService = mock(SseService.class);
+        SeatService seatService = mock(SeatService.class);
+        ScheduledTaskHandler taskHandler = mock(ScheduledTaskHandler.class);
+        PinSeatSender pinSeatSender = new PinSeatSender(sseService, seatService, taskHandler);
+        LoggerCapture capture = capture(PinSeatSender.class);
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        when(taskHandler.getTaskCount()).thenReturn(0);
+        when(sseService.getConnectedTokens()).thenReturn(List.of(token));
+        when(seatService.getPinSeatsByTokens(List.of(token))).thenReturn(Map.of(token, List.of()));
+
+        // when
+        pinSeatSender.send();
+        verify(taskHandler).scheduleAtFixedRate(taskCaptor.capture(), eq(Duration.ofSeconds(1)));
+        taskCaptor.getValue().run();
+
+        // then
+        assertThat(capture.messages()).doesNotContain(token);
+    }
+
+    @Test
+    @DisplayName("인증 후속 처리 실패 로그에 학번, userId, 외부 예외 원문을 남기지 않는다")
+    void authFacadeDoesNotLogAuthenticationSensitiveValues() {
+        // given
+        String studentId = "24000002";
+        String password = "login-password-secret";
+        String externalMessage = "external-auth-response-secret";
+        long userId = 314159L;
+        LoginRequest loginRequest = new LoginRequest(studentId, password);
+        AuthService authService = mock(AuthService.class);
+        UserFetcher userFetcher = mock(UserFetcher.class);
+        UserService userService = mock(UserService.class);
+        ToscAuthService toscAuthService = mock(ToscAuthService.class);
+        GraduationCertService graduationCertService = mock(GraduationCertService.class);
+        GraduationCertResolver graduationCertResolver = mock(GraduationCertResolver.class);
+        AuthFacade authFacade = new AuthFacade(
+            authService,
+            userFetcher,
+            userService,
+            toscAuthService,
+            graduationCertService,
+            graduationCertResolver
+        );
+        User user = mock(User.class);
+        LoggerCapture capture = capture(AuthFacade.class);
+        when(authService.login(loginRequest)).thenReturn(new OkHttpClient());
+        doThrow(new IllegalStateException(externalMessage)).when(toscAuthService).loginTosc(any(), eq(loginRequest));
+        when(userFetcher.fetch(any())).thenReturn(UserInfo.of(studentId, "name", "department"));
+        when(userService.findOrCreate(any())).thenReturn(user);
+        when(user.getId()).thenReturn(userId);
+        when(graduationCertResolver.resolve(eq(user), any())).thenThrow(new IllegalStateException(externalMessage));
+
+        // when
+        authFacade.login(loginRequest);
+
+        // then
+        assertThat(capture.messages()).doesNotContain(studentId, password, String.valueOf(userId), externalMessage);
+    }
+
+    private LoggerCapture capture(Class<?> type) {
+        Logger logger = (Logger) LoggerFactory.getLogger(type);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        LoggerCapture capture = new LoggerCapture(logger, logger.getLevel(), appender);
+        logger.setLevel(Level.DEBUG);
+        logger.addAppender(appender);
+        loggerCaptures.add(capture);
+        return capture;
+    }
+
+    private record LoggerCapture(Logger logger, Level originalLevel, ListAppender<ILoggingEvent> appender) {
+
+        String messages() {
+            return appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .collect(Collectors.joining("\n"));
+        }
+
+        void close() {
+            logger.detachAppender(appender);
+            logger.setLevel(originalLevel);
+            appender.stop();
+        }
+    }
+
+    private static class CallbackSseEmitter extends SseEmitter {
+
+        private java.util.function.Consumer<Throwable> errorCallback;
+
+        @Override
+        public void onError(java.util.function.Consumer<Throwable> callback) {
+            errorCallback = callback;
+        }
+
+        void triggerError(Throwable throwable) {
+            errorCallback.accept(throwable);
+        }
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/logging/SensitiveLogMaskingTest.java
+++ b/src/test/java/kr/allcll/backend/support/logging/SensitiveLogMaskingTest.java
@@ -153,7 +153,7 @@ class SensitiveLogMaskingTest {
         User user = mock(User.class);
         LoggerCapture capture = capture(AuthFacade.class);
         when(authService.login(loginRequest)).thenReturn(new OkHttpClient());
-        doThrow(new IllegalStateException(externalMessage)).when(toscAuthService).loginTosc(any(), eq(loginRequest));
+        doThrow(new IllegalStateException(externalMessage)).when(toscAuthService).loginTosc(eq(loginRequest));
         when(userFetcher.fetch(any())).thenReturn(UserInfo.of(studentId, "name", "department"));
         when(userService.findOrCreate(any())).thenReturn(user);
         when(user.getId()).thenReturn(userId);


### PR DESCRIPTION
## 변경 사항

로키 중앙 로그 수집 전 사전 보안 작업으로, 로그의 민감정보 노출 경로를 제거했습니다.

1. GlobalExceptionHandler
    - request body, query string, raw URI 대신 method, route template, status, errorCode, exceptionType 기록
    - Sentry path 태그도 raw URI 대신 route template 사용
2. SSE
    - emitter token, token 목록, 예외 원문 로그 제거
    - 연결 수, eventName, exceptionType 등 안전한 분류값만 기록
3. PinSeatSender
    - token 목록 및 개별 token 로그 제거
4. AuthFacade
    - 학번, userId, 외부 예외 메시지 로그 제거


## 추후 예정 작업

Loki/Alloy 설정과 배포 구성

---

## Codex Review
- `src/main/java/kr/allcll/backend/domain/user/AuthFacade.java:37` -- "아 개인적으로는 이 에러 로그를 너무 애용(🐈)했었는데,,"

---
- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기