### PR TITLE
[TSK-140-3] 운영 시작 오류 로그 수집 누락 방지

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -99,6 +99,23 @@ jobs:
           mkdir -p ${{ secrets.APP_DIR }}
           cp build/libs/*-SNAPSHOT.jar ${{ secrets.APP_DIR }}/server.jar
 
+      - name: Prepare Application Logs
+        run: |
+          sudo mkdir -p "${{ secrets.APP_DIR }}/logs"
+          if [ ! -f "${{ secrets.APP_DIR }}/logs/spring-boot-application-error.log" ]; then
+            sudo touch "${{ secrets.APP_DIR }}/logs/spring-boot-application-error.log"
+          fi
+
+      - name: Deploy Observability
+        run: |
+          mkdir -p ${{ secrets.APP_DIR }}/observability
+          cp -R observability/. ${{ secrets.APP_DIR }}/observability/
+          printf 'GRAFANA_ADMIN_PASSWORD=%s\n' "${GRAFANA_ADMIN_PASSWORD}" > ${{ secrets.APP_DIR }}/observability/.env
+          chmod 600 ${{ secrets.APP_DIR }}/observability/.env
+
+          cd ${{ secrets.APP_DIR }}/observability
+          docker compose -f compose.prod.yml up -d
+
       - name: Stop Existing Application
         run: |
           set -x
@@ -112,9 +129,6 @@ jobs:
 
       - name: Run Application
         run: |
-          echo "Creating logs directory..."
-          mkdir -p ${{ secrets.APP_DIR }}/logs
-          
           echo "Starting new application..."
           sudo -E nohup java \
           -Dspring.profiles.active=prod \
@@ -123,13 +137,3 @@ jobs:
           -Dlogging.file.path=${{ secrets.APP_DIR }}/logs \
           -DEMAIL_PASSWORD="${EMAIL_PASSWORD}" \
           -jar ${{ secrets.APP_DIR }}/server.jar & 
-
-      - name: Deploy Observability
-        run: |
-          mkdir -p ${{ secrets.APP_DIR }}/observability
-          cp -R observability/. ${{ secrets.APP_DIR }}/observability/
-          printf 'GRAFANA_ADMIN_PASSWORD=%s\n' "${GRAFANA_ADMIN_PASSWORD}" > ${{ secrets.APP_DIR }}/observability/.env
-          chmod 600 ${{ secrets.APP_DIR }}/observability/.env
-
-          cd ${{ secrets.APP_DIR }}/observability
-          docker compose -f compose.prod.yml up -d

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -116,6 +116,23 @@ jobs:
           cd ${{ secrets.APP_DIR }}/observability
           docker compose -f compose.prod.yml up -d
 
+      - name: Wait for Loki and Alloy
+        run: |
+          for attempt in {1..30}; do
+            if docker exec allcll-loki /busybox/wget -q --spider http://127.0.0.1:3100/ready \
+              && docker exec allcll-alloy /usr/bin/timeout 2 /usr/bin/bash -c \
+                'exec 3<>/dev/tcp/127.0.0.1/12345 && printf "GET /-/healthy HTTP/1.0\r\n\r\n" >&3 && grep -q "200 OK" <&3'; then
+              echo "Loki and Alloy are ready."
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Loki or Alloy did not become ready."
+          docker logs allcll-loki || true
+          docker logs allcll-alloy || true
+          exit 1
+
       - name: Stop Existing Application
         run: |
           set -x


### PR DESCRIPTION
## 작업 배경

[PR #395 리뷰](https://github.com/allcll/allcll-backend/pull/395#discussion_r3757155535)에서 백엔드가 Alloy보다 먼저 실행되어, 백엔드 시작 과정에서 발생한 ERROR 로그가 Loki에 수집되지 않을 수 있는 문제가 확인되었습니다.

쉽게 말하면 로그 수집기를 켜기 전에 백엔드를 실행하고 있어서, 백엔드가 켜지는 순간 발생한 오류를 놓칠 수 있었습니다.

## 변경 내용

- ERROR 로그 파일이 없으면 미리 생성합니다.
- Loki와 Alloy를 먼저 실행합니다.
- 로그 수집기가 실행된 뒤 기존 백엔드를 종료하고 새 백엔드를 시작합니다.
- `tail_from_end=true`는 유지해 기존 과거 로그는 수집하지 않습니다.

---

## Codex Review
- `.github/workflows/deploy-to-prod.yml:117` -- "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Add a readiness gate before starting the app**"

---
- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기