### PR TITLE
[TSK-140-2] 모니터링 메트릭의 초기 미등록 문제 수정

### DIFF
--- a/src/main/java/kr/allcll/backend/support/batch/AbstractBatch.java
+++ b/src/main/java/kr/allcll/backend/support/batch/AbstractBatch.java
@@ -27,6 +27,7 @@ public abstract class AbstractBatch<T> {
         this.oldestPendingAtMillis = new AtomicLong(0);
         this.seatPipelineMetrics.registerBatchQueueSize(type, queue);
         this.seatPipelineMetrics.registerBatchOldestPendingAge(type, oldestPendingAtMillis);
+        this.seatPipelineMetrics.registerBatchFlushMetrics(type);
     }
 
     public void add(T item) {

--- a/src/main/java/kr/allcll/backend/support/metrics/SeatPipelineMetrics.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/SeatPipelineMetrics.java
@@ -110,6 +110,10 @@ public class SeatPipelineMetrics {
             .increment();
     }
 
+    public void registerSchedulerTask(String task) {
+        schedulerLastSuccessEpochSeconds.computeIfAbsent(task, this::registerSchedulerGauge);
+    }
+
     public void recordSchedulerTaskSuccess(String task) {
         AtomicLong lastSuccess = schedulerLastSuccessEpochSeconds.computeIfAbsent(task, this::registerSchedulerGauge);
         lastSuccess.set(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()));

--- a/src/main/java/kr/allcll/backend/support/metrics/SeatPipelineMetrics.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/SeatPipelineMetrics.java
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -18,15 +19,34 @@ public class SeatPipelineMetrics {
     private static final String TYPE_TAG = "type";
     private static final String TASK_TAG = "task";
     private static final String EVENT_TAG = "event";
+    private static final List<String> SSE_EVENT_NAMES = List.of(
+        "connection",
+        "nonMajorSeats",
+        "pinSeats"
+    );
 
     private final MeterRegistry meterRegistry;
     private final AtomicLong seatCrawlerActive = new AtomicLong(0);
     private final AtomicLong seatSseSchedulerActive = new AtomicLong(0);
     private final AtomicLong lastCrawledAtMillis = new AtomicLong(0);
+    private final Map<String, Counter> batchFlushFailureCounters = new ConcurrentHashMap<>();
+    private final Map<String, Timer> batchFlushDurationTimers = new ConcurrentHashMap<>();
+    private final Map<String, Counter> sseEventCoalescedCounters = new ConcurrentHashMap<>();
     private final Map<String, AtomicLong> schedulerLastSuccessEpochSeconds = new ConcurrentHashMap<>();
+    private final Counter sseSendFailureCounter;
+    private final Timer sseSendDurationTimer;
 
     public SeatPipelineMetrics(MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;
+        this.sseSendFailureCounter = Counter.builder("sse.send.failure.count")
+            .register(meterRegistry);
+        this.sseSendDurationTimer = Timer.builder("sse.send.duration")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+        SSE_EVENT_NAMES.forEach(eventName -> sseEventCoalescedCounters.computeIfAbsent(
+            eventName,
+            this::registerSseEventCoalescedCounter
+        ));
         Gauge.builder("seat.crawler.active", seatCrawlerActive, AtomicLong::get)
             .register(meterRegistry);
         Gauge.builder("seat.sse.scheduler.active", seatSseSchedulerActive, AtomicLong::get)
@@ -69,21 +89,25 @@ public class SeatPipelineMetrics {
             .register(meterRegistry);
     }
 
+    public void registerBatchFlushMetrics(String type) {
+        batchFlushFailureCounters.computeIfAbsent(type, this::registerBatchFlushFailureCounter);
+        batchFlushDurationTimers.computeIfAbsent(type, this::registerBatchFlushDurationTimer);
+    }
+
     public void recordBatchFlush(String type, ThrowingRunnable runnable) {
+        Counter failureCounter = batchFlushFailureCounters.computeIfAbsent(
+            type,
+            this::registerBatchFlushFailureCounter
+        );
+        Timer durationTimer = batchFlushDurationTimers.computeIfAbsent(type, this::registerBatchFlushDurationTimer);
         Timer.Sample sample = Timer.start(meterRegistry);
         try {
             runnable.run();
         } catch (Exception e) {
-            Counter.builder("seat.batch.flush.failure.count")
-                .tags(TYPE_TAG, type)
-                .register(meterRegistry)
-                .increment();
+            failureCounter.increment();
             throwAsUnchecked(e);
         } finally {
-            sample.stop(Timer.builder("seat.batch.flush.duration")
-                .tags(TYPE_TAG, type)
-                .publishPercentileHistogram()
-                .register(meterRegistry));
+            sample.stop(durationTimer);
         }
     }
 
@@ -92,22 +116,18 @@ public class SeatPipelineMetrics {
         try {
             runnable.run();
         } catch (Exception e) {
-            Counter.builder("sse.send.failure.count")
-                .register(meterRegistry)
-                .increment();
+            sseSendFailureCounter.increment();
             throw e;
         } finally {
-            sample.stop(Timer.builder("sse.send.duration")
-                .publishPercentileHistogram()
-                .register(meterRegistry));
+            sample.stop(sseSendDurationTimer);
         }
     }
 
     public void recordSseEventCoalesced(String eventName) {
-        Counter.builder("sse.event.coalesced")
-            .tags(EVENT_TAG, eventName)
-            .register(meterRegistry)
-            .increment();
+        sseEventCoalescedCounters.computeIfAbsent(
+            eventName,
+            this::registerSseEventCoalescedCounter
+        ).increment();
     }
 
     public void registerSchedulerTask(String task) {
@@ -125,6 +145,25 @@ public class SeatPipelineMetrics {
             .tags(Tags.of(TASK_TAG, task))
             .register(meterRegistry);
         return lastSuccess;
+    }
+
+    private Counter registerBatchFlushFailureCounter(String type) {
+        return Counter.builder("seat.batch.flush.failure.count")
+            .tags(TYPE_TAG, type)
+            .register(meterRegistry);
+    }
+
+    private Timer registerBatchFlushDurationTimer(String type) {
+        return Timer.builder("seat.batch.flush.duration")
+            .tags(TYPE_TAG, type)
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+    }
+
+    private Counter registerSseEventCoalescedCounter(String eventName) {
+        return Counter.builder("sse.event.coalesced")
+            .tags(EVENT_TAG, eventName)
+            .register(meterRegistry);
     }
 
     private double getLastCrawledAgeSeconds(AtomicLong lastCrawledAtMillis) {

--- a/src/main/java/kr/allcll/backend/support/scheduler/ScheduledTaskHandler.java
+++ b/src/main/java/kr/allcll/backend/support/scheduler/ScheduledTaskHandler.java
@@ -36,6 +36,9 @@ public class ScheduledTaskHandler {
         scheduler.initialize();
         this.seatPipelineMetrics = seatPipelineMetrics;
         this.taskName = resolveTaskName(namePrefix);
+        if (seatPipelineMetrics != null) {
+            seatPipelineMetrics.registerSchedulerTask(taskName);
+        }
 
         ExecutorServiceMetrics.monitor(meterRegistry, scheduler.getScheduledExecutor(), namePrefix);
     }

--- a/src/test/java/kr/allcll/backend/support/batch/AbstractBatchMetricsTest.java
+++ b/src/test/java/kr/allcll/backend/support/batch/AbstractBatchMetricsTest.java
@@ -15,6 +15,26 @@ import org.junit.jupiter.api.Test;
 class AbstractBatchMetricsTest {
 
     @Test
+    @DisplayName("batch flush 메트릭은 첫 flush 전부터 0으로 등록된다.")
+    void initializesBatchFlushMetrics() {
+        // given
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+        // when
+        new TestBatch(new SeatPipelineMetrics(meterRegistry), "general");
+
+        // then
+        assertThat(meterRegistry.get("seat.batch.flush.failure.count")
+            .tag("type", "general")
+            .counter()
+            .count()).isZero();
+        assertThat(meterRegistry.get("seat.batch.flush.duration")
+            .tag("type", "general")
+            .timer()
+            .count()).isZero();
+    }
+
+    @Test
     @DisplayName("batch queue size gauge는 현재 큐 크기를 반영한다.")
     void batchQueueSizeGauge() {
         // given

--- a/src/test/java/kr/allcll/backend/support/metrics/SeatPipelineMetricsTest.java
+++ b/src/test/java/kr/allcll/backend/support/metrics/SeatPipelineMetricsTest.java
@@ -3,10 +3,35 @@ package kr.allcll.backend.support.metrics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class SeatPipelineMetricsTest {
+
+    private static final List<String> SSE_EVENT_NAMES = List.of(
+        "connection",
+        "nonMajorSeats",
+        "pinSeats"
+    );
+
+    @Test
+    @DisplayName("SSE 메트릭은 첫 이벤트 전부터 0으로 등록된다.")
+    void initializesSseMetrics() {
+        // given
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+        // when
+        new SeatPipelineMetrics(meterRegistry);
+
+        // then
+        assertThat(meterRegistry.get("sse.send.failure.count").counter().count()).isZero();
+        assertThat(meterRegistry.get("sse.send.duration").timer().count()).isZero();
+        SSE_EVENT_NAMES.forEach(eventName -> assertThat(meterRegistry.get("sse.event.coalesced")
+            .tag("event", eventName)
+            .counter()
+            .count()).isZero());
+    }
 
     @Test
     @DisplayName("크롤러 시작과 중지에 따라 active gauge가 갱신된다.")

--- a/src/test/java/kr/allcll/backend/support/scheduler/ScheduledTaskHandlerTest.java
+++ b/src/test/java/kr/allcll/backend/support/scheduler/ScheduledTaskHandlerTest.java
@@ -14,6 +14,28 @@ import org.junit.jupiter.api.Test;
 class ScheduledTaskHandlerTest {
 
     @Test
+    @DisplayName("스케줄러 handler 생성 시 마지막 성공 시각 gauge를 미리 등록한다.")
+    void initializesLastSuccessTimestampGauge() {
+        // given
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        SeatPipelineMetrics seatPipelineMetrics = new SeatPipelineMetrics(meterRegistry);
+
+        // when
+        new ScheduledTaskHandler(1, "general-seat-sender", meterRegistry, seatPipelineMetrics);
+        new ScheduledTaskHandler(20, "pin-seat-sender", meterRegistry, seatPipelineMetrics);
+
+        // then
+        assertThat(meterRegistry.get("scheduler.task.last.success.timestamp")
+            .tag("task", "general-seat")
+            .gauge()
+            .value()).isZero();
+        assertThat(meterRegistry.get("scheduler.task.last.success.timestamp")
+            .tag("task", "pin-seat")
+            .gauge()
+            .value()).isZero();
+    }
+
+    @Test
     @DisplayName("스케줄링 작업을 등록한다.")
     void scheduledTask() {
         // given


### PR DESCRIPTION
## 작업 배경

일부 커스텀 메트릭이 첫 성공이나 첫 실패가 발생한 후에야 생성되고 있었습니다.

이 때문에 애플리케이션 배포 직후 Grafana에서 `No Data`로 판단하거나, Prometheus가 첫 번째 실패 증가를 정상적으로 관측하지 못할 수 있었습니다.

## 변경 사항

1. SSE scheduler 생성 시 마지막 성공 시각 메트릭을 `0`으로 미리 등록
  - `general-seat`
  - `pin-seat`
2. Batch 생성 시 flush 메트릭을 미리 등록
  - 실패 횟수
  - 처리 시간
  - `general`, `pin` 구분
3. SSE 메트릭을 첫 이벤트 전부터 미리 등록
  - 전송 실패 횟수
  - 전송 시간
  - 이벤트 병합 횟수
- 실제 성공·실패 발생 시 기존과 동일하게 메트릭 값이 갱신되도록 유지

## 기대 효과

- 배포 직후 발생하는 잘못된 `DatasourceNoData` 방지
- Batch 및 SSE의 첫 번째 실패 누락 방지
- Prometheus에서 주요 메트릭을 초기값 `0`부터 안정적으로 수집

## 테스트

- 메트릭이 첫 이벤트 전부터 `0`으로 등록되는지 검증
- Scheduler 성공 시 마지막 성공 시각이 갱신되는지 검증
- Batch/SSE 성공 및 실패 메트릭이 기존처럼 기록되는지 검증

## 운영 설정

Grafana에서는 별도로 다음 설정을 적용했습니다.

- SSE stale 기준: 30초, `For 1m`
- SSE,Batch Queue,Crawler: `No Data=Normal`, `Error=Error`
- Backend Down 및 Hikari 알림 severity 정리