### PR TITLE
[TSK-146] 엔드포인트별 요청당 DB 쿼리 수 및 실행 시간 메트릭 수집

### DIFF
--- a/src/main/java/kr/allcll/backend/config/QueryMetricsConfig.java
+++ b/src/main/java/kr/allcll/backend/config/QueryMetricsConfig.java
@@ -1,0 +1,78 @@
+package kr.allcll.backend.config;
+
+import java.util.Map;
+import java.util.Set;
+import kr.allcll.backend.support.metrics.QueryMetrics;
+import kr.allcll.backend.support.metrics.QueryStatsSessionListener;
+import kr.allcll.backend.support.web.QueryMetricsFilter;
+import org.hibernate.cfg.AvailableSettings;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.servlet.mvc.condition.PathPatternsRequestCondition;
+import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+@Configuration
+@ConditionalOnProperty(prefix = "allcll.metrics.query", name = "enabled", matchIfMissing = true)
+public class QueryMetricsConfig {
+
+    /*
+    RequestIdFilter(HIGHEST_PRECEDENCE) 다음에 두어 집계 로그가 requestId 와 함께 남도록 한다.
+     */
+    private static final int QUERY_METRICS_FILTER_ORDER = Ordered.HIGHEST_PRECEDENCE + 10;
+
+    @Bean
+    public HibernatePropertiesCustomizer queryStatsSessionListenerCustomizer() {
+        return this::registerSessionListener;
+    }
+
+    @Bean
+    public FilterRegistrationBean<QueryMetricsFilter> queryMetricsFilterRegistration(QueryMetrics queryMetrics) {
+        FilterRegistrationBean<QueryMetricsFilter> registration =
+            new FilterRegistrationBean<>(new QueryMetricsFilter(queryMetrics));
+        registration.setOrder(QUERY_METRICS_FILTER_ORDER);
+        return registration;
+    }
+
+    @Bean
+    public ApplicationListener<ApplicationReadyEvent> queryMetricsEndpointRegistrar(
+        QueryMetrics queryMetrics,
+        ObjectProvider<RequestMappingHandlerMapping> handlerMappings
+    ) {
+        return event -> handlerMappings.stream()
+            .flatMap(handlerMapping -> handlerMapping.getHandlerMethods().keySet().stream())
+            .flatMap(mappingInfo -> uriPatterns(mappingInfo).stream())
+            .distinct()
+            .forEach(queryMetrics::registerEndpoint);
+    }
+
+    private Set<String> uriPatterns(RequestMappingInfo mappingInfo) {
+        PathPatternsRequestCondition pathPatterns = mappingInfo.getPathPatternsCondition();
+        if (pathPatterns != null) {
+            return pathPatterns.getPatternValues();
+        }
+        PatternsRequestCondition patterns = mappingInfo.getPatternsCondition();
+        if (patterns != null) {
+            return patterns.getPatterns();
+        }
+        return Set.of();
+    }
+
+    /*
+    Hibernate 가 세션마다 인스턴스를 직접 만들기 때문에 인스턴스가 아니라 클래스 이름으로 지정한다.
+     */
+    private void registerSessionListener(Map<String, Object> hibernateProperties) {
+        hibernateProperties.put(
+            AvailableSettings.AUTO_SESSION_EVENTS_LISTENER,
+            QueryStatsSessionListener.class.getName()
+        );
+    }
+}

--- a/src/main/java/kr/allcll/backend/config/QueryMetricsConfig.java
+++ b/src/main/java/kr/allcll/backend/config/QueryMetricsConfig.java
@@ -15,6 +15,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.mvc.condition.PathPatternsRequestCondition;
 import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
