### PR TITLE
[TSK-150] 로그 수집 범위 수정, stack trace 수정

### DIFF
--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -13,6 +13,12 @@ loki.source.file "allcll" {
       "env"         = "prod",
       "level"       = "info",
     },
+    {
+      "__path__"    = "/var/log/allcll/spring-boot-application-warn.log",
+      "application" = "backend",
+      "env"         = "prod",
+      "level"       = "warn",
+    },
   ]
   forward_to = [loki.write.local.receiver]
 }

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -1,4 +1,4 @@
-loki.source.file "allcll_error" {
+loki.source.file "allcll" {
   tail_from_end           = true
   targets = [
     {
@@ -6,6 +6,12 @@ loki.source.file "allcll_error" {
       "application" = "backend",
       "env"         = "prod",
       "level"       = "error",
+    },
+    {
+      "__path__"    = "/var/log/allcll/spring-boot-application-info.log",
+      "application" = "backend",
+      "env"         = "prod",
+      "level"       = "info",
     },
   ]
   forward_to = [loki.write.local.receiver]

--- a/src/main/java/kr/allcll/backend/support/web/RequestIdFilter.java
+++ b/src/main/java/kr/allcll/backend/support/web/RequestIdFilter.java
@@ -5,7 +5,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.UUID;
+import java.security.SecureRandom;
+import java.util.Base64;
 import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -17,6 +18,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class RequestIdFilter extends OncePerRequestFilter {
 
     static final String REQUEST_ID_MDC_KEY = "requestId";
+    private static final int REQUEST_ID_BYTE_LENGTH = 9;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
     @Override
     protected void doFilterInternal(
@@ -24,12 +28,18 @@ public class RequestIdFilter extends OncePerRequestFilter {
         HttpServletResponse response,
         FilterChain filterChain
     ) throws ServletException, IOException {
-        MDC.put(REQUEST_ID_MDC_KEY, UUID.randomUUID().toString());
+        MDC.put(REQUEST_ID_MDC_KEY, generateRequestId());
 
         try {
             filterChain.doFilter(request, response);
         } finally {
             MDC.remove(REQUEST_ID_MDC_KEY);
         }
+    }
+
+    private String generateRequestId() {
+        byte[] randomBytes = new byte[REQUEST_ID_BYTE_LENGTH];
+        SECURE_RANDOM.nextBytes(randomBytes);
+        return URL_ENCODER.encodeToString(randomBytes);
     }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -74,7 +74,7 @@
   <property name="LOG_PATTERN"
     value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr([requestId=%X{requestId:-}]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
   <property name="LOG_FILE_PATTERN"
-    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %-5level ${PID:-} --- [%15.15thread] [requestId=%X{requestId:-}] %-40.40logger{36} : %msg%n%ex{20}"/>
+    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %-5level ${PID:-} --- [%15.15thread] [requestId=%X{requestId:-}] %-40.40logger{36} : %msg%n%nopex"/>
 
   <!--  ec2와 local 에서의 로그 경로 분리  -->
   <property name="LOG_PATH" value="${LOG_PATH:-/home/ubuntu/app/logs}"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -74,7 +74,7 @@
   <property name="LOG_PATTERN"
     value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr([requestId=%X{requestId:-}]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
   <property name="LOG_FILE_PATTERN"
-    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %-5level ${PID:-} --- [%15.15thread] [requestId=%X{requestId:-}] %-40.40logger{36} : %msg%n"/>
+    value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %-5level ${PID:-} --- [%15.15thread] [requestId=%X{requestId:-}] %-40.40logger{36} : %msg%n%ex{20}"/>
 
   <!--  ec2와 local 에서의 로그 경로 분리  -->
   <property name="LOG_PATH" value="${LOG_PATH:-/home/ubuntu/app/logs}"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -107,8 +107,9 @@
   </springProfile>
 
   <springProfile name="prod">
-    <root level="ERROR">
+    <root level="INFO">
       <appender-ref ref="ERROR-ROLLING"/>
+      <appender-ref ref="INFO-ROLLING"/>
     </root>
   </springProfile>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -109,6 +109,7 @@
   <springProfile name="prod">
     <root level="INFO">
       <appender-ref ref="ERROR-ROLLING"/>
+      <appender-ref ref="WARN-ROLLING"/>
       <appender-ref ref="INFO-ROLLING"/>
     </root>
   </springProfile>

--- a/src/test/java/kr/allcll/backend/support/web/RequestIdFilterTest.java
+++ b/src/test/java/kr/allcll/backend/support/web/RequestIdFilterTest.java
@@ -1,7 +1,6 @@
 package kr.allcll.backend.support.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ch.qos.logback.classic.Level;
@@ -10,7 +9,6 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import jakarta.servlet.ServletException;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +28,7 @@ class RequestIdFilterTest {
     }
 
     @Test
-    void 요청_처리_중에는_서버가_생성한_UUID_requestId가_MDC에_있고_응답은_그대로_전달된다() throws Exception {
+    void 요청_처리_중에는_서버가_생성한_12자리_requestId가_MDC에_있고_응답은_그대로_전달된다() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("X-Request-Id", "client-supplied-request-id");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -43,7 +41,7 @@ class RequestIdFilterTest {
         });
 
         assertThat(requestIdDuringRequest.get()).isNotNull().isNotEqualTo("client-supplied-request-id");
-        assertThatCode(() -> UUID.fromString(requestIdDuringRequest.get())).doesNotThrowAnyException();
+        assertThat(requestIdDuringRequest.get()).matches("[A-Za-z0-9_-]{12}");
         assertThat(response.getStatus()).isEqualTo(HttpStatus.CREATED.value());
         assertThat(response.getContentAsString()).isEqualTo("unchanged-response");
         assertThat(MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY)).isNull();
@@ -64,8 +62,8 @@ class RequestIdFilterTest {
     }
 
     @Test
-    void UUID_requestId는_로그_패턴에_출력될_수_있다() {
-        String requestId = UUID.randomUUID().toString();
+    void 짧은_requestId는_로그_패턴에_출력될_수_있다() {
+        String requestId = "Cx8rP2mKq9Vd";
         MDC.put(RequestIdFilter.REQUEST_ID_MDC_KEY, requestId);
 
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();


### PR DESCRIPTION
## 작업 내용
### 로그 수집 범위 수정
1. 운영 서버에서 로그 범위를 INFO도 추가했습니다.
2. Loki에서도 수집하도록 수정했습니다.

### stack trace 수정
기존에 회의록에서 stack trace를 제거한다고 한 것 같은데 맞나요?
컨텍스트를 더 듣고싶습니다~!
stack trace를 sentry에서 활용하지 않고 있나요..?! loki나 sentry에서 활용할 수 있지 않나해서요, 아예 없애는 방안이 어떤 맥락에서 나온 건지 더 듣고 싶어요!
그래서 우선은 20줄까지만 나오도록 해봤는데 의견 더 주시면 맞춰보면 좋겠어요!
+)추가로, 용량을 초과하면 롤링할 수도 있다고 하네요! 이 방안도 있으니 필요한데 용량때문에 없애는거라면, 더 다방면을 고려해볼 수 있을 것 같아요!!!

## 고민 지점과 리뷰 포인트
stack trace에 대해 컨텍스트 공유 + 의견 주세요!!

1. stack trace 아예 없애는게 낫다고 판단한 이유가 어떤 것인지?
2. 용량 때문이라면 다른 방안을 함께 고려했으나 아예 제거가 낫다고 판단한 것인지?
3. loki와 sentry에 활용 가능성이 없어서 그렇게 결정했는지?
4. 20줄도 너무 많아보이는지?

요런 것들이 위주로 궁금한 것 같아용
<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->