### PR TITLE
[TSK-143] Loki 기반 오류 로그 수집 구성

### DIFF
--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -1,0 +1,18 @@
+loki.source.file "allcll_error" {
+  tail_from_end           = true
+  targets = [
+    {
+      "__path__"    = "/var/log/allcll/spring-boot-application-error.log",
+      "application" = "backend",
+      "env"         = "prod",
+      "level"       = "error",
+    },
+  ]
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/observability/compose.prod.yml
+++ b/observability/compose.prod.yml
@@ -32,7 +32,36 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
+      - loki
+
+  loki:
+    image: grafana/loki:3.2.0
+    container_name: allcll-loki
+    restart: unless-stopped
+    command:
+      - "-config.file=/etc/loki/config.yml"
+    volumes:
+      - ./loki/config.yml:/etc/loki/config.yml:ro
+      - loki-data:/loki
+
+  alloy:
+    image: grafana/alloy:v1.5.1
+    container_name: allcll-alloy
+    restart: unless-stopped
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/var/lib/alloy/data
+      - --server.http.listen-addr=127.0.0.1:12345
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - ../logs:/var/log/allcll:ro
+      - alloy-data:/var/lib/alloy/data
+    depends_on:
+      - loki
 
 volumes:
   prometheus-data:
   grafana-data:
+  loki-data:
+  alloy-data:

--- a/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/observability/grafana/provisioning/datasources/prometheus.yml
@@ -8,3 +8,10 @@ datasources:
     url: http://prometheus:9090
     isDefault: true
     editable: true
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: true

--- a/observability/loki/config.yml
+++ b/observability/loki/config.yml
@@ -1,0 +1,37 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+
+schema_config:
+  configs:
+    - from: "2024-04-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 168h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
+analytics:
+  reporting_enabled: false

--- a/src/main/java/kr/allcll/backend/support/web/RequestIdFilter.java
+++ b/src/main/java/kr/allcll/backend/support/web/RequestIdFilter.java
@@ -1,0 +1,35 @@
+package kr.allcll.backend.support.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    static final String REQUEST_ID_MDC_KEY = "requestId";
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        MDC.put(REQUEST_ID_MDC_KEY, UUID.randomUUID().toString());
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(REQUEST_ID_MDC_KEY);
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -72,9 +72,9 @@
   <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 
   <property name="LOG_PATTERN"
-    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
+    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr([requestId=%X{requestId:-}]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
   <property name="LOG_FILE_PATTERN"
-    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %-5level ${PID:-} --- [%15.15thread] %-40.40logger{36} : %msg%n"/>
+    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %-5level ${PID:-} --- [%15.15thread] [requestId=%X{requestId:-}] %-40.40logger{36} : %msg%n"/>
 
   <!--  ec2와 local 에서의 로그 경로 분리  -->
   <property name="LOG_PATH" value="${LOG_PATH:-/home/ubuntu/app/logs}"/>

--- a/src/test/java/kr/allcll/backend/support/web/RequestIdFilterTest.java
+++ b/src/test/java/kr/allcll/backend/support/web/RequestIdFilterTest.java
@@ -1,0 +1,87 @@
+package kr.allcll.backend.support.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import jakarta.servlet.ServletException;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class RequestIdFilterTest {
+
+    private final RequestIdFilter requestIdFilter = new RequestIdFilter();
+
+    @AfterEach
+    void tearDown() {
+        MDC.remove(RequestIdFilter.REQUEST_ID_MDC_KEY);
+    }
+
+    @Test
+    void 요청_처리_중에는_서버가_생성한_UUID_requestId가_MDC에_있고_응답은_그대로_전달된다() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Request-Id", "client-supplied-request-id");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicReference<String> requestIdDuringRequest = new AtomicReference<>();
+
+        requestIdFilter.doFilter(request, response, (servletRequest, servletResponse) -> {
+            requestIdDuringRequest.set(MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY));
+            response.setStatus(HttpStatus.CREATED.value());
+            response.getWriter().write("unchanged-response");
+        });
+
+        assertThat(requestIdDuringRequest.get()).isNotNull().isNotEqualTo("client-supplied-request-id");
+        assertThatCode(() -> UUID.fromString(requestIdDuringRequest.get())).doesNotThrowAnyException();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.getContentAsString()).isEqualTo("unchanged-response");
+        assertThat(MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY)).isNull();
+    }
+
+    @Test
+    void 요청_처리_중_예외가_발생해도_requestId를_MDC에서_제거한다() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> requestIdFilter.doFilter(request, response,
+            (servletRequest, servletResponse) -> {
+                throw new ServletException("request failed");
+            }))
+            .isInstanceOf(ServletException.class);
+
+        assertThat(MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY)).isNull();
+    }
+
+    @Test
+    void UUID_requestId는_로그_패턴에_출력될_수_있다() {
+        String requestId = UUID.randomUUID().toString();
+        MDC.put(RequestIdFilter.REQUEST_ID_MDC_KEY, requestId);
+
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        PatternLayout layout = new PatternLayout();
+        layout.setContext(loggerContext);
+        layout.setPattern("[requestId=%X{requestId:-}] %msg%n");
+        layout.start();
+
+        Logger logger = loggerContext.getLogger(RequestIdFilterTest.class);
+        LoggingEvent event = new LoggingEvent(
+            RequestIdFilterTest.class.getName(), logger, Level.INFO, "request completed", null, null
+        );
+
+        assertThat(layout.doLayout(event))
+            .isEqualTo("[requestId=" + requestId + "] request completed" + System.lineSeparator());
+
+        layout.stop();
+    }
+}


### PR DESCRIPTION
운영 compose에 Loki와 Grafana Alloy를 추가했습니다.

## 작업 내용

Alloy가 prod ERROR 로그 파일을 Loki로 수집하도록 구성했습니다.

- Grafana provisioning에 Loki datasource를 추가했습니다.
- Loki는 파일시스템 TSDB와 7일 retention을 사용하며, Loki·Alloy 포트는 외부에 노출하지 않습니다.
- 최초 기동 시 과거 로그를 재수집하지 않고 이후 생성되는 ERROR 로그부터 수집합니다.

## 검증

- Docker Compose 설정 검증
- Loki·Alloy 실제 컨테이너 기동 확인
- Alloy ERROR 로그 tailer 및 Loki writer 로드 확인

## 고민 지점

- 현재는 ERROR 로그만 수집하는데, WARN/INFO 로그 수집 계획은 없으신가요?