### PR TITLE
[TSK-146-1] DB 조회 구조 개선

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/seat/TargetSubjectService.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/TargetSubjectService.java
@@ -2,6 +2,7 @@ package kr.allcll.backend.admin.seat;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import kr.allcll.backend.admin.seat.dto.PinSubjectUpdateRequest;
 import kr.allcll.backend.admin.seat.dto.PinSubjectUpdateRequest.PinSubject;
@@ -36,13 +37,30 @@ public class TargetSubjectService {
     }
 
     private Map<CrawlerSubject, Integer> resolveSubjectWithPriority(PinSubjectUpdateRequest request) {
-        return request.subjects().stream()
-            .map(subject -> Map.entry(getSubject(subject), subject.priority()))
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        List<PinSubject> pinSubjects = request.subjects();
+        Map<Long, CrawlerSubject> subjectsById = findSubjectsById(pinSubjects);
+
+        return pinSubjects.stream()
+            .collect(Collectors.toMap(
+                pinSubject -> getSubject(subjectsById, pinSubject),
+                PinSubject::priority
+            ));
     }
 
-    private CrawlerSubject getSubject(PinSubject subject) {
-        return crawlerSubjectRepository.findById(subject.subjectId())
-            .orElseThrow(() -> new CrawlerAllcllException("SUBJECT_NOT_FOUND", "과목 정보가 없습니다."));
+    private Map<Long, CrawlerSubject> findSubjectsById(List<PinSubject> pinSubjects) {
+        List<Long> subjectIds = pinSubjects.stream()
+            .map(PinSubject::subjectId)
+            .toList();
+
+        return crawlerSubjectRepository.findAllById(subjectIds).stream()
+            .collect(Collectors.toMap(CrawlerSubject::getId, Function.identity()));
+    }
+
+    private CrawlerSubject getSubject(Map<Long, CrawlerSubject> subjectsById, PinSubject subject) {
+        CrawlerSubject crawlerSubject = subjectsById.get(subject.subjectId());
+        if (crawlerSubject == null) {
+            throw new CrawlerAllcllException("SUBJECT_NOT_FOUND", "과목 정보가 없습니다.");
+        }
+        return crawlerSubject;
     }
 }

--- a/src/main/java/kr/allcll/backend/admin/subject/AdminSubjectService.java
+++ b/src/main/java/kr/allcll/backend/admin/subject/AdminSubjectService.java
@@ -1,6 +1,9 @@
 package kr.allcll.backend.admin.subject;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import kr.allcll.backend.support.semester.Semester;
 import kr.allcll.crawler.common.exception.CrawlerAllcllException;
 import kr.allcll.crawler.subject.CrawlerSubject;
@@ -27,7 +30,7 @@ public class AdminSubjectService {
         log.info("[SubjectService] 기존 과목 수: {}", existingCrawlerSubjects.size());
         SubjectSyncResult syncResult = SubjectSyncProcessor.process(allCrawlerSubjects, existingCrawlerSubjects);
         saveAddedSubjects(syncResult);
-        updateChangedSubjects(syncResult);
+        updateChangedSubjects(syncResult, existingCrawlerSubjects);
         deleteRemovedSubjects(syncResult);
 
         return syncResult;
@@ -49,18 +52,19 @@ public class AdminSubjectService {
         }
     }
 
