### PR TITLE
[TSK-142] 요청 로그 상관관계를 위한 requestId 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/support/web/RequestIdFilter.java
+++ b/src/main/java/kr/allcll/backend/support/web/RequestIdFilter.java
@@ -1,0 +1,35 @@
+package kr.allcll.backend.support.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    static final String REQUEST_ID_MDC_KEY = "requestId";
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        MDC.put(REQUEST_ID_MDC_KEY, UUID.randomUUID().toString());
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(REQUEST_ID_MDC_KEY);
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -72,9 +72,9 @@
   <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 
   <property name="LOG_PATTERN"
-    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
+    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr([requestId=%X{requestId:-}]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
   <property name="LOG_FILE_PATTERN"
-    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %-5level ${PID:-} --- [%15.15thread] %-40.40logger{36} : %msg%n"/>
+    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %-5level ${PID:-} --- [%15.15thread] [requestId=%X{requestId:-}] %-40.40logger{36} : %msg%n"/>
 
   <!--  ec2와 local 에서의 로그 경로 분리  -->
   <property name="LOG_PATH" value="${LOG_PATH:-/home/ubuntu/app/logs}"/>

--- a/src/test/java/kr/allcll/backend/support/web/RequestIdFilterTest.java
+++ b/src/test/java/kr/allcll/backend/support/web/RequestIdFilterTest.java
@@ -1,0 +1,87 @@
+package kr.allcll.backend.support.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import jakarta.servlet.ServletException;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class RequestIdFilterTest {
+
+    private final RequestIdFilter requestIdFilter = new RequestIdFilter();
+
+    @AfterEach
+    void tearDown() {
+        MDC.remove(RequestIdFilter.REQUEST_ID_MDC_KEY);
+    }
+
+    @Test
+    void 요청_처리_중에는_서버가_생성한_UUID_requestId가_MDC에_있고_응답은_그대로_전달된다() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Request-Id", "client-supplied-request-id");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicReference<String> requestIdDuringRequest = new AtomicReference<>();
+
+        requestIdFilter.doFilter(request, response, (servletRequest, servletResponse) -> {
+            requestIdDuringRequest.set(MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY));
+            response.setStatus(HttpStatus.CREATED.value());
+            response.getWriter().write("unchanged-response");
+        });
+
+        assertThat(requestIdDuringRequest.get()).isNotNull().isNotEqualTo("client-supplied-request-id");
+        assertThatCode(() -> UUID.fromString(requestIdDuringRequest.get())).doesNotThrowAnyException();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.getContentAsString()).isEqualTo("unchanged-response");
+        assertThat(MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY)).isNull();
+    }
+
+    @Test
+    void 요청_처리_중_예외가_발생해도_requestId를_MDC에서_제거한다() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> requestIdFilter.doFilter(request, response,
+            (servletRequest, servletResponse) -> {
+                throw new ServletException("request failed");
+            }))
+            .isInstanceOf(ServletException.class);
+
+        assertThat(MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY)).isNull();
+    }
+
+    @Test
+    void UUID_requestId는_로그_패턴에_출력될_수_있다() {
+        String requestId = UUID.randomUUID().toString();
+        MDC.put(RequestIdFilter.REQUEST_ID_MDC_KEY, requestId);
+
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        PatternLayout layout = new PatternLayout();
+        layout.setContext(loggerContext);
+        layout.setPattern("[requestId=%X{requestId:-}] %msg%n");
+        layout.start();
+
+        Logger logger = loggerContext.getLogger(RequestIdFilterTest.class);
+        LoggingEvent event = new LoggingEvent(
+            RequestIdFilterTest.class.getName(), logger, Level.INFO, "request completed", null, null
+        );
+
+        assertThat(layout.doLayout(event))
+            .isEqualTo("[requestId=" + requestId + "] request completed" + System.lineSeparator());
+
+        layout.stop();
+    }
+}


### PR DESCRIPTION
## 🌁 배경

[#390](https://github.com/allcll/allcll-backend/pull/390)에서 민감정보가 로그에 남지 않도록 마스킹 작업을 진행했습니다.

이후 Loki에서 장애 시점의 로그를 확인할 때, 개인정보 없이도 하나의 HTTP 요청에서 발생한 로그를 묶어 볼 수 있는 식별자가 필요했습니다.

## 🤔 고려한 방법들

1. 별도 마스킹, 상관관계 없이 기존 로그를 유지한다.
2. 민감정보를 모두 마스킹한다.
3. 전체 마스킹 후 요청 로그 상관관계를 위한 ID를 도입한다.
4. Loki로 전송하는 시점에 별도 마스킹을 적용한다.

위 방법들 중 논의 결과 3번 방향을 선택했습니다.  
(구체적인 비교 내용은 노션에 정리 후 공유드리겠습니다!)

다만 이번 PR에서는 Micrometer Tracing, OpenTelemetry, Tempo처럼 여러 서비스까지 연결하는 `traceId`는 아직 도입하지 않았으며,
백엔드 내부의 동기 HTTP 요청 로그를 묶는 최소 단위인 `requestId`를 적용했습니다.

## ✏️ 변경 사항

- 모든 HTTP 요청마다 서버가 UUID 기반 `requestId`를 새로 생성
- 요청 처리 중 MDC에 `requestId` 저장
- 요청 종료 시 `finally`에서 MDC 값 제거
- 콘솔·파일 로그 패턴에 `[requestId=...]` 출력
- 외부 `X-Request-Id` 헤더는 사용하지 않음
- 기존 API 응답, 비즈니스 로직, 로그 레벨은 변경하지 않음

## 📝 로그 조회 예시

Loki 도입 후 아래처럼 특정 요청의 로그를 조회할 수 있습니다.

```logql
{application="backend", env="prod"} |= "requestId=550e8400-e29b-41d4-a716-446655440000"