@@ -49,9 +50,16 @@ public class QueryMetricsConfig {
     ) {
         return event -> handlerMappings.stream()
             .flatMap(handlerMapping -> handlerMapping.getHandlerMethods().keySet().stream())
-            .flatMap(mappingInfo -> uriPatterns(mappingInfo).stream())
-            .distinct()
-            .forEach(queryMetrics::registerEndpoint);
+            .forEach(mappingInfo -> registerEndpoints(queryMetrics, mappingInfo));
+    }
+
+    private void registerEndpoints(QueryMetrics queryMetrics, RequestMappingInfo mappingInfo) {
+        Set<String> uriPatterns = uriPatterns(mappingInfo);
+        for (RequestMethod httpMethod : mappingInfo.getMethodsCondition().getMethods()) {
+            for (String uriPattern : uriPatterns) {
+                queryMetrics.registerEndpoint(httpMethod.name(), uriPattern);
+            }
+        }
     }
 
     private Set<String> uriPatterns(RequestMappingInfo mappingInfo) {
@@ -66,9 +74,6 @@ public class QueryMetricsConfig {
         return Set.of();
     }
 
-    /*
-    Hibernate 가 세션마다 인스턴스를 직접 만들기 때문에 인스턴스가 아니라 클래스 이름으로 지정한다.
-     */
     private void registerSessionListener(Map<String, Object> hibernateProperties) {
         hibernateProperties.put(
             AvailableSettings.AUTO_SESSION_EVENTS_LISTENER,

--- a/src/main/java/kr/allcll/backend/support/metrics/QueryMetrics.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/QueryMetrics.java
@@ -22,6 +22,7 @@ public class QueryMetrics {
 
     private static final String QUERY_COUNT_METER_NAME = "db.query.count";
     private static final String QUERY_TIME_METER_NAME = "db.query.time";
+    private static final String METHOD_TAG = "method";
     private static final String URI_TAG = "uri";
 
     private static final double[] QUERY_COUNT_BUCKETS = {1, 2, 3, 5, 10, 20, 50, 100, 500, 1_000, 5_000};
@@ -33,44 +34,46 @@ public class QueryMetrics {
     };
 
     private final MeterRegistry meterRegistry;
-    private final Map<String, DistributionSummary> queryCountSummaries = new ConcurrentHashMap<>();
-    private final Map<String, Timer> queryTimeTimers = new ConcurrentHashMap<>();
+    private final Map<Endpoint, DistributionSummary> queryCountSummaries = new ConcurrentHashMap<>();
+    private final Map<Endpoint, Timer> queryTimeTimers = new ConcurrentHashMap<>();
 
     public QueryMetrics(MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;
     }
 
-    /**
-     * @param uriTemplate 실제 경로가 아니라 핸들러 매핑 패턴(/api/baskets/{subjectId}). 경로를 넘기면 시계열이 무한히 늘어난다.
-     */
-    public void registerEndpoint(String uriTemplate) {
-        queryCountSummaries.computeIfAbsent(uriTemplate, this::registerQueryCountSummary);
-        queryTimeTimers.computeIfAbsent(uriTemplate, this::registerQueryTimeTimer);
+    public void registerEndpoint(String httpMethod, String uriTemplate) {
+        Endpoint endpoint = new Endpoint(httpMethod, uriTemplate);
+        queryCountSummaries.computeIfAbsent(endpoint, this::registerQueryCountSummary);
+        queryTimeTimers.computeIfAbsent(endpoint, this::registerQueryTimeTimer);
     }
 
-    /**
-     * @param uriTemplate 실제 경로가 아니라 핸들러 매핑 패턴(/api/baskets/{subjectId}). 경로를 넘기면 시계열이 무한히 늘어난다.
-     */
-    public void record(String uriTemplate, RequestQueryStats queryStats) {
-        queryCountSummaries.computeIfAbsent(uriTemplate, this::registerQueryCountSummary)
+    public void record(String httpMethod, String uriTemplate, RequestQueryStats queryStats) {
+        Endpoint endpoint = new Endpoint(httpMethod, uriTemplate);
+        queryCountSummaries.computeIfAbsent(endpoint, this::registerQueryCountSummary)
             .record(queryStats.statementCount());
-        queryTimeTimers.computeIfAbsent(uriTemplate, this::registerQueryTimeTimer)
+        queryTimeTimers.computeIfAbsent(endpoint, this::registerQueryTimeTimer)
             .record(queryStats.executionNanos(), TimeUnit.NANOSECONDS);
     }
 
-    private DistributionSummary registerQueryCountSummary(String uriTemplate) {
+    private DistributionSummary registerQueryCountSummary(Endpoint endpoint) {
         return DistributionSummary.builder(QUERY_COUNT_METER_NAME)
             .description("요청 1건이 발행한 SQL 문 수")
-            .tag(URI_TAG, uriTemplate)
+            .tag(METHOD_TAG, endpoint.httpMethod())
+            .tag(URI_TAG, endpoint.uriTemplate())
             .serviceLevelObjectives(QUERY_COUNT_BUCKETS)
             .register(meterRegistry);
     }
 
-    private Timer registerQueryTimeTimer(String uriTemplate) {
+    private Timer registerQueryTimeTimer(Endpoint endpoint) {
         return Timer.builder(QUERY_TIME_METER_NAME)
             .description("요청 1건이 SQL 실행에 쓴 시간")
-            .tag(URI_TAG, uriTemplate)
+            .tag(METHOD_TAG, endpoint.httpMethod())
+            .tag(URI_TAG, endpoint.uriTemplate())
             .serviceLevelObjectives(QUERY_TIME_BUCKETS)
             .register(meterRegistry);
+    }
+
+    private record Endpoint(String httpMethod, String uriTemplate) {
+
     }
 }

--- a/src/main/java/kr/allcll/backend/support/metrics/QueryMetrics.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/QueryMetrics.java
@@ -55,7 +55,7 @@ public class QueryMetrics {
         queryCountSummaries.computeIfAbsent(uriTemplate, this::registerQueryCountSummary)
             .record(queryStats.statementCount());
         queryTimeTimers.computeIfAbsent(uriTemplate, this::registerQueryTimeTimer)
-            .record((long) (queryStats.executionMillis() * 1_000), TimeUnit.MICROSECONDS);
+            .record(queryStats.executionNanos(), TimeUnit.NANOSECONDS);
     }
 
     private DistributionSummary registerQueryCountSummary(String uriTemplate) {

--- a/src/main/java/kr/allcll/backend/support/metrics/QueryMetrics.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/QueryMetrics.java
@@ -1,0 +1,76 @@
+package kr.allcll.backend.support.metrics;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Component;
+
+/**
+ * 요청 하나가 DB에 쓴 비용을 엔드포인트별로 기록한다.
+ *
+ * - 메트릭 두 개를 노출한다.
+ *  # 요청당 SQL문 수(db_query_count)
+ *  # 요청당 SQL 실행 시간(db_query_time_seconds)
+ */
+
+@Component
+public class QueryMetrics {
+
+    private static final String QUERY_COUNT_METER_NAME = "db.query.count";
+    private static final String QUERY_TIME_METER_NAME = "db.query.time";
+    private static final String URI_TAG = "uri";
+
+    private static final double[] QUERY_COUNT_BUCKETS = {1, 2, 3, 5, 10, 20, 50, 100, 500, 1_000, 5_000};
+
+    private static final Duration[] QUERY_TIME_BUCKETS = {
+        Duration.ofMillis(1), Duration.ofMillis(2), Duration.ofMillis(5), Duration.ofMillis(10),
+        Duration.ofMillis(20), Duration.ofMillis(50), Duration.ofMillis(100), Duration.ofMillis(200),
+        Duration.ofMillis(500), Duration.ofSeconds(1), Duration.ofSeconds(2), Duration.ofSeconds(5)
+    };
+
+    private final MeterRegistry meterRegistry;
+    private final Map<String, DistributionSummary> queryCountSummaries = new ConcurrentHashMap<>();
+    private final Map<String, Timer> queryTimeTimers = new ConcurrentHashMap<>();
+
+    public QueryMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * @param uriTemplate 실제 경로가 아니라 핸들러 매핑 패턴(/api/baskets/{subjectId}). 경로를 넘기면 시계열이 무한히 늘어난다.
+     */
+    public void registerEndpoint(String uriTemplate) {
+        queryCountSummaries.computeIfAbsent(uriTemplate, this::registerQueryCountSummary);
+        queryTimeTimers.computeIfAbsent(uriTemplate, this::registerQueryTimeTimer);
+    }
+
+    /**
+     * @param uriTemplate 실제 경로가 아니라 핸들러 매핑 패턴(/api/baskets/{subjectId}). 경로를 넘기면 시계열이 무한히 늘어난다.
+     */
+    public void record(String uriTemplate, RequestQueryStats queryStats) {
+        queryCountSummaries.computeIfAbsent(uriTemplate, this::registerQueryCountSummary)
+            .record(queryStats.statementCount());
+        queryTimeTimers.computeIfAbsent(uriTemplate, this::registerQueryTimeTimer)
+            .record((long) (queryStats.executionMillis() * 1_000), TimeUnit.MICROSECONDS);
+    }
+
+    private DistributionSummary registerQueryCountSummary(String uriTemplate) {
+        return DistributionSummary.builder(QUERY_COUNT_METER_NAME)
+            .description("요청 1건이 발행한 SQL 문 수")
+            .tag(URI_TAG, uriTemplate)
+            .serviceLevelObjectives(QUERY_COUNT_BUCKETS)
+            .register(meterRegistry);
+    }
+
+    private Timer registerQueryTimeTimer(String uriTemplate) {
+        return Timer.builder(QUERY_TIME_METER_NAME)
+            .description("요청 1건이 SQL 실행에 쓴 시간")
+            .tag(URI_TAG, uriTemplate)
+            .serviceLevelObjectives(QUERY_TIME_BUCKETS)
+            .register(meterRegistry);
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/metrics/QueryStatsSessionListener.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/QueryStatsSessionListener.java
@@ -8,6 +8,7 @@ import org.hibernate.SessionEventListener;
 public class QueryStatsSessionListener implements SessionEventListener {
 
     private long statementStartNanos;
+    private long batchStartNanos;
 
     @Override
     public void jdbcExecuteStatementStart() {
@@ -17,5 +18,15 @@ public class QueryStatsSessionListener implements SessionEventListener {
     @Override
     public void jdbcExecuteStatementEnd() {
         RequestQueryStats.recordStatement(System.nanoTime() - statementStartNanos);
+    }
+
+    @Override
+    public void jdbcExecuteBatchStart() {
+        batchStartNanos = System.nanoTime();
+    }
+
+    @Override
+    public void jdbcExecuteBatchEnd() {
+        RequestQueryStats.recordStatement(System.nanoTime() - batchStartNanos);
     }
 }

--- a/src/main/java/kr/allcll/backend/support/metrics/QueryStatsSessionListener.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/QueryStatsSessionListener.java
@@ -1,0 +1,21 @@
+package kr.allcll.backend.support.metrics;
+
+import org.hibernate.SessionEventListener;
+
+/**
+ * Hibernate 가 JDBC 문을 실행할 때마다 실행 시간을 RequestQueryStats에 수집한다.
+ */
+public class QueryStatsSessionListener implements SessionEventListener {
+
+    private long statementStartNanos;
+
+    @Override
+    public void jdbcExecuteStatementStart() {
+        statementStartNanos = System.nanoTime();
+    }
+
+    @Override
+    public void jdbcExecuteStatementEnd() {
+        RequestQueryStats.recordStatement(System.nanoTime() - statementStartNanos);
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/metrics/RequestQueryStats.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/RequestQueryStats.java
@@ -1,0 +1,44 @@
+package kr.allcll.backend.support.metrics;
+
+/**
+ * 요청 하나가 DB에 쓴 비용 - 발행한 SQL문 수와 그 실행에 걸린 시간을 함께 수집한다.
+ */
+public class RequestQueryStats {
+
+    private static final RequestQueryStats EMPTY = new RequestQueryStats();
+    private static final double NANOS_PER_MILLI = 1_000_000.0;
+    private static final ThreadLocal<RequestQueryStats> CURRENT = new ThreadLocal<>();
+
+    private int statementCount;
+    private long executionNanos;
+
+    public static void start() {
+        CURRENT.set(new RequestQueryStats());
+    }
+
+    public static RequestQueryStats stop() {
+        RequestQueryStats current = CURRENT.get();
+        CURRENT.remove();
+        if (current == null) {
+            return EMPTY;
+        }
+        return current;
+    }
+
+    static void recordStatement(long elapsedNanos) {
+        RequestQueryStats current = CURRENT.get();
+        if (current == null) {
+            return;
+        }
+        current.statementCount++;
+        current.executionNanos += elapsedNanos;
+    }
+
+    public int statementCount() {
+        return statementCount;
+    }
+
+    public double executionMillis() {
+        return executionNanos / NANOS_PER_MILLI;
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/metrics/RequestQueryStats.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/RequestQueryStats.java
@@ -6,7 +6,6 @@ package kr.allcll.backend.support.metrics;
 public class RequestQueryStats {
 
     private static final RequestQueryStats EMPTY = new RequestQueryStats();
-    private static final double NANOS_PER_MILLI = 1_000_000.0;
     private static final ThreadLocal<RequestQueryStats> CURRENT = new ThreadLocal<>();
 
     private int statementCount;
@@ -38,7 +37,7 @@ public class RequestQueryStats {
         return statementCount;
     }
 
-    public double executionMillis() {
-        return executionNanos / NANOS_PER_MILLI;
+    public long executionNanos() {
+        return executionNanos;
     }
 }

--- a/src/main/java/kr/allcll/backend/support/web/QueryMetricsFilter.java
+++ b/src/main/java/kr/allcll/backend/support/web/QueryMetricsFilter.java
@@ -1,0 +1,44 @@
+package kr.allcll.backend.support.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import kr.allcll.backend.support.metrics.QueryMetrics;
+import kr.allcll.backend.support.metrics.RequestQueryStats;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerMapping;
+
+/**
+ * 요청 경계에서 DB 비용 집계를 시작·종료하고 엔드포인트별로 기록한다.
+ */
+@RequiredArgsConstructor
+public class QueryMetricsFilter extends OncePerRequestFilter {
+
+    private final QueryMetrics queryMetrics;
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        RequestQueryStats.start();
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            record(request, RequestQueryStats.stop());
+        }
+    }
+
+    private void record(HttpServletRequest request, RequestQueryStats queryStats) {
+        Object uriTemplate = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        if (uriTemplate == null) {
+            return;
+        }
+        queryMetrics.record(uriTemplate.toString(), queryStats);
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/web/QueryMetricsFilter.java
+++ b/src/main/java/kr/allcll/backend/support/web/QueryMetricsFilter.java
@@ -39,6 +39,6 @@ public class QueryMetricsFilter extends OncePerRequestFilter {
         if (uriTemplate == null) {
             return;
         }
-        queryMetrics.record(uriTemplate.toString(), queryStats);
+        queryMetrics.record(request.getMethod(), uriTemplate.toString(), queryStats);
     }
 }

--- a/src/test/java/kr/allcll/backend/support/metrics/QueryMetricsIntegrationTest.java
+++ b/src/test/java/kr/allcll/backend/support/metrics/QueryMetricsIntegrationTest.java
@@ -19,6 +19,7 @@ class QueryMetricsIntegrationTest {
 
     private static final String NOTICES_URI = "/api/notices";
     private static final String NEVER_CALLED_URI = "/api/baskets";
+    private static final String GET_AND_POST_URI = "/api/graduation/check";
 
     @LocalServerPort
     private int port;
@@ -38,8 +39,8 @@ class QueryMetricsIntegrationTest {
         RestAssured.given().when().get(NOTICES_URI).then().statusCode(200);
 
         // when
-        DistributionSummary queryCount = meterRegistry.find("db.query.count").tag("uri", NOTICES_URI).summary();
-        Timer queryTime = meterRegistry.find("db.query.time").tag("uri", NOTICES_URI).timer();
+        DistributionSummary queryCount = findQueryCount("GET", NOTICES_URI);
+        Timer queryTime = findQueryTime("GET", NOTICES_URI);
 
         // then
         assertThat(queryCount).isNotNull();
@@ -56,13 +57,37 @@ class QueryMetricsIntegrationTest {
         // 이 테스트는 NEVER_CALLED_URI 로 요청을 보내지 않는다
 
         // when
-        DistributionSummary queryCount = meterRegistry.find("db.query.count").tag("uri", NEVER_CALLED_URI).summary();
-        Timer queryTime = meterRegistry.find("db.query.time").tag("uri", NEVER_CALLED_URI).timer();
+        DistributionSummary queryCount = findQueryCount("GET", NEVER_CALLED_URI);
+        Timer queryTime = findQueryTime("GET", NEVER_CALLED_URI);
 
         // then
         assertThat(queryCount).isNotNull();
         assertThat(queryCount.count()).isZero();
         assertThat(queryTime).isNotNull();
         assertThat(queryTime.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("한 경로에 여러 method 가 매핑돼 있으면 method 별로 미터가 등록된다.")
+    void registerEndpointPerHttpMethod() {
+        // given
+        // 이 테스트는 GET_AND_POST_URI 로 요청을 보내지 않는다
+
+        // when
+        DistributionSummary getQueryCount = findQueryCount("GET", GET_AND_POST_URI);
+        DistributionSummary postQueryCount = findQueryCount("POST", GET_AND_POST_URI);
+
+        // then
+        assertThat(getQueryCount).isNotNull();
+        assertThat(postQueryCount).isNotNull();
+        assertThat(getQueryCount).isNotSameAs(postQueryCount);
+    }
+
+    private DistributionSummary findQueryCount(String httpMethod, String uri) {
+        return meterRegistry.find("db.query.count").tag("method", httpMethod).tag("uri", uri).summary();
+    }
+
+    private Timer findQueryTime(String httpMethod, String uri) {
+        return meterRegistry.find("db.query.time").tag("method", httpMethod).tag("uri", uri).timer();
     }
 }

--- a/src/test/java/kr/allcll/backend/support/metrics/QueryMetricsIntegrationTest.java
+++ b/src/test/java/kr/allcll/backend/support/metrics/QueryMetricsIntegrationTest.java
@@ -1,0 +1,68 @@
+package kr.allcll.backend.support.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class QueryMetricsIntegrationTest {
+
+    private static final String NOTICES_URI = "/api/notices";
+    private static final String NEVER_CALLED_URI = "/api/baskets";
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("요청을 보내면 그 요청이 쓴 쿼리 수와 시간이 엔드포인트별로 기록된다.")
+    void recordQueryStatsOnRealRequest() {
+        // given
+        RestAssured.given().when().get(NOTICES_URI).then().statusCode(200);
+
+        // when
+        DistributionSummary queryCount = meterRegistry.find("db.query.count").tag("uri", NOTICES_URI).summary();
+        Timer queryTime = meterRegistry.find("db.query.time").tag("uri", NOTICES_URI).timer();
+
+        // then
+        assertThat(queryCount).isNotNull();
+        assertThat(queryCount.count()).isPositive();
+        assertThat(queryCount.totalAmount()).isPositive();
+        assertThat(queryTime).isNotNull();
+        assertThat(queryTime.count()).isPositive();
+    }
+
+    @Test
+    @DisplayName("요청이 한 번도 없던 엔드포인트도 기동 시점에 미터가 등록돼 있다.")
+    void registerEndpointBeforeFirstRequest() {
+        // given
+        // 이 테스트는 NEVER_CALLED_URI 로 요청을 보내지 않는다
+
+        // when
+        DistributionSummary queryCount = meterRegistry.find("db.query.count").tag("uri", NEVER_CALLED_URI).summary();
+        Timer queryTime = meterRegistry.find("db.query.time").tag("uri", NEVER_CALLED_URI).timer();
+
+        // then
+        assertThat(queryCount).isNotNull();
+        assertThat(queryCount.count()).isZero();
+        assertThat(queryTime).isNotNull();
+        assertThat(queryTime.count()).isZero();
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/metrics/QueryStatsSessionListenerTest.java
+++ b/src/test/java/kr/allcll/backend/support/metrics/QueryStatsSessionListenerTest.java
@@ -44,6 +44,40 @@ class QueryStatsSessionListenerTest {
     }
 
     @Test
+    @DisplayName("JDBC 배치로 나간 실행도 집계에 더한다.")
+    void recordBatchExecution() {
+        // given
+        RequestQueryStats.start();
+        QueryStatsSessionListener listener = new QueryStatsSessionListener();
+
+        // when
+        listener.jdbcExecuteBatchStart();
+        listener.jdbcExecuteBatchEnd();
+
+        // then
+        RequestQueryStats queryStats = RequestQueryStats.stop();
+        assertThat(queryStats.statementCount()).isEqualTo(1);
+        assertThat(queryStats.executionNanos()).isNotNegative();
+    }
+
+    @Test
+    @DisplayName("한 세션에서 단건 실행과 배치 실행이 섞이면 둘 다 집계된다.")
+    void recordStatementAndBatchInSession() {
+        // given
+        RequestQueryStats.start();
+        QueryStatsSessionListener listener = new QueryStatsSessionListener();
+
+        // when
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+        listener.jdbcExecuteBatchStart();
+        listener.jdbcExecuteBatchEnd();
+
+        // then
+        assertThat(RequestQueryStats.stop().statementCount()).isEqualTo(2);
+    }
+
+    @Test
     @DisplayName("집계를 시작하지 않은 스레드의 실행은 무시한다.")
     void ignoreExecutionWithoutStart() {
         // given

--- a/src/test/java/kr/allcll/backend/support/metrics/QueryStatsSessionListenerTest.java
+++ b/src/test/java/kr/allcll/backend/support/metrics/QueryStatsSessionListenerTest.java
@@ -21,7 +21,7 @@ class QueryStatsSessionListenerTest {
         // then
         RequestQueryStats queryStats = RequestQueryStats.stop();
         assertThat(queryStats.statementCount()).isEqualTo(1);
-        assertThat(queryStats.executionMillis()).isNotNegative();
+        assertThat(queryStats.executionNanos()).isNotNegative();
     }
 
     @Test

--- a/src/test/java/kr/allcll/backend/support/metrics/QueryStatsSessionListenerTest.java
+++ b/src/test/java/kr/allcll/backend/support/metrics/QueryStatsSessionListenerTest.java
@@ -1,0 +1,59 @@
+package kr.allcll.backend.support.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class QueryStatsSessionListenerTest {
+
+    @Test
+    @DisplayName("SQL문 실행 시작과 종료 사이의 시간을 집계에 더한다.")
+    void recordExecutionTime() {
+        // given
+        RequestQueryStats.start();
+        QueryStatsSessionListener listener = new QueryStatsSessionListener();
+
+        // when
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+
+        // then
+        RequestQueryStats queryStats = RequestQueryStats.stop();
+        assertThat(queryStats.statementCount()).isEqualTo(1);
+        assertThat(queryStats.executionMillis()).isNotNegative();
+    }
+
+    @Test
+    @DisplayName("한 세션에서 쿼리문을 여러 번 실행하면 실행 수만큼 집계된다.")
+    void recordEveryStatementInSession() {
+        // given
+        RequestQueryStats.start();
+        QueryStatsSessionListener listener = new QueryStatsSessionListener();
+
+        // when
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+
+        // then
+        assertThat(RequestQueryStats.stop().statementCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("집계를 시작하지 않은 스레드의 실행은 무시한다.")
+    void ignoreExecutionWithoutStart() {
+        // given
+        QueryStatsSessionListener listener = new QueryStatsSessionListener();
+
+        // when
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+
+        // then
+        assertThat(RequestQueryStats.stop().statementCount()).isZero();
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/metrics/RequestQueryStatsTest.java
+++ b/src/test/java/kr/allcll/backend/support/metrics/RequestQueryStatsTest.java
@@ -23,7 +23,7 @@ class RequestQueryStatsTest {
         // then
         RequestQueryStats queryStats = RequestQueryStats.stop();
         assertThat(queryStats.statementCount()).isEqualTo(2);
-        assertThat(queryStats.executionMillis()).isEqualTo(3.0);
+        assertThat(queryStats.executionNanos()).isEqualTo(3 * ONE_MILLI_NANOS);
     }
 
     @Test
@@ -37,7 +37,7 @@ class RequestQueryStatsTest {
 
         // then
         assertThat(queryStats.statementCount()).isZero();
-        assertThat(queryStats.executionMillis()).isZero();
+        assertThat(queryStats.executionNanos()).isZero();
     }
 
     @Test

--- a/src/test/java/kr/allcll/backend/support/metrics/RequestQueryStatsTest.java
+++ b/src/test/java/kr/allcll/backend/support/metrics/RequestQueryStatsTest.java
@@ -1,0 +1,77 @@
+package kr.allcll.backend.support.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RequestQueryStatsTest {
+
+    private static final long ONE_MILLI_NANOS = 1_000_000L;
+
+    @Test
+    @DisplayName("집계를 시작한 뒤 실행한 SQL 수와 시간을 수집한다.")
+    void collectCountAndTimeAfterStart() {
+        // given
+        RequestQueryStats.start();
+
+        // when
+        RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+        RequestQueryStats.recordStatement(2 * ONE_MILLI_NANOS);
+
+        // then
+        RequestQueryStats queryStats = RequestQueryStats.stop();
+        assertThat(queryStats.statementCount()).isEqualTo(2);
+        assertThat(queryStats.executionMillis()).isEqualTo(3.0);
+    }
+
+    @Test
+    @DisplayName("집계를 시작하지 않은 스레드에서는 수집하지 않는다.")
+    void collectNothingWithoutStart() {
+        // given
+        RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+
+        // when
+        RequestQueryStats queryStats = RequestQueryStats.stop();
+
+        // then
+        assertThat(queryStats.statementCount()).isZero();
+        assertThat(queryStats.executionMillis()).isZero();
+    }
+
+    @Test
+    @DisplayName("스레드마다 따로 수집하므로 동시 요청이 서로 섞이지 않는다.")
+    void collectPerThread() {
+        // given
+        RequestQueryStats.start();
+        RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+
+        // when
+        int otherThreadCount = CompletableFuture.supplyAsync(() -> {
+            RequestQueryStats.start();
+            RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+            RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+            return RequestQueryStats.stop().statementCount();
+        }).join();
+
+        // then
+        assertThat(otherThreadCount).isEqualTo(2);
+        assertThat(RequestQueryStats.stop().statementCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("집계를 끝내면 값이 남지 않아 스레드를 재사용해도 이어서 수집하지 않는다.")
+    void resetAfterStop() {
+        // given
+        RequestQueryStats.start();
+        RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+        RequestQueryStats.stop();
+
+        // when
+        RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+
+        // then
+        assertThat(RequestQueryStats.stop().statementCount()).isZero();
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/web/QueryMetricsFilterTest.java
+++ b/src/test/java/kr/allcll/backend/support/web/QueryMetricsFilterTest.java
@@ -1,0 +1,107 @@
+package kr.allcll.backend.support.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import kr.allcll.backend.support.metrics.QueryMetrics;
+import kr.allcll.backend.support.metrics.QueryStatsSessionListener;
+import kr.allcll.backend.support.metrics.RequestQueryStats;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.HandlerMapping;
+
+class QueryMetricsFilterTest {
+
+    private MeterRegistry meterRegistry;
+    private QueryMetricsFilter queryMetricsFilter;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        queryMetricsFilter = new QueryMetricsFilter(new QueryMetrics(meterRegistry));
+    }
+
+    @Test
+    @DisplayName("요청이 실행한 SQL 수와 시간을 핸들러 매핑 패턴 태그로 기록한다.")
+    void recordQueryStatsWithUriTemplateTag() throws Exception {
+        // given
+        MockHttpServletRequest request = requestWithUriTemplate("/api/baskets/{subjectId}");
+
+        // when
+        queryMetricsFilter.doFilter(request, new MockHttpServletResponse(), (req, res) -> {
+            executeStatement();
+            executeStatement();
+        });
+
+        // then
+        DistributionSummary queryCount = findQueryCount("/api/baskets/{subjectId}");
+        assertThat(queryCount).isNotNull();
+        assertThat(queryCount.count()).isEqualTo(1);
+        assertThat(queryCount.totalAmount()).isEqualTo(2.0);
+
+        Timer queryTime = findQueryTime("/api/baskets/{subjectId}");
+        assertThat(queryTime).isNotNull();
+        assertThat(queryTime.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("핸들러가 매칭되지 않은 요청은 기록하지 않는다.")
+    void skipUnmappedRequest() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/존재하지않는경로");
+
+        // when
+        queryMetricsFilter.doFilter(request, new MockHttpServletResponse(), (req, res) -> {
+        });
+
+        // then
+        assertThat(meterRegistry.find("db.query.count").summaries()).isEmpty();
+        assertThat(meterRegistry.find("db.query.time").timers()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("요청 처리 중 예외가 나도 집계를 정리해 다음 요청에 값이 새지 않는다.")
+    void clearStatsWhenRequestFails() {
+        // given
+        MockHttpServletRequest request = requestWithUriTemplate("/api/subjects");
+
+        // when
+        try {
+            queryMetricsFilter.doFilter(request, new MockHttpServletResponse(), (req, res) -> {
+                executeStatement();
+                throw new IllegalStateException("조회 실패");
+            });
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(findQueryCount("/api/subjects").totalAmount()).isEqualTo(1.0);
+        assertThat(RequestQueryStats.stop().statementCount()).isZero();
+    }
+
+    private void executeStatement() {
+        QueryStatsSessionListener listener = new QueryStatsSessionListener();
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+    }
+
+    private MockHttpServletRequest requestWithUriTemplate(String uriTemplate) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", uriTemplate);
+        request.setAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, uriTemplate);
+        return request;
+    }
+
+    private DistributionSummary findQueryCount(String uri) {
+        return meterRegistry.find("db.query.count").tag("uri", uri).summary();
+    }
+
+    private Timer findQueryTime(String uri) {
+        return meterRegistry.find("db.query.time").tag("uri", uri).timer();
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/web/QueryMetricsFilterTest.java
+++ b/src/test/java/kr/allcll/backend/support/web/QueryMetricsFilterTest.java
@@ -31,7 +31,7 @@ class QueryMetricsFilterTest {
     @DisplayName("요청이 실행한 SQL 수와 시간을 핸들러 매핑 패턴 태그로 기록한다.")
     void recordQueryStatsWithUriTemplateTag() throws Exception {
         // given
-        MockHttpServletRequest request = requestWithUriTemplate("/api/baskets/{subjectId}");
+        MockHttpServletRequest request = requestWithUriTemplate("GET", "/api/baskets/{subjectId}");
 
         // when
         queryMetricsFilter.doFilter(request, new MockHttpServletResponse(), (req, res) -> {
@@ -40,14 +40,34 @@ class QueryMetricsFilterTest {
         });
 
         // then
-        DistributionSummary queryCount = findQueryCount("/api/baskets/{subjectId}");
+        DistributionSummary queryCount = findQueryCount("GET", "/api/baskets/{subjectId}");
         assertThat(queryCount).isNotNull();
         assertThat(queryCount.count()).isEqualTo(1);
         assertThat(queryCount.totalAmount()).isEqualTo(2.0);
 
-        Timer queryTime = findQueryTime("/api/baskets/{subjectId}");
+        Timer queryTime = findQueryTime("GET", "/api/baskets/{subjectId}");
         assertThat(queryTime).isNotNull();
         assertThat(queryTime.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("경로가 같아도 HTTP method 가 다르면 따로 기록한다.")
+    void recordSameUriPerHttpMethod() throws Exception {
+        // given
+        MockHttpServletRequest getRequest = requestWithUriTemplate("GET", "/api/timetables");
+        MockHttpServletRequest postRequest = requestWithUriTemplate("POST", "/api/timetables");
+
+        // when
+        queryMetricsFilter.doFilter(getRequest, new MockHttpServletResponse(), (req, res) -> executeStatement());
+        queryMetricsFilter.doFilter(postRequest, new MockHttpServletResponse(), (req, res) -> {
+            executeStatement();
+            executeStatement();
+            executeStatement();
+        });
+
+        // then
+        assertThat(findQueryCount("GET", "/api/timetables").totalAmount()).isEqualTo(1.0);
+        assertThat(findQueryCount("POST", "/api/timetables").totalAmount()).isEqualTo(3.0);
     }
 
     @Test
@@ -69,7 +89,7 @@ class QueryMetricsFilterTest {
     @DisplayName("요청 처리 중 예외가 나도 집계를 정리해 다음 요청에 값이 새지 않는다.")
     void clearStatsWhenRequestFails() {
         // given
-        MockHttpServletRequest request = requestWithUriTemplate("/api/subjects");
+        MockHttpServletRequest request = requestWithUriTemplate("GET", "/api/subjects");
 
         // when
         try {
@@ -81,7 +101,7 @@ class QueryMetricsFilterTest {
         }
 
         // then
-        assertThat(findQueryCount("/api/subjects").totalAmount()).isEqualTo(1.0);
+        assertThat(findQueryCount("GET", "/api/subjects").totalAmount()).isEqualTo(1.0);
         assertThat(RequestQueryStats.stop().statementCount()).isZero();
     }
 
@@ -91,17 +111,17 @@ class QueryMetricsFilterTest {
         listener.jdbcExecuteStatementEnd();
     }
 
-    private MockHttpServletRequest requestWithUriTemplate(String uriTemplate) {
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", uriTemplate);
+    private MockHttpServletRequest requestWithUriTemplate(String httpMethod, String uriTemplate) {
+        MockHttpServletRequest request = new MockHttpServletRequest(httpMethod, uriTemplate);
         request.setAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, uriTemplate);
         return request;
     }
 
-    private DistributionSummary findQueryCount(String uri) {
-        return meterRegistry.find("db.query.count").tag("uri", uri).summary();
+    private DistributionSummary findQueryCount(String httpMethod, String uri) {
+        return meterRegistry.find("db.query.count").tag("method", httpMethod).tag("uri", uri).summary();
     }
 
-    private Timer findQueryTime(String uri) {
-        return meterRegistry.find("db.query.time").tag("uri", uri).timer();
+    private Timer findQueryTime(String httpMethod, String uri) {
+        return meterRegistry.find("db.query.time").tag("method", httpMethod).tag("uri", uri).timer();
     }
 }


### PR DESCRIPTION
## 작업 배경
쿼리 튜닝 전후의 효과를 운영 환경에서 비교할 수 있도록 요청 단위 DB 비용을 측정하는 지표를 추가했습니다.
기존 지표는 전체 응답 시간이나 커넥션 풀 상태만 제공하여 응답 지연의 원인이 DB 쿼리 수인지, 쿼리 실행 시간인지 구분하기 어려웠습니다.
따라서 튜닝 배포 전에 관련 메트릭을 새롭게 수집하고, 배포 후 동일한 지표를 비교할 수 있도록 구성했습니다.

## 작업 내용
### 1. SQL 실행 정보 수집
JDBC 실행 훅을 활용해 요청별 실제 SQL 실행 횟수와 총 실행 시간을 수집했습니다.
JPA Repository 호출 횟수가 아닌 실제 JDBC 문을 기준으로 측정해 N+1 문제도 확인할 수 있도록 했습니다.

### 2. Micrometer 메트릭 추가
uri 태그 기준으로 다음 메트릭을 기록합니다.

> `db.query.count`: 요청당 SQL 실행 수
>`db.query.time`: 요청 내 SQL 총 실행 시간

### 3. 요청 단위 집계 연결
`OncePerRequestFilter`에서 요청 시작부터 종료까지 SQL 실행 정보를 집계하고, 요청이 끝난 시점에 메트릭을 기록하도록 구성했습니다.
URI는 실제 경로가 아닌 Spring의 핸들러 매핑 패턴을 사용해 태그 카디널리티를 제한했습니다.

### 4. 테스트 코드 작성
- 집계 객체, Hibernate 리스너, 필터 단위 테스트
- 실제 요청을 통한 Hibernate 리스너·필터 통합 테스트

## 검증
로컬 MySQL 환경에서 Hibernate SQL 로그와 메트릭을 대조해 실제 SQL 실행 수가 일치하는지 확인했습니다.

| 엔드포인트 | SQL 실행 수 | 실행 시간 |
| --- | ---: | ---: |
| `/api/notices` | 1 | 2.7ms |
| `/api/subjects` | 1 | 56.2ms |
| `/api/admin/graduation/{studentId}` | 28 | 120.7ms |
| `/api/admin/graduation/{studentId}` | 26 | 68.8ms |

3개 엔드포인트에 30개 병렬 요청을 수행한 결과.

> 요청 수: 90
> SQL 실행 수: 900
> 메트릭·Hibernate 로그 간 오차: 0

또한 SQL 총 실행 시간이 전체 HTTP 응답 시간보다 커지지 않는 조건도 병렬 요청 환경에서 확인했습니다.

## 기대 효과
- 엔드포인트별 요청당 DB 비용을 정량적으로 비교
- 응답 지연이 쿼리 수와 실행 시간 중 어디에서 발생하는지 파악 가능
- 튜닝 배포 후 쿼리 수 증가를 통해 N+1 문제 조기 감지
- 운영 환경에서 튜닝 전후 효과를 동일한 기준으로 비교

---

## Codex Review
- `src/main/java/kr/allcll/backend/support/web/QueryMetricsFilter.java:43` -- "[P2] HTTP method를 메트릭 태그에 포함해 주세요"

---
- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기