-    private void updateChangedSubjects(SubjectSyncResult syncResult) {
+    private void updateChangedSubjects(SubjectSyncResult syncResult, List<CrawlerSubject> existingCrawlerSubjects) {
         if (syncResult.subjectsToUpdateIsExist()) {
             List<CrawlerSubject> subjectsToUpdate = syncResult.subjectsCanUpdate();
             log.info("[SubjectService] 변경된 과목 수: {}", subjectsToUpdate.size());
+            Map<String, CrawlerSubject> existingSubjectsByKey = existingCrawlerSubjects.stream()
+                .collect(Collectors.toMap(SubjectSyncProcessor::generateSubjectKey, subject -> subject));
             for (CrawlerSubject updatedSubject : subjectsToUpdate) {
-                CrawlerSubject existingSubject = crawlerSubjectRepository.findByLogicalKeyIncludingDeleted(
-                    updatedSubject.getCuriNo(),
-                    updatedSubject.getDeptCd(),
-                    updatedSubject.getClassName(),
-                    updatedSubject.getSmtCd(),
-                    Semester.getCurrentSemester()
-                ).orElseThrow(() -> new CrawlerAllcllException("SUBJECT_NOT_FOUND", "과목이 존재하지 않습니다."));
+                String subjectKey = SubjectSyncProcessor.generateSubjectKey(updatedSubject);
+                CrawlerSubject existingSubject = Optional.ofNullable(
+                    existingSubjectsByKey.get(subjectKey)
+                ).orElseThrow(() ->
+                    new CrawlerAllcllException("SUBJECT_NOT_FOUND", "과목이 존재하지 않습니다.")
+                );
                 existingSubject.updateFrom(updatedSubject);
             }
         }

--- a/src/main/java/kr/allcll/backend/admin/subject/SubjectSyncProcessor.java
+++ b/src/main/java/kr/allcll/backend/admin/subject/SubjectSyncProcessor.java
@@ -68,7 +68,7 @@ public class SubjectSyncProcessor {
         return new SubjectSyncResult(subjectsToAdd, subjectsToDelete, subjectsToUpdate, updateDiffs);
     }
 
-    private static String generateSubjectKey(CrawlerSubject crawlerSubject) {
+    static String generateSubjectKey(CrawlerSubject crawlerSubject) {
         return crawlerSubject.getCuriNo() + "|" +
             crawlerSubject.getDeptCd() + "|" +
             crawlerSubject.getClassName() + "|" +

--- a/src/main/java/kr/allcll/backend/config/QueryMetricsConfig.java
+++ b/src/main/java/kr/allcll/backend/config/QueryMetricsConfig.java
@@ -1,0 +1,78 @@
+package kr.allcll.backend.config;
+
+import java.util.Map;
+import java.util.Set;
+import kr.allcll.backend.support.metrics.QueryMetrics;
+import kr.allcll.backend.support.metrics.QueryStatsSessionListener;
+import kr.allcll.backend.support.web.QueryMetricsFilter;
+import org.hibernate.cfg.AvailableSettings;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.servlet.mvc.condition.PathPatternsRequestCondition;
+import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+@Configuration
+@ConditionalOnProperty(prefix = "allcll.metrics.query", name = "enabled", matchIfMissing = true)
+public class QueryMetricsConfig {
+
+    /*
+    RequestIdFilter(HIGHEST_PRECEDENCE) 다음에 두어 집계 로그가 requestId 와 함께 남도록 한다.
+     */
+    private static final int QUERY_METRICS_FILTER_ORDER = Ordered.HIGHEST_PRECEDENCE + 10;
+
+    @Bean
+    public HibernatePropertiesCustomizer queryStatsSessionListenerCustomizer() {
+        return this::registerSessionListener;
+    }
+
+    @Bean
+    public FilterRegistrationBean<QueryMetricsFilter> queryMetricsFilterRegistration(QueryMetrics queryMetrics) {
+        FilterRegistrationBean<QueryMetricsFilter> registration =
+            new FilterRegistrationBean<>(new QueryMetricsFilter(queryMetrics));
+        registration.setOrder(QUERY_METRICS_FILTER_ORDER);
+        return registration;
+    }
+
+    @Bean
+    public ApplicationListener<ApplicationReadyEvent> queryMetricsEndpointRegistrar(
+        QueryMetrics queryMetrics,
+        ObjectProvider<RequestMappingHandlerMapping> handlerMappings
+    ) {
+        return event -> handlerMappings.stream()
+            .flatMap(handlerMapping -> handlerMapping.getHandlerMethods().keySet().stream())
+            .flatMap(mappingInfo -> uriPatterns(mappingInfo).stream())
+            .distinct()
+            .forEach(queryMetrics::registerEndpoint);
+    }
+
+    private Set<String> uriPatterns(RequestMappingInfo mappingInfo) {
+        PathPatternsRequestCondition pathPatterns = mappingInfo.getPathPatternsCondition();
+        if (pathPatterns != null) {
+            return pathPatterns.getPatternValues();
+        }
+        PatternsRequestCondition patterns = mappingInfo.getPatternsCondition();
+        if (patterns != null) {
+            return patterns.getPatterns();
+        }
+        return Set.of();
+    }
+
+    /*
+    Hibernate 가 세션마다 인스턴스를 직접 만들기 때문에 인스턴스가 아니라 클래스 이름으로 지정한다.
+     */
+    private void registerSessionListener(Map<String, Object> hibernateProperties) {
+        hibernateProperties.put(
+            AvailableSettings.AUTO_SESSION_EVENTS_LISTENER,
+            QueryStatsSessionListener.class.getName()
+        );
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java
@@ -1,6 +1,7 @@
 package kr.allcll.backend.domain.basket;
 
 import java.util.List;
+import kr.allcll.backend.domain.basket.dto.SubjectTotalCount;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -14,4 +15,15 @@ public interface BasketRepository extends JpaRepository<Basket, Long> {
         and s.semesterAt = :semesterAt
         """)
     List<Basket> findBySubjectId(Long id, String semesterAt);
+
+    @Query("""
+        select new kr.allcll.backend.domain.basket.dto.SubjectTotalCount(s.id, max(b.totRcnt))
+        from Basket b
+        join b.subject s
+        where s.id in :subjectIds
+        and s.isDeleted = false
+        and s.semesterAt = :semesterAt
+        group by s.id
+        """)
+    List<SubjectTotalCount> findTotalCountsBySubjectIds(List<Long> subjectIds, String semesterAt);
 }

--- a/src/main/java/kr/allcll/backend/domain/basket/BasketService.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/BasketService.java
@@ -1,7 +1,8 @@
 package kr.allcll.backend.domain.basket;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import kr.allcll.backend.domain.basket.dto.BasketsEachSubject;
 import kr.allcll.backend.domain.basket.dto.BasketsResponse;
 import kr.allcll.backend.domain.basket.dto.SubjectBasketsResponse;
@@ -14,10 +15,14 @@ import kr.allcll.backend.support.semester.Semester;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class BasketService {
+
+    private static final int NO_BASKET_TOTAL_COUNT = 0;
 
     private final BasketRepository basketRepository;
     private final SubjectRepository subjectRepository;
@@ -34,15 +39,30 @@ public class BasketService {
     }
 
     private List<BasketsEachSubject> getBasketsEachSubject(List<Subject> subjects) {
-        List<BasketsEachSubject> result = new ArrayList<>();
-        for (Subject subject : subjects) {
-            List<Basket> baskets = basketRepository.findBySubjectId(
-                subject.getId(),
-                Semester.getCurrentSemester()
-            );
-            result.add(BasketsEachSubject.from(subject, baskets));
+        if (subjects.isEmpty()) {
+            return List.of();
         }
-        return result;
+
+        List<Long> subjectIds = subjects.stream()
+            .map(Subject::getId)
+            .toList();
+        Map<Long, Integer> totalCountsBySubjectId = findTotalCountsBySubjectIds(subjectIds);
+
+        return subjectIds.stream()
+            .map(subjectId -> BasketsEachSubject.of(
+                subjectId,
+                totalCountsBySubjectId.getOrDefault(subjectId, NO_BASKET_TOTAL_COUNT)
+            ))
+            .toList();
+    }
+
+    private Map<Long, Integer> findTotalCountsBySubjectIds(List<Long> subjectIds) {
+        Map<Long, Integer> totalCountsBySubjectId = new HashMap<>();
+        basketRepository.findTotalCountsBySubjectIds(subjectIds, Semester.getCurrentSemester())
+            .forEach(totalCount ->
+                totalCountsBySubjectId.put(totalCount.subjectId(), totalCount.totalCount())
+            );
+        return totalCountsBySubjectId;
     }
 
     private Specification<Subject> getCondition(

--- a/src/main/java/kr/allcll/backend/domain/basket/dto/BasketsEachSubject.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/dto/BasketsEachSubject.java
@@ -1,24 +1,11 @@
 package kr.allcll.backend.domain.basket.dto;
 
-import java.util.List;
-import kr.allcll.backend.domain.basket.Basket;
-import kr.allcll.backend.domain.subject.Subject;
-
 public record BasketsEachSubject(
     Long subjectId,
     Integer totalCount //총 인원
 ) {
 
-    public static BasketsEachSubject from(Subject subject, List<Basket> baskets) {
-        if (baskets.isEmpty()) {
-            return new BasketsEachSubject(
-                subject.getId(),
-                0
-            );
-        }
-        return new BasketsEachSubject(
-            subject.getId(),
-            baskets.getFirst().getTotRcnt()
-        );
+    public static BasketsEachSubject of(Long subjectId, Integer totalCount) {
+        return new BasketsEachSubject(subjectId, totalCount);
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/basket/dto/SubjectTotalCount.java
+++ b/src/main/java/kr/allcll/backend/domain/basket/dto/SubjectTotalCount.java
@@ -1,0 +1,9 @@
+package kr.allcll.backend.domain.basket.dto;
+
+
+public record SubjectTotalCount(
+    Long subjectId,
+    Integer totalCount
+) {
+
+}

--- a/src/main/java/kr/allcll/backend/domain/graduation/check/result/CategoryCreditCalculator.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/check/result/CategoryCreditCalculator.java
@@ -98,13 +98,7 @@ public class CategoryCreditCalculator {
         List<CompletedCourse> earnedCourses,
         CreditCriterion criterion
     ) {
-        double earnedCredits = earnedCourses.stream()
-            .filter(course -> course.getCategoryType() == criterion.getCategoryType())
-            .filter(course -> matchesMajorScope(course, criterion.getMajorScope()))
-            .filter(course -> academicBasicPolicy.isRecentMajorAcademicBasic(course, criterion))
-            .mapToDouble(CompletedCourse::getCredits)
-            .sum();
-
+        double earnedCredits = calculateEarnedCredits(earnedCourses, criterion);
         int requiredCredits = criterion.getRequiredCredits();
         double remainingCredits = calculateRemainingCredits(requiredCredits, earnedCredits);
         boolean isSatisfied = remainingCredits <= 0;
@@ -120,6 +114,22 @@ public class CategoryCreditCalculator {
             null,
             isSatisfied
         );
+    }
+
+    private double calculateEarnedCredits(
+        List<CompletedCourse> earnedCourses,
+        CreditCriterion criterion
+    ) {
+        List<CompletedCourse> matchedCourses = earnedCourses.stream()
+            .filter(course -> course.getCategoryType() == criterion.getCategoryType())
+            .filter(course -> matchesMajorScope(course, criterion.getMajorScope()))
+            .toList();
+        List<CompletedCourse> recognizedCourses =
+            academicBasicPolicy.filterRecentMajorAcademicBasic(matchedCourses, criterion);
+
+        return recognizedCourses.stream()
+            .mapToDouble(CompletedCourse::getCredits)
+            .sum();
     }
 
     private boolean matchesMajorScope(CompletedCourse course, MajorScope criterionScope) {

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/AcademicBasicPolicy.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/AcademicBasicPolicy.java
@@ -1,6 +1,9 @@
 package kr.allcll.backend.domain.graduation.credit;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,46 +15,115 @@ public class AcademicBasicPolicy {
     private final RequiredCourseResolver requiredCourseResolver;
     private final CourseEquivalenceRepository courseEquivalenceRepository;
 
-    public boolean isRecentMajorAcademicBasic(CompletedCourse course, CreditCriterion criterion) {
-        if (isNotAcademicBasic(course)) {
-            return true;
+    public List<CompletedCourse> filterRecentMajorAcademicBasic(
+        List<CompletedCourse> courses,
+        CreditCriterion criterion
+    ) {
+        List<CompletedCourse> academicBasicCourses = courses.stream()
+            .filter(this::isAcademicBasic)
+            .toList();
+        if (academicBasicCourses.isEmpty()) {
+            return courses;
         }
-        String curiNm = course.getCuriNm();
-        String curiNo = course.getCuriNo();
-        Integer admissionYear = criterion.getAdmissionYear();
-        String departmentName = criterion.getDeptNm();
-        List<String> academicBasicRequiredCourseNames = requiredCourseResolver.findRequiredCourseNames(
-            departmentName,
-            admissionYear,
+
+        List<String> requiredCourseNames = requiredCourseResolver.findRequiredCourseNames(
+            criterion.getDeptNm(),
+            criterion.getAdmissionYear(),
             CategoryType.ACADEMIC_BASIC
         );
 
-        if (isExistAcademicBasicCourse(academicBasicRequiredCourseNames, curiNm)) {
+        List<CompletedCourse> unmatchedAcademicBasicCourses = academicBasicCourses.stream()
+            .filter(course -> !requiredCourseNames.contains(course.getCuriNm()))
+            .toList();
+
+        Set<String> equivalenceCuriNos = findEquivalenceCuriNos(
+            unmatchedAcademicBasicCourses,
+            criterion
+        );
+
+        return courses.stream()
+            .filter(course -> isRecentMajorAcademicBasic(
+                course,
+                requiredCourseNames,
+                equivalenceCuriNos
+            ))
+            .toList();
+    }
+
+    private boolean isRecentMajorAcademicBasic(
+        CompletedCourse course,
+        List<String> requiredCourseNames,
+        Set<String> equivalenceCuriNos
+    ) {
+        if (!isAcademicBasic(course)) {
             return true;
         }
 
-        return isHaveReplaceOrEquivalenceCourse(admissionYear, departmentName, curiNo);
+        return requiredCourseNames.contains(course.getCuriNm())
+            || equivalenceCuriNos.contains(course.getCuriNo());
     }
 
-    private boolean isExistAcademicBasicCourse(List<String> academicBasicRequiredCourseNames, String courseName) {
-        return academicBasicRequiredCourseNames.contains(courseName);
-    }
-
-    private boolean isNotAcademicBasic(CompletedCourse course) {
-        return !CategoryType.ACADEMIC_BASIC.equals(course.getCategoryType());
-    }
-
-    private boolean isHaveReplaceOrEquivalenceCourse(
-        Integer admissionYear,
-        String departmentName,
-        String curiNo
+    private Set<String> findEquivalenceCuriNos(
+        List<CompletedCourse> unmatchedAcademicBasicCourses,
+        CreditCriterion criterion
     ) {
-        return courseEquivalenceRepository.findSameCourseCodesByCuriNo(curiNo).stream()
-            .anyMatch(sameCourseCode -> requiredCourseResolver.findRequiredCourseInGroup(
-                departmentName,
-                admissionYear,
-                CategoryType.ACADEMIC_BASIC,
-                sameCourseCode
+        Set<String> curiNos = unmatchedAcademicBasicCourses.stream()
+            .map(CompletedCourse::getCuriNo)
+            .collect(Collectors.toSet());
+
+        Map<String, Set<String>> sameCourseCodesByCuriNo = findSameCourseCodesByCuriNo(curiNos);
+        if (sameCourseCodesByCuriNo.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<String> requiredSameCourseCodes = findRequiredSameCourseCodes(
+            sameCourseCodesByCuriNo,
+            criterion
+        );
+
+        return sameCourseCodesByCuriNo.entrySet().stream()
+            .filter(entry -> hasRequiredSameCourseCode(entry.getValue(), requiredSameCourseCodes))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+    }
+
+    private Map<String, Set<String>> findSameCourseCodesByCuriNo(Set<String> curiNos) {
+        if (curiNos.isEmpty()) {
+            return Map.of();
+        }
+
+        return courseEquivalenceRepository.findAllByCuriNoIn(curiNos).stream()
+            .collect(Collectors.groupingBy(
+                CourseEquivalence::getCuriNo,
+                Collectors.mapping(CourseEquivalence::getSameCourseCode, Collectors.toSet())
             ));
+    }
+
+    private Set<String> findRequiredSameCourseCodes(
+        Map<String, Set<String>> sameCourseCodesByCuriNo,
+        CreditCriterion criterion
+    ) {
+        Set<String> sameCourseCodes = sameCourseCodesByCuriNo.values().stream()
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet());
+
+        return requiredCourseResolver.findRequiredCourseInGroups(
+            criterion.getDeptNm(),
+            criterion.getAdmissionYear(),
+            CategoryType.ACADEMIC_BASIC,
+            sameCourseCodes
+        );
+    }
+
+    private boolean hasRequiredSameCourseCode(
+        Set<String> sameCourseCodes,
+        Set<String> requiredSameCourseCodes
+    ) {
+        return sameCourseCodes.stream()
+            .anyMatch(requiredSameCourseCodes::contains);
+    }
+
+    private boolean isAcademicBasic(CompletedCourse course) {
+        return CategoryType.ACADEMIC_BASIC.equals(course.getCategoryType());
     }
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/CourseEquivalenceRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/CourseEquivalenceRepository.java
@@ -15,8 +15,8 @@ public interface CourseEquivalenceRepository extends JpaRepository<CourseEquival
     List<String> findSameGroupCuriNos(Set<String> curiNos);
 
     @Query("""
-        select distinct e.sameCourseCode from CourseEquivalence e
-        where e.curiNo = :curiNo
+        select e from CourseEquivalence e
+        where e.curiNo in :curiNos
     """)
-    List<String> findSameCourseCodesByCuriNo(String curiNo);
+    List<CourseEquivalence> findAllByCuriNoIn(Set<String> curiNos);
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseRepository.java
@@ -1,7 +1,7 @@
 package kr.allcll.backend.domain.graduation.credit;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -38,10 +38,9 @@ public interface RequiredCourseRepository extends JpaRepository<RequiredCourse, 
 
     @Query("""
             select r from RequiredCourse r
-            where r.sameCourseCode = :sameCourseCode
+            where r.sameCourseCode in :sameCourseCodes
             and r.curiNo != :deprecatedCuriNo
-            order by r.admissionYear desc
-            limit 1
+            order by r.admissionYear desc, r.id desc
         """)
-    Optional<RequiredCourse> findCurrentCourseBySameCourseCode(String sameCourseCode, String deprecatedCuriNo);
+    List<RequiredCourse> findCurrentCoursesBySameCourseCodes(Set<String> sameCourseCodes, String deprecatedCuriNo);
 }

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseRepository.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseRepository.java
@@ -27,13 +27,14 @@ public interface RequiredCourseRepository extends JpaRepository<RequiredCourse, 
             where r.deptNm in :deptNms
             and r.admissionYear = :admissionYear
             and r.categoryType = :categoryType
-            and r.sameCourseCode = :sameCourseCode
+            and r.sameCourseCode in :sameCourseCodes
+            order by r.id asc
         """)
-    List<RequiredCourse> findRequiredCoursesBySameCourseCode(
+    List<RequiredCourse> findRequiredCoursesBySameCourseCodes(
         List<String> deptNms,
         Integer admissionYear,
         CategoryType categoryType,
-        String sameCourseCode
+        Set<String> sameCourseCodes
     );
 
     @Query("""

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseResolver.java
@@ -59,6 +59,32 @@ public class RequiredCourseResolver {
             ));
     }
 
+    public Set<String> findRequiredCourseInGroups(
+        String departmentName,
+        Integer admissionYear,
+        CategoryType categoryType,
+        Set<String> sameCourseCodes
+    ) {
+        if (sameCourseCodes.isEmpty()) {
+            return Set.of();
+        }
+
+        Map<String, List<RequiredCourse>> candidatesBySameCourseCode =
+            requiredCourseRepository.findRequiredCoursesBySameCourseCodes(
+                    List.of(WILD_CARD_DEPT_NM, departmentName),
+                    admissionYear,
+                    categoryType,
+                    sameCourseCodes
+                )
+                .stream()
+                .collect(Collectors.groupingBy(RequiredCourse::getSameCourseCode));
+
+        return candidatesBySameCourseCode.entrySet().stream()
+            .filter(candidates -> hasRequiredCourse(candidates.getValue(), departmentName))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+    }
+
     /**
      * DEPRECATED 지정과목의 현행 과목을 동일과목 그룹 단위로 한 번에 조회한다.
      */
@@ -81,24 +107,17 @@ public class RequiredCourseResolver {
         return currentCoursesBySameCourseCode;
     }
 
-    public boolean findRequiredCourseInGroup(
-        String departmentName,
-        Integer admissionYear,
-        CategoryType categoryType,
-        String sameCourseCode
+    private List<RequiredCourseResponse> resolveDeprecatedCourses(
+        List<RequiredCourse> requiredCourses,
+        Map<String, RequiredCourse> currentCoursesBySameCourseCode
     ) {
-        List<RequiredCourse> requiredCourseCandidatesWithWildCard =
-            requiredCourseRepository.findRequiredCoursesBySameCourseCode(
-                List.of(WILD_CARD_DEPT_NM, departmentName),
-                admissionYear,
-                categoryType,
-                sameCourseCode
-            );
+        return requiredCourses.stream()
+            .map(requiredCourse -> mapToCurrentCourse(requiredCourse, currentCoursesBySameCourseCode))
+            .toList();
+    }
 
-        List<RequiredCourse> requiredCoursesWithStatus
-            = getDepartmentRequiredCourses(requiredCourseCandidatesWithWildCard, departmentName);
-
-        return requiredCoursesWithStatus.stream()
+    private boolean hasRequiredCourse(List<RequiredCourse> candidateRequiredCourses, String departmentName) {
+        return getDepartmentRequiredCourses(candidateRequiredCourses, departmentName).stream()
             .anyMatch(RequiredCourse::getRequired);
     }
 
@@ -141,15 +160,6 @@ public class RequiredCourseResolver {
         }
 
         return requiredCourseCandidates.values().stream().toList();
-    }
-
-    private List<RequiredCourseResponse> resolveDeprecatedCourses(
-        List<RequiredCourse> requiredCourses,
-        Map<String, RequiredCourse> currentCoursesBySameCourseCode
-    ) {
-        return requiredCourses.stream()
-            .map(requiredCourse -> mapToCurrentCourse(requiredCourse, currentCoursesBySameCourseCode))
-            .toList();
     }
 
     private boolean isWildCardRule(RequiredCourse requiredCourse, String departmentName) {

--- a/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseResolver.java
+++ b/src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseResolver.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import kr.allcll.backend.domain.graduation.credit.dto.RequiredCourseResponse;
 import kr.allcll.backend.support.graduation.KeyUtils;
@@ -42,12 +44,41 @@ public class RequiredCourseResolver {
             selectedByCourseKey.put(courseKey, course);
         }
 
-        return selectedByCourseKey.values().stream()
+        List<RequiredCourse> requiredCourses = selectedByCourseKey.values().stream()
             .filter(RequiredCourse::getRequired)
+            .toList();
+        Map<String, RequiredCourse> currentCoursesBySameCourseCode = findCurrentCourses(requiredCourses);
+
+        return requiredCourses.stream()
             .collect(Collectors.groupingBy(
                 RequiredCourse::getCategoryType,
-                Collectors.collectingAndThen(Collectors.toList(), this::resolveDeprecatedCourses)
+                Collectors.collectingAndThen(
+                    Collectors.toList(),
+                    categoryCourses -> resolveDeprecatedCourses(categoryCourses, currentCoursesBySameCourseCode)
+                )
             ));
+    }
+
+    /**
+     * DEPRECATED 지정과목의 현행 과목을 동일과목 그룹 단위로 한 번에 조회한다.
+     */
+    private Map<String, RequiredCourse> findCurrentCourses(List<RequiredCourse> requiredCourses) {
+        Set<String> deprecatedSameCourseCodes = requiredCourses.stream()
+            .filter(requiredCourse -> isDeprecated(requiredCourse.getCuriNo()))
+            .map(RequiredCourse::getSameCourseCode)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        if (deprecatedSameCourseCodes.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, RequiredCourse> currentCoursesBySameCourseCode = new HashMap<>();
+        requiredCourseRepository.findCurrentCoursesBySameCourseCodes(deprecatedSameCourseCodes, DEPRECATED)
+            .forEach(currentCourse ->
+                currentCoursesBySameCourseCode.putIfAbsent(currentCourse.getSameCourseCode(), currentCourse)
+            );
+        return currentCoursesBySameCourseCode;
     }
 
     public boolean findRequiredCourseInGroup(
@@ -112,9 +143,12 @@ public class RequiredCourseResolver {
         return requiredCourseCandidates.values().stream().toList();
     }
 
-    public List<RequiredCourseResponse> resolveDeprecatedCourses(List<RequiredCourse> requiredCourses) {
+    private List<RequiredCourseResponse> resolveDeprecatedCourses(
+        List<RequiredCourse> requiredCourses,
+        Map<String, RequiredCourse> currentCoursesBySameCourseCode
+    ) {
         return requiredCourses.stream()
-            .map(this::mapToCurrentCourse)
+            .map(requiredCourse -> mapToCurrentCourse(requiredCourse, currentCoursesBySameCourseCode))
             .toList();
     }
 
@@ -126,18 +160,21 @@ public class RequiredCourseResolver {
         return requiredCourse.getDeptNm().equals(departmentName);
     }
 
-    private RequiredCourseResponse mapToCurrentCourse(RequiredCourse requiredCourse) {
+    private RequiredCourseResponse mapToCurrentCourse(
+        RequiredCourse requiredCourse,
+        Map<String, RequiredCourse> currentCoursesBySameCourseCode
+    ) {
         if (isNotDeprecated(requiredCourse.getCuriNo())) {
             return RequiredCourseResponse.of(requiredCourse.getCuriNo(), requiredCourse.getCuriNm());
         }
-        return requiredCourseRepository.findCurrentCourseBySameCourseCode(requiredCourse.getSameCourseCode(), DEPRECATED)
-            .map(currentCourse -> RequiredCourseResponse.of(currentCourse.getCuriNo(), currentCourse.getCuriNm()))
-            .orElseGet(() -> {
-                log.error(
-                    "[졸업요건] DEPRECATED된 과목의 현재 과목 조회에 실패했습니다. sameCourseCode={}", requiredCourse.getSameCourseCode()
-                );
-                return RequiredCourseResponse.of(requiredCourse.getCuriNo(), requiredCourse.getCuriNm());
-            });
+        RequiredCourse currentCourse = currentCoursesBySameCourseCode.get(requiredCourse.getSameCourseCode());
+        if (currentCourse == null) {
+            log.error(
+                "[졸업요건] DEPRECATED된 과목의 현재 과목 조회에 실패했습니다. sameCourseCode={}", requiredCourse.getSameCourseCode()
+            );
+            return RequiredCourseResponse.of(requiredCourse.getCuriNo(), requiredCourse.getCuriNm());
+        }
+        return RequiredCourseResponse.of(currentCourse.getCuriNo(), currentCourse.getCuriNm());
     }
 
     private boolean isNotDeprecated(String curiNo) {

--- a/src/main/java/kr/allcll/backend/support/metrics/QueryMetrics.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/QueryMetrics.java
@@ -1,0 +1,76 @@
+package kr.allcll.backend.support.metrics;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Component;
+
+/**
+ * 요청 하나가 DB에 쓴 비용을 엔드포인트별로 기록한다.
+ *
+ * - 메트릭 두 개를 노출한다.
+ *  # 요청당 SQL문 수(db_query_count)
+ *  # 요청당 SQL 실행 시간(db_query_time_seconds)
+ */
+
+@Component
+public class QueryMetrics {
+
+    private static final String QUERY_COUNT_METER_NAME = "db.query.count";
+    private static final String QUERY_TIME_METER_NAME = "db.query.time";
+    private static final String URI_TAG = "uri";
+
+    private static final double[] QUERY_COUNT_BUCKETS = {1, 2, 3, 5, 10, 20, 50, 100, 500, 1_000, 5_000};
+
+    private static final Duration[] QUERY_TIME_BUCKETS = {
+        Duration.ofMillis(1), Duration.ofMillis(2), Duration.ofMillis(5), Duration.ofMillis(10),
+        Duration.ofMillis(20), Duration.ofMillis(50), Duration.ofMillis(100), Duration.ofMillis(200),
+        Duration.ofMillis(500), Duration.ofSeconds(1), Duration.ofSeconds(2), Duration.ofSeconds(5)
+    };
+
+    private final MeterRegistry meterRegistry;
+    private final Map<String, DistributionSummary> queryCountSummaries = new ConcurrentHashMap<>();
+    private final Map<String, Timer> queryTimeTimers = new ConcurrentHashMap<>();
+
+    public QueryMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * @param uriTemplate 실제 경로가 아니라 핸들러 매핑 패턴(/api/baskets/{subjectId}). 경로를 넘기면 시계열이 무한히 늘어난다.
+     */
+    public void registerEndpoint(String uriTemplate) {
+        queryCountSummaries.computeIfAbsent(uriTemplate, this::registerQueryCountSummary);
+        queryTimeTimers.computeIfAbsent(uriTemplate, this::registerQueryTimeTimer);
+    }
+
+    /**
+     * @param uriTemplate 실제 경로가 아니라 핸들러 매핑 패턴(/api/baskets/{subjectId}). 경로를 넘기면 시계열이 무한히 늘어난다.
+     */
+    public void record(String uriTemplate, RequestQueryStats queryStats) {
+        queryCountSummaries.computeIfAbsent(uriTemplate, this::registerQueryCountSummary)
+            .record(queryStats.statementCount());
+        queryTimeTimers.computeIfAbsent(uriTemplate, this::registerQueryTimeTimer)
+            .record((long) (queryStats.executionMillis() * 1_000), TimeUnit.MICROSECONDS);
+    }
+
+    private DistributionSummary registerQueryCountSummary(String uriTemplate) {
+        return DistributionSummary.builder(QUERY_COUNT_METER_NAME)
+            .description("요청 1건이 발행한 SQL 문 수")
+            .tag(URI_TAG, uriTemplate)
+            .serviceLevelObjectives(QUERY_COUNT_BUCKETS)
+            .register(meterRegistry);
+    }
+
+    private Timer registerQueryTimeTimer(String uriTemplate) {
+        return Timer.builder(QUERY_TIME_METER_NAME)
+            .description("요청 1건이 SQL 실행에 쓴 시간")
+            .tag(URI_TAG, uriTemplate)
+            .serviceLevelObjectives(QUERY_TIME_BUCKETS)
+            .register(meterRegistry);
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/metrics/QueryStatsSessionListener.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/QueryStatsSessionListener.java
@@ -1,0 +1,21 @@
+package kr.allcll.backend.support.metrics;
+
+import org.hibernate.SessionEventListener;
+
+/**
+ * Hibernate 가 JDBC 문을 실행할 때마다 실행 시간을 RequestQueryStats에 수집한다.
+ */
+public class QueryStatsSessionListener implements SessionEventListener {
+
+    private long statementStartNanos;
+
+    @Override
+    public void jdbcExecuteStatementStart() {
+        statementStartNanos = System.nanoTime();
+    }
+
+    @Override
+    public void jdbcExecuteStatementEnd() {
+        RequestQueryStats.recordStatement(System.nanoTime() - statementStartNanos);
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/metrics/RequestQueryStats.java
+++ b/src/main/java/kr/allcll/backend/support/metrics/RequestQueryStats.java
@@ -1,0 +1,44 @@
+package kr.allcll.backend.support.metrics;
+
+/**
+ * 요청 하나가 DB에 쓴 비용 - 발행한 SQL문 수와 그 실행에 걸린 시간을 함께 수집한다.
+ */
+public class RequestQueryStats {
+
+    private static final RequestQueryStats EMPTY = new RequestQueryStats();
+    private static final double NANOS_PER_MILLI = 1_000_000.0;
+    private static final ThreadLocal<RequestQueryStats> CURRENT = new ThreadLocal<>();
+
+    private int statementCount;
+    private long executionNanos;
+
+    public static void start() {
+        CURRENT.set(new RequestQueryStats());
+    }
+
+    public static RequestQueryStats stop() {
+        RequestQueryStats current = CURRENT.get();
+        CURRENT.remove();
+        if (current == null) {
+            return EMPTY;
+        }
+        return current;
+    }
+
+    static void recordStatement(long elapsedNanos) {
+        RequestQueryStats current = CURRENT.get();
+        if (current == null) {
+            return;
+        }
+        current.statementCount++;
+        current.executionNanos += elapsedNanos;
+    }
+
+    public int statementCount() {
+        return statementCount;
+    }
+
+    public double executionMillis() {
+        return executionNanos / NANOS_PER_MILLI;
+    }
+}

--- a/src/main/java/kr/allcll/backend/support/web/QueryMetricsFilter.java
+++ b/src/main/java/kr/allcll/backend/support/web/QueryMetricsFilter.java
@@ -1,0 +1,44 @@
+package kr.allcll.backend.support.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import kr.allcll.backend.support.metrics.QueryMetrics;
+import kr.allcll.backend.support.metrics.RequestQueryStats;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerMapping;
+
+/**
+ * 요청 경계에서 DB 비용 집계를 시작·종료하고 엔드포인트별로 기록한다.
+ */
+@RequiredArgsConstructor
+public class QueryMetricsFilter extends OncePerRequestFilter {
+
+    private final QueryMetrics queryMetrics;
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        RequestQueryStats.start();
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            record(request, RequestQueryStats.stop());
+        }
+    }
+
+    private void record(HttpServletRequest request, RequestQueryStats queryStats) {
+        Object uriTemplate = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        if (uriTemplate == null) {
+            return;
+        }
+        queryMetrics.record(uriTemplate.toString(), queryStats);
+    }
+}

--- a/src/test/java/kr/allcll/backend/domain/graduation/credit/AcademicBasicPolicyTest.java
+++ b/src/test/java/kr/allcll/backend/domain/graduation/credit/AcademicBasicPolicyTest.java
@@ -1,11 +1,18 @@
 package kr.allcll.backend.domain.graduation.credit;
 
 import static kr.allcll.backend.fixture.CompletedCourseFixture.createCompletedCourse;
+import static kr.allcll.backend.fixture.CourseEquivalenceFixture.createCourseEquivalence;
 import static kr.allcll.backend.fixture.CreditCriterionFixture.createAcademicBasicCriterion;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 import java.util.List;
+import java.util.Set;
 import kr.allcll.backend.domain.graduation.check.excel.CompletedCourse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,21 +34,21 @@ class AcademicBasicPolicyTest {
 
     @Test
     @DisplayName("ACADEMIC_BASIC이 아닌 과목은 검사 없이 통과한다")
-    void returnTrueWhenNotAcademicBasic() {
+    void passThroughCourseWhenNotAcademicBasic() {
         // given
         CompletedCourse course = createCompletedCourse("123456", "알고리즘및실습", CategoryType.MAJOR_BASIC);
         CreditCriterion criterion = createAcademicBasicCriterion("컴퓨터공학과", 2021);
 
         // when
-        boolean result = academicBasicPolicy.isRecentMajorAcademicBasic(course, criterion);
+        List<CompletedCourse> result = academicBasicPolicy.filterRecentMajorAcademicBasic(List.of(course), criterion);
 
         // then
-        assertThat(result).isTrue();
+        assertThat(result).containsExactly(course);
     }
 
     @Test
-    @DisplayName("필수 과목 리스트에 존재하는 과목이면 true를 반환한다")
-    void returnTrueWhenDirectMatch() {
+    @DisplayName("학과 지정과목명에 있는 과목은 학문기초로 인정한다")
+    void acceptCourseWhenNameMatchesRequiredCourse() {
         // given
         String courseName = "공학설계기초";
         String departmentName = "컴퓨터공학과";
@@ -57,15 +64,15 @@ class AcademicBasicPolicyTest {
         ).willReturn(List.of("공학설계기초", "기초미적분학"));
 
         // when
-        boolean result = academicBasicPolicy.isRecentMajorAcademicBasic(course, criterion);
+        List<CompletedCourse> result = academicBasicPolicy.filterRecentMajorAcademicBasic(List.of(course), criterion);
 
         // then
-        assertThat(result).isTrue();
+        assertThat(result).containsExactly(course);
     }
 
     @Test
-    @DisplayName("필수 과목에 없지만 동일과목 그룹에 속하면 true를 반환한다")
-    void returnTrueWhenGroupCodeMatchesRequiredCourse() {
+    @DisplayName("지정과목명에 없어도 동일과목 그룹으로 인정되면 학문기초로 인정한다")
+    void acceptCourseWhenGroupCodeMatchesRequiredCourse() {
         // given
         String curiNo = "123456";
         String sameCourseCode = "1";
@@ -81,27 +88,27 @@ class AcademicBasicPolicyTest {
                 CategoryType.ACADEMIC_BASIC
             )
         ).willReturn(List.of());
-        given(courseEquivalenceRepository.findSameCourseCodesByCuriNo(curiNo))
-            .willReturn(List.of(sameCourseCode));
+        given(courseEquivalenceRepository.findAllByCuriNoIn(Set.of(curiNo)))
+            .willReturn(List.of(createCourseEquivalence(curiNo, sameCourseCode)));
         given(
-            requiredCourseResolver.findRequiredCourseInGroup(
+            requiredCourseResolver.findRequiredCourseInGroups(
                 departmentName,
                 admissionYear,
                 CategoryType.ACADEMIC_BASIC,
-                sameCourseCode
+                Set.of(sameCourseCode)
             )
-        ).willReturn(true);
+        ).willReturn(Set.of(sameCourseCode));
 
         // when
-        boolean result = academicBasicPolicy.isRecentMajorAcademicBasic(course, criterion);
+        List<CompletedCourse> result = academicBasicPolicy.filterRecentMajorAcademicBasic(List.of(course), criterion);
 
         // then
-        assertThat(result).isTrue();
+        assertThat(result).containsExactly(course);
     }
 
     @Test
-    @DisplayName("여러 동일과목 그룹에 속한 과목은 그중 하나라도 필수과목을 포함하면 true를 반환한다")
-    void returnTrueWhenAnyOfMultipleGroupsMatchesRequiredCourse() {
+    @DisplayName("여러 동일과목 그룹에 속하면 그중 하나만 인정되어도 학문기초로 인정한다")
+    void acceptCourseWhenAnyOfMultipleGroupsMatchesRequiredCourse() {
         // given
         String curiNo = "009960";
         String firstGroupCode = "1";
@@ -119,35 +126,31 @@ class AcademicBasicPolicyTest {
                 CategoryType.ACADEMIC_BASIC
             )
         ).willReturn(List.of());
-        given(courseEquivalenceRepository.findSameCourseCodesByCuriNo(curiNo))
-            .willReturn(List.of(firstGroupCode, secondGroupCode));
+        given(courseEquivalenceRepository.findAllByCuriNoIn(Set.of(curiNo)))
+            .willReturn(List.of(
+                createCourseEquivalence(curiNo, firstGroupCode),
+                createCourseEquivalence(curiNo, secondGroupCode)
+            ));
         given(
-            requiredCourseResolver.findRequiredCourseInGroup(
+            requiredCourseResolver.findRequiredCourseInGroups(
                 departmentName,
                 admissionYear,
                 CategoryType.ACADEMIC_BASIC,
-                firstGroupCode
+                Set.of(firstGroupCode, secondGroupCode)
             )
-        ).willReturn(false);
-        given(
-            requiredCourseResolver.findRequiredCourseInGroup(
-                departmentName,
-                admissionYear,
-                CategoryType.ACADEMIC_BASIC,
-                secondGroupCode
-            )
-        ).willReturn(true);
+        ).willReturn(Set.of(secondGroupCode));
 
         // when
-        boolean result = academicBasicPolicy.isRecentMajorAcademicBasic(course, criterion);
+        List<CompletedCourse> result = academicBasicPolicy.filterRecentMajorAcademicBasic(List.of(course), criterion);
 
         // then
-        assertThat(result).isTrue();
+        assertThat(result).containsExactly(course);
     }
 
     @Test
-    @DisplayName("과목명이 필수과목에 없고 동일과목 그룹에 속하지만, 해당 과의 이수 요건에 해당하지 않으면 false를 반환한다")
-    void returnFalseWhenGroupCodeNotMatchesRequiredCourse() {
+    @DisplayName("동일과목 그룹에 속해도 해당 학과의 지정과목이 아니면 학문기초로 인정하지 않는다")
+    void rejectCourseWhenGroupCodeNotMatchesRequiredCourse() {
+        // given
         String curiNo = "123456";
         String sameCourseCode = "1";
         String departmentName = "컴퓨터공학과";
@@ -162,26 +165,27 @@ class AcademicBasicPolicyTest {
                 CategoryType.ACADEMIC_BASIC
             )
         ).willReturn(List.of());
-        given(courseEquivalenceRepository.findSameCourseCodesByCuriNo(curiNo))
-            .willReturn(List.of(sameCourseCode));
+        given(courseEquivalenceRepository.findAllByCuriNoIn(Set.of(curiNo)))
+            .willReturn(List.of(createCourseEquivalence(curiNo, sameCourseCode)));
         given(
-            requiredCourseResolver.findRequiredCourseInGroup(
+            requiredCourseResolver.findRequiredCourseInGroups(
                 departmentName,
                 admissionYear,
                 CategoryType.ACADEMIC_BASIC,
-                sameCourseCode)
-        ).willReturn(false); //해당 학과의 지정 과목이 required=false인 경우
+                Set.of(sameCourseCode)
+            )
+        ).willReturn(Set.of()); //해당 학과의 지정 과목이 required=false인 경우
 
         // when
-        boolean result = academicBasicPolicy.isRecentMajorAcademicBasic(course, criterion);
+        List<CompletedCourse> result = academicBasicPolicy.filterRecentMajorAcademicBasic(List.of(course), criterion);
 
         // then
-        assertThat(result).isFalse();
+        assertThat(result).isEmpty();
     }
 
     @Test
-    @DisplayName("과목명이 필수과목에도 없고 동일과목 그룹에도 속하지 않으면 false를 반환한다")
-    void returnFalseWhenCuriNoNotInEquivalence() {
+    @DisplayName("지정과목명에도 없고 동일과목 그룹에도 속하지 않으면 학문기초로 인정하지 않는다")
+    void rejectCourseWhenCuriNoNotInEquivalence() {
         // given
         String curiNo = "123456";
         String departmentName = "컴퓨터공학과";
@@ -191,13 +195,49 @@ class AcademicBasicPolicyTest {
 
         given(requiredCourseResolver.findRequiredCourseNames(departmentName, admissionYear, CategoryType.ACADEMIC_BASIC))
             .willReturn(List.of());
-        given(courseEquivalenceRepository.findSameCourseCodesByCuriNo(curiNo))
+        given(courseEquivalenceRepository.findAllByCuriNoIn(Set.of(curiNo)))
             .willReturn(List.of());
 
         // when
-        boolean result = academicBasicPolicy.isRecentMajorAcademicBasic(course, criterion);
+        List<CompletedCourse> result = academicBasicPolicy.filterRecentMajorAcademicBasic(List.of(course), criterion);
 
         // then
-        assertThat(result).isFalse();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("학문기초 과목이 여러 개여도 지정과목·동일과목 조회는 각각 한 번만 수행한다")
+    void queryOncePerCourseList() {
+        // given
+        String departmentName = "컴퓨터공학과";
+        Integer admissionYear = 2021;
+        List<CompletedCourse> courses = List.of(
+            createCompletedCourse("100001", "공학설계기초", CategoryType.ACADEMIC_BASIC),
+            createCompletedCourse("100002", "옛날공학설계기초", CategoryType.ACADEMIC_BASIC),
+            createCompletedCourse("100003", "존재하지않는과목", CategoryType.ACADEMIC_BASIC)
+        );
+        CreditCriterion criterion = createAcademicBasicCriterion(departmentName, admissionYear);
+
+        given(requiredCourseResolver.findRequiredCourseNames(departmentName, admissionYear, CategoryType.ACADEMIC_BASIC))
+            .willReturn(List.of("공학설계기초"));
+        given(courseEquivalenceRepository.findAllByCuriNoIn(Set.of("100002", "100003")))
+            .willReturn(List.of(createCourseEquivalence("100002", "1")));
+        given(
+            requiredCourseResolver.findRequiredCourseInGroups(
+                departmentName,
+                admissionYear,
+                CategoryType.ACADEMIC_BASIC,
+                Set.of("1")
+            )
+        ).willReturn(Set.of("1"));
+
+        // when
+        List<CompletedCourse> result = academicBasicPolicy.filterRecentMajorAcademicBasic(courses, criterion);
+
+        // then
+        assertThat(result).containsExactly(courses.get(0), courses.get(1));
+        then(requiredCourseResolver).should(times(1))
+            .findRequiredCourseNames(anyString(), anyInt(), any(CategoryType.class));
+        then(courseEquivalenceRepository).should(times(1)).findAllByCuriNoIn(any());
     }
 }

--- a/src/test/java/kr/allcll/backend/fixture/CourseEquivalenceFixture.java
+++ b/src/test/java/kr/allcll/backend/fixture/CourseEquivalenceFixture.java
@@ -1,0 +1,10 @@
+package kr.allcll.backend.fixture;
+
+import kr.allcll.backend.domain.graduation.credit.CourseEquivalence;
+
+public class CourseEquivalenceFixture {
+
+    public static CourseEquivalence createCourseEquivalence(String curiNo, String sameCourseCode) {
+        return new CourseEquivalence(sameCourseCode, curiNo, "테스트과목");
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/metrics/QueryMetricsIntegrationTest.java
+++ b/src/test/java/kr/allcll/backend/support/metrics/QueryMetricsIntegrationTest.java
@@ -1,0 +1,68 @@
+package kr.allcll.backend.support.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class QueryMetricsIntegrationTest {
+
+    private static final String NOTICES_URI = "/api/notices";
+    private static final String NEVER_CALLED_URI = "/api/baskets";
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("요청을 보내면 그 요청이 쓴 쿼리 수와 시간이 엔드포인트별로 기록된다.")
+    void recordQueryStatsOnRealRequest() {
+        // given
+        RestAssured.given().when().get(NOTICES_URI).then().statusCode(200);
+
+        // when
+        DistributionSummary queryCount = meterRegistry.find("db.query.count").tag("uri", NOTICES_URI).summary();
+        Timer queryTime = meterRegistry.find("db.query.time").tag("uri", NOTICES_URI).timer();
+
+        // then
+        assertThat(queryCount).isNotNull();
+        assertThat(queryCount.count()).isPositive();
+        assertThat(queryCount.totalAmount()).isPositive();
+        assertThat(queryTime).isNotNull();
+        assertThat(queryTime.count()).isPositive();
+    }
+
+    @Test
+    @DisplayName("요청이 한 번도 없던 엔드포인트도 기동 시점에 미터가 등록돼 있다.")
+    void registerEndpointBeforeFirstRequest() {
+        // given
+        // 이 테스트는 NEVER_CALLED_URI 로 요청을 보내지 않는다
+
+        // when
+        DistributionSummary queryCount = meterRegistry.find("db.query.count").tag("uri", NEVER_CALLED_URI).summary();
+        Timer queryTime = meterRegistry.find("db.query.time").tag("uri", NEVER_CALLED_URI).timer();
+
+        // then
+        assertThat(queryCount).isNotNull();
+        assertThat(queryCount.count()).isZero();
+        assertThat(queryTime).isNotNull();
+        assertThat(queryTime.count()).isZero();
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/metrics/QueryStatsSessionListenerTest.java
+++ b/src/test/java/kr/allcll/backend/support/metrics/QueryStatsSessionListenerTest.java
@@ -1,0 +1,59 @@
+package kr.allcll.backend.support.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class QueryStatsSessionListenerTest {
+
+    @Test
+    @DisplayName("SQL문 실행 시작과 종료 사이의 시간을 집계에 더한다.")
+    void recordExecutionTime() {
+        // given
+        RequestQueryStats.start();
+        QueryStatsSessionListener listener = new QueryStatsSessionListener();
+
+        // when
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+
+        // then
+        RequestQueryStats queryStats = RequestQueryStats.stop();
+        assertThat(queryStats.statementCount()).isEqualTo(1);
+        assertThat(queryStats.executionMillis()).isNotNegative();
+    }
+
+    @Test
+    @DisplayName("한 세션에서 쿼리문을 여러 번 실행하면 실행 수만큼 집계된다.")
+    void recordEveryStatementInSession() {
+        // given
+        RequestQueryStats.start();
+        QueryStatsSessionListener listener = new QueryStatsSessionListener();
+
+        // when
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+
+        // then
+        assertThat(RequestQueryStats.stop().statementCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("집계를 시작하지 않은 스레드의 실행은 무시한다.")
+    void ignoreExecutionWithoutStart() {
+        // given
+        QueryStatsSessionListener listener = new QueryStatsSessionListener();
+
+        // when
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+
+        // then
+        assertThat(RequestQueryStats.stop().statementCount()).isZero();
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/metrics/RequestQueryStatsTest.java
+++ b/src/test/java/kr/allcll/backend/support/metrics/RequestQueryStatsTest.java
@@ -1,0 +1,77 @@
+package kr.allcll.backend.support.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RequestQueryStatsTest {
+
+    private static final long ONE_MILLI_NANOS = 1_000_000L;
+
+    @Test
+    @DisplayName("집계를 시작한 뒤 실행한 SQL 수와 시간을 수집한다.")
+    void collectCountAndTimeAfterStart() {
+        // given
+        RequestQueryStats.start();
+
+        // when
+        RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+        RequestQueryStats.recordStatement(2 * ONE_MILLI_NANOS);
+
+        // then
+        RequestQueryStats queryStats = RequestQueryStats.stop();
+        assertThat(queryStats.statementCount()).isEqualTo(2);
+        assertThat(queryStats.executionMillis()).isEqualTo(3.0);
+    }
+
+    @Test
+    @DisplayName("집계를 시작하지 않은 스레드에서는 수집하지 않는다.")
+    void collectNothingWithoutStart() {
+        // given
+        RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+
+        // when
+        RequestQueryStats queryStats = RequestQueryStats.stop();
+
+        // then
+        assertThat(queryStats.statementCount()).isZero();
+        assertThat(queryStats.executionMillis()).isZero();
+    }
+
+    @Test
+    @DisplayName("스레드마다 따로 수집하므로 동시 요청이 서로 섞이지 않는다.")
+    void collectPerThread() {
+        // given
+        RequestQueryStats.start();
+        RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+
+        // when
+        int otherThreadCount = CompletableFuture.supplyAsync(() -> {
+            RequestQueryStats.start();
+            RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+            RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+            return RequestQueryStats.stop().statementCount();
+        }).join();
+
+        // then
+        assertThat(otherThreadCount).isEqualTo(2);
+        assertThat(RequestQueryStats.stop().statementCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("집계를 끝내면 값이 남지 않아 스레드를 재사용해도 이어서 수집하지 않는다.")
+    void resetAfterStop() {
+        // given
+        RequestQueryStats.start();
+        RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+        RequestQueryStats.stop();
+
+        // when
+        RequestQueryStats.recordStatement(ONE_MILLI_NANOS);
+
+        // then
+        assertThat(RequestQueryStats.stop().statementCount()).isZero();
+    }
+}

--- a/src/test/java/kr/allcll/backend/support/web/QueryMetricsFilterTest.java
+++ b/src/test/java/kr/allcll/backend/support/web/QueryMetricsFilterTest.java
@@ -1,0 +1,107 @@
+package kr.allcll.backend.support.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import kr.allcll.backend.support.metrics.QueryMetrics;
+import kr.allcll.backend.support.metrics.QueryStatsSessionListener;
+import kr.allcll.backend.support.metrics.RequestQueryStats;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.HandlerMapping;
+
+class QueryMetricsFilterTest {
+
+    private MeterRegistry meterRegistry;
+    private QueryMetricsFilter queryMetricsFilter;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        queryMetricsFilter = new QueryMetricsFilter(new QueryMetrics(meterRegistry));
+    }
+
+    @Test
+    @DisplayName("요청이 실행한 SQL 수와 시간을 핸들러 매핑 패턴 태그로 기록한다.")
+    void recordQueryStatsWithUriTemplateTag() throws Exception {
+        // given
+        MockHttpServletRequest request = requestWithUriTemplate("/api/baskets/{subjectId}");
+
+        // when
+        queryMetricsFilter.doFilter(request, new MockHttpServletResponse(), (req, res) -> {
+            executeStatement();
+            executeStatement();
+        });
+
+        // then
+        DistributionSummary queryCount = findQueryCount("/api/baskets/{subjectId}");
+        assertThat(queryCount).isNotNull();
+        assertThat(queryCount.count()).isEqualTo(1);
+        assertThat(queryCount.totalAmount()).isEqualTo(2.0);
+
+        Timer queryTime = findQueryTime("/api/baskets/{subjectId}");
+        assertThat(queryTime).isNotNull();
+        assertThat(queryTime.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("핸들러가 매칭되지 않은 요청은 기록하지 않는다.")
+    void skipUnmappedRequest() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/존재하지않는경로");
+
+        // when
+        queryMetricsFilter.doFilter(request, new MockHttpServletResponse(), (req, res) -> {
+        });
+
+        // then
+        assertThat(meterRegistry.find("db.query.count").summaries()).isEmpty();
+        assertThat(meterRegistry.find("db.query.time").timers()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("요청 처리 중 예외가 나도 집계를 정리해 다음 요청에 값이 새지 않는다.")
+    void clearStatsWhenRequestFails() {
+        // given
+        MockHttpServletRequest request = requestWithUriTemplate("/api/subjects");
+
+        // when
+        try {
+            queryMetricsFilter.doFilter(request, new MockHttpServletResponse(), (req, res) -> {
+                executeStatement();
+                throw new IllegalStateException("조회 실패");
+            });
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(findQueryCount("/api/subjects").totalAmount()).isEqualTo(1.0);
+        assertThat(RequestQueryStats.stop().statementCount()).isZero();
+    }
+
+    private void executeStatement() {
+        QueryStatsSessionListener listener = new QueryStatsSessionListener();
+        listener.jdbcExecuteStatementStart();
+        listener.jdbcExecuteStatementEnd();
+    }
+
+    private MockHttpServletRequest requestWithUriTemplate(String uriTemplate) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", uriTemplate);
+        request.setAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, uriTemplate);
+        return request;
+    }
+
+    private DistributionSummary findQueryCount(String uri) {
+        return meterRegistry.find("db.query.count").tag("uri", uri).summary();
+    }
+
+    private Timer findQueryTime(String uri) {
+        return meterRegistry.find("db.query.time").tag("uri", uri).timer();
+    }
+}


### PR DESCRIPTION
## 작업 배경
조회 경로의 쿼리 비용을 점검하고 병목을 개선했습니다.

기존 테스트는 H2 인메모리 DB를 사용해 쿼리 왕복 비용이 거의 없어 N+1 문제를 발견하기 어려웠습니다. 
또한 운영 환경에서 요청당 SQL 실행 수를 확인할 방법이 없어 실제 조회 비용과 개선 효과를 정량적으로 확인하기 어려웠습니다.

이에 실제 SQL 실행 수를 기준으로 조회 경로를 점검하고, N+1 개선을 진행했습니다.

## 작업 내용
### N+1 조회 5건 개선
반복문 내부에서 `Repository`를 호출하는 조회 경로를 확인하고, 동일한 데이터를 반복 조회하던 5개 경로를 일괄 조회 방식으로 개선했습니다.

**1. 관심과목 전체 조회**

> **[기존 코드의 문제점]**
> `BasketService#getBasketsEachSubject`에서 조회된 과목마다 `basketRepository.findBySubjectId`를 호출해 과목 수만큼 추가 쿼리가 발생했습니다.
> 
> **[해결 방안]**
> 과목 ID를 한 번에 조회하고 집계 쿼리로 필요한 인원 수만 가져오도록 변경했습니다.
> - 과목별 Basket 조회 → 집계 쿼리 1회
> - 엔티티 전체 조회 → 프로젝션 기반 조회

**2. 졸업요건 학문기초 검사**

> **[기존 코드의 문제점]**
> `AcademicBasicPolicy#isRecentMajorAcademicBasic`에서 이수 과목을 하나씩 판정하면서 
> 동일한 조건의 조회를 과목 수만큼 반복했습니다.
> 
> **[해결 방안]**
> 과목 단위 판정을 목록 단위 판정으로 변경해 필요한 조회를 각각 한 번씩 수행하도록 묶었습니다.
> - 반복 조회 → 목록 단위 일괄 조회
> - 기존 판정 규칙은 그대로 유지

**3. 졸업요건 지정과목 조회**

> **[기존 코드의 문제점]**
> 폐지 과목을 현행 과목으로 치환하는 과정에서 과목마다 최신 현행 과목을 조회해 반복적인 DB 접근이 발생했습니다.
> 
> **[해결 방안]**
> `DEPRECATED` 과목의 `sameCourseCode`를 먼저 모아 현행 과목을 한 번에 조회하고, 
> 결과를 Map으로 구성해 메모리에서 매칭하도록 변경했습니다.
> - 과목별 조회 → 일괄 조회 + Map 매칭
> - 기존 order by admission_year desc limit 1과 동일한 우선순위를 유지

**4. 크롤러 핀 과목 전달**

> **[기존 코드의 문제점]**
> `TargetSubjectService#resolveSubjectWithPriority`에서 핀 과목마다 `findById`를 호출해 전달되는 과목 수에 따라 조회 쿼리가 증가했습니다.
> 
> **[해결 방안]**
> 과목 ID를 한 번에 조회한 뒤 ID를 기준으로 Map에서 매칭하도록 변경했습니다.
> - 과목별 findById → findAllById 일괄 조회
> - 조회되지 않은 과목은 기존과 동일하게 `SUBJECT_NOT_FOUND` 처리

**5. 과목 동기화**

> **[기존 코드의 문제점]**
> `AdminSubjectService#updateChangedSubjects`에서 변경된 과목마다 `findByLogicalKeyIncludingDeleted`를 호출했습니다. 하지만 해당 과목들은 `syncSubjects` 초반에 이미 전체 조회한 상태였기 때문에 동일한 데이터를 다시 조회하는 불필요한 쿼리가 발생했습니다. 또한 반복적인 조회 과정에서 Flush가 발생해 변경 과목 수에 따라 UPDATE 쿼리도 함께 증가했습니다.
> 
> **[해결 방안]**
> 이미 조회한 기존 과목 목록을 logical key 기준 Map으로 구성하고, 변경 대상 과목을 메모리에서 매칭하도록 변경했습니다.
> - 변경 과목별 재조회 → 기존 조회 결과 재사용
> - 기존 1 + 2N → 1 + N 쿼리
> - 불필요한 재조회와 반복적인 Flush 제거

## 성능 측정
운영 DB 복원본과 동일한 규모의 로컬 MySQL 8.0.41 환경에서 측정했습니다.
| 대상 | 쿼리 수 | p50 | 개선 배수 |
| --- | ---: | ---: | ---: |
| 과목 동기화 (2,646개 변경) | 5,293 → 2,647 | 44,662.6 → 234.8ms | **190.2배** |
| 과목 동기화 (500개 변경) | 1,001 → 501 | 8,716.3 → 63.9ms | **136.4배** |
| 크롤러 핀 과목 전달 (203개) | 203 → 1 | 50.5 → 3.7ms | **13.5배** |
| 관심과목 전체 조회 | 2,647 → 2 | 402.0 → 38.3ms | **10.5배** |
| 졸업요건 검사 | 54 → 19 | 81.4 → 40.6ms | **2.0배** |

> 로컬 측정값은 운영 환경과 하드웨어·동시성 차이가 있어 절대적인 운영 성능 개선으로 해석하지 않습니다.
> 운영에서는 요청당 SQL 실행 수와 쿼리 실행 시간을 1차 기준으로 삼아 배포 후 효과를 검증할 예정입니다.

## 운영 적용 계획
개선 전 운영 쿼리 수 baseline이 없기 때문에 다음과 같이 단계적으로 배포합니다.
1. [DB 모니터링 지표 설정 PR]() 배포 - db_query_count, db_query_time_seconds baseline 확보
2. 코드 개선 PR(현 PR) 배포 -N+1 제거에 따른 쿼리 수 감소 확인
3. 인덱스 추가 적용 예정 - 쿼리 수는 동일한 상태에서 DB 실행 시간 감소 여부 확인

각 단계 사이에 충분한 관측 기간을 두고 다음 지표를 비교합니다.

> - db_query_count p95
> - db_query_time_seconds p95
> - HTTP 응답 시간 p95
> - HikariCP 사용 시간 및 pending/active
> - MySQL rows_examined / rows_sent
> - 인덱스 실제 사용 여부

## 검증
1. 졸업요건 전 사용자 2,018명 결과 전수 비교 완료 → 차이 0건
2. 관심과목 / 크롤러 핀 과목 / 과목 동기화 결과 비교 → 모두 일치
3. ./gradlew clean build 통과

---

이번 변경은 조회 경로의 불필요한 DB 왕복을 줄이고
요청당 DB 비용을 지속적으로 측정할 수 있는 기반을 마련하는 것​에 초점을 맞췄습니다! 

## 고민 지점과 리뷰 포인트
N+1 제거를 위해 일괄 조회 및 메모리 매칭 방식으로 변경한 방향이 적절한지 !!
성능 측정 및 단계적 배포를 포함한 전체적인 개선 방향에 다른 의견이나 더 나은 방법이 있다면 리뷰 부탁드립니다!!!

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->

---

## Codex Review
- `src/main/java/kr/allcll/backend/domain/basket/BasketRepository.java:20` -- "이 부분이 max를 추출하네요!"
- `src/main/java/kr/allcll/backend/domain/graduation/credit/RequiredCourseRepository.java:44` -- "이 부분이 첫번째 조회 값을 가져오다가 id를 기준으로 더 큰 아이를 가져오게 바뀌었네요!! 의도한걸까요?! 이 부분이 더 나을까요?? 이 부분에 대해서는 사실 큰 영향이 생각나진 않는데 기존이랑 바뀐 부분 같아서 코멘트 남겨봅니다!"

---
- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기