### PR TITLE
[TSK-145] 로그인 OkHttpClient를 공유 ConnectionPool 기반으로 전환

### DIFF
--- a/src/main/java/kr/allcll/backend/client/ConnectionEventListener.java
+++ b/src/main/java/kr/allcll/backend/client/ConnectionEventListener.java
@@ -1,0 +1,27 @@
+package kr.allcll.backend.client;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.EventListener;
+
+@Slf4j
+public class ConnectionEventListener extends EventListener {
+
+    @Override
+    public void connectStart(Call call, InetSocketAddress inetSocketAddress, Proxy proxy) {
+        log.info("[CONN] new connection to {}", inetSocketAddress);
+    }
+
+    @Override
+    public void connectionAcquired(Call call, Connection connection) {
+        log.info("[CONN] acquired: {}", connection);
+    }
+
+    @Override
+    public void connectionReleased(Call call, Connection connection) {
+        log.info("[CONN] released: {}", connection);
+    }
+}

--- a/src/main/java/kr/allcll/backend/client/ConnectionHeaderInterceptor.java
+++ b/src/main/java/kr/allcll/backend/client/ConnectionHeaderInterceptor.java
@@ -1,0 +1,20 @@
+package kr.allcll.backend.client;
+
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+@Slf4j
+public class ConnectionHeaderInterceptor implements Interceptor {
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Response response = chain.proceed(chain.request());
+        String connectionHeader = response.header("Connection");
+        if ("close".equalsIgnoreCase(connectionHeader)) {
+            log.warn("[CONN] Connection: close. url={}", chain.request().url());
+        }
+        return response;
+    }
+}

--- a/src/main/java/kr/allcll/backend/config/LoginConfig.java
+++ b/src/main/java/kr/allcll/backend/config/LoginConfig.java
@@ -1,8 +1,14 @@
 package kr.allcll.backend.config;
 
+import java.util.concurrent.TimeUnit;
+import kr.allcll.backend.client.ConnectionEventListener;
+import kr.allcll.backend.client.ConnectionHeaderInterceptor;
 import kr.allcll.backend.client.LoginProperties;
 import lombok.RequiredArgsConstructor;
+import okhttp3.ConnectionPool;
+import okhttp3.OkHttpClient;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -10,4 +16,15 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(LoginProperties.class)
 public class LoginConfig {
 
+    @Bean
+    public OkHttpClient loginHttpClient() {
+        ConnectionPool connectionPool = new ConnectionPool(10, 2, TimeUnit.MINUTES);
+        return new OkHttpClient.Builder()
+            .connectionPool(connectionPool)
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(5, TimeUnit.SECONDS)
+            .addNetworkInterceptor(new ConnectionHeaderInterceptor())
+            .eventListener(new ConnectionEventListener())
+            .build();
+    }
 }

