### PR TITLE
fix: [AI] 운영 모니터링 Compose 프로젝트명 유지

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -114,7 +114,7 @@ jobs:
           chmod 600 ${{ secrets.APP_DIR }}/observability/.env
 
           cd ${{ secrets.APP_DIR }}/observability
-          docker compose -f compose.prod.yml up -d
+          docker compose -p monitoring -f compose.prod.yml up -d
 
       - name: Wait for Loki and Alloy
         run: |


### PR DESCRIPTION
## 작업 내용

- 운영 배포 워크플로의 Compose 실행에 `-p monitoring`을 지정했습니다.

## 고민 지점과 리뷰 포인트

- release-1.0에만 있던 Compose 프로젝트명을 main에도 반영해, 다음 main → release-1.0 승격 시 배포 워크플로 충돌이 나지 않도록 했습니다.

## 관련 이슈

- 없음