--- a/src/main/java/kr/allcll/backend/domain/user/AuthService.java
+++ b/src/main/java/kr/allcll/backend/domain/user/AuthService.java
@@ -22,6 +22,7 @@ public class AuthService {
 
     public static final String RESULT_OK = "var result = 'OK'";
     private final LoginProperties properties;
+    private final OkHttpClient loginHttpClient;
 
     public OkHttpClient login(LoginRequest loginRequest) {
         try {
@@ -31,7 +32,7 @@ public class AuthService {
             CookieManager cookieManager = new CookieManager();
             cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
 
-            OkHttpClient client = new OkHttpClient().newBuilder()
+            OkHttpClient client = loginHttpClient.newBuilder()
                 .cookieJar(new JavaNetCookieJar(cookieManager))
                 .build();
 

--- a/src/main/java/kr/allcll/backend/domain/user/ToscAuthService.java
+++ b/src/main/java/kr/allcll/backend/domain/user/ToscAuthService.java
@@ -21,9 +21,10 @@ import org.springframework.stereotype.Service;
 public class ToscAuthService {
 
     private final LoginProperties properties;
+    private final OkHttpClient loginHttpClient;
 
     public void loginTosc(LoginRequest loginRequest) {
-        OkHttpClient client = new OkHttpClient();
+        OkHttpClient client = loginHttpClient.newBuilder().build();
 
         RequestBody body = new FormBody.Builder()
             .add("email", loginRequest.studentId())

--- a/src/test/java/kr/allcll/backend/domain/user/ToscAuthServiceTest.java
+++ b/src/test/java/kr/allcll/backend/domain/user/ToscAuthServiceTest.java
@@ -39,7 +39,7 @@ class ToscAuthServiceTest {
             "https://portal.sejong.ac.kr/englishInfo",
             "https://portal.sejong.ac.kr/codingInfo"
         );
-        toscAuthService = new ToscAuthService(properties);
+        toscAuthService = new ToscAuthService(properties, new okhttp3.OkHttpClient());
         portalCookieManager = new CookieManager();
         portalCookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
     }


### PR DESCRIPTION
# 작업 배경

기존 구현은 **로그인 요청마다 새 OkHttpClient를 생성해도 성능에 문제가 없다**는 가정을 기반으로 작성되어 있었습니다.

하지만 실제로는 로그인 1회당 포털에 5건의 HTTP 요청(로그인 + 학생정보 + 영어/코딩/고전독서 인증)을 순차로 보내며, 매번 새 클라이언트를 생성하면 TCP + TLS 핸드셰이크(2~3 RTT)가 요청마다 반복됩니다.

- 포털 로그인 응답 실측 결과, `Connection: close` 헤더 없음 + `Connection #0 left intact` 확인 -> 서버는 keep-alive를 허용
- 현재 코드: `new OkHttpClient().newBuilder()...build()` -> 매번 새 ConnectionPool 생성 -> 연결 재사용 불가

동시 로그인이 몰리는 수강신청 시점에 불필요한 핸드셰이크가 곱해져 응답 지연이 발생할 수 있습니다.

# 해결 방법

공유 `OkHttpClient` 빈을 싱글턴으로 등록하고, `newBuilder()` 패턴으로 요청별 cookie jar만 분리합니다.

매 요청마다 새 `OkHttpClient`를 만드는 방식을 유지할 경우, ConnectionPool이 클라이언트마다 독립적으로 생성되어 연결 재사용이 원천적으로 불가능합니다.

`newBuilder()`는 ConnectionPool, Dispatcher, timeout 설정을 원본과 공유하면서 cookieJar 등 요청별 설정만 독립시키므로, 포털 세션 격리(cookie jar 분리)와 연결 재사용(pool 공유)을 동시에 달성합니다.

# 작업 내용

- `LoginConfig`
    - 공유 `OkHttpClient` 빈 등록 (ConnectionPool: maxIdle 10 / keepAlive 2분, Timeout: connect 5초 / read 5초)
- `AuthService`
    - 공유 클라이언트를 주입받아 `newBuilder()`로 cookie jar만 분리
- `ToscAuthService`
    - 공유 클라이언트를 주입받아 `newBuilder()`로 파생
- `ConnectionEventListener`
    - 연결 수립/획득/반납 로깅 (연결 재사용 검증용)
- `ConnectionHeaderInterceptor`
    - 서버의 `Connection: close` 응답 감지 경고 로깅
- `ToscAuthServiceTest`
    - 생성자 시그니처 변경에 맞춰 `OkHttpClient` 인자 추가

# 검증

**기존 로그인/TOSC 테스트 전체 통과 확인**

> 수정 전: 로그인마다 독립 OkHttpClient + 독립 ConnectionPool 생성, 연결 재사용 불가
> 수정 후: 공유 ConnectionPool에서 같은 호스트의 유휴 연결을 재사용, TCP+TLS 핸드셰이크 생략

실제 연결 재사용 여부는 배포 후 `ConnectionEventListener` 로그로 확인 필요:
- `connectStart`가 로그인 1회(5건)에 1번만 찍히면 -> 순차 요청 간 재사용 성공
- 다른 사용자 로그인에서 `connectStart` 없이 `connectionAcquired`만 찍히면 -> 사용자 간 재사용 성공

# 리뷰 포인트

ConnectionPool 설정값(maxIdleConnections=10, keepAliveDuration=2분)이 현재 운영 환경의 동시 로그인 규모에 적절한지. 피크 동시 로그인 수 측정 후 조정 예정이지만, 초기값으로 이 수준이 괜찮은지 판단이 필요합니다.
설정값을 판단했던 기준에 대해 [DISCUSSION](https://github.com/allcll/allcll-backend/discussions/408) 문서로 분리해두었습니다 :) 한번 참고해주시고 설정값에 대한 논의는 discussion에서 나눠봐도 좋을 것 같습니다 !

# 참고

- Dispatcher 설정(maxRequests, maxRequestsPerHost)은 현재 동기 호출(`execute()`)을 사용하므로 작동하지 않아 기본값 유지. 비동기 전환 시 재판단 대상.
- 포털 서버의 keep-alive 유휴 타임아웃은 응답 헤더에 명시되지 않아 정확한 값을 알 수 없음. keepAliveDuration을 보수적으로 2분으로 설정하고, OkHttp의 stale connection 감지에 의존.
