### PR TITLE
[TSK-151] 여석 처리 반복 DB 조회 축소

### DIFF
--- a/src/main/java/kr/allcll/backend/admin/seat/AdminSeatService.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/AdminSeatService.java
@@ -9,12 +9,10 @@ import kr.allcll.backend.admin.seat.dto.SeatStatusResponse;
 import kr.allcll.backend.domain.seat.SeatStorage;
 import kr.allcll.backend.domain.seat.dto.SeatDto;
 import kr.allcll.backend.domain.subject.Subject;
-import kr.allcll.backend.domain.subject.SubjectRepository;
 import kr.allcll.backend.support.batch.BatchService;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
 import kr.allcll.backend.support.exception.AllcllException;
 import kr.allcll.backend.support.metrics.SeatPipelineMetrics;
-import kr.allcll.backend.support.semester.Semester;
 import kr.allcll.backend.support.web.PrefixParser;
 import kr.allcll.backend.support.web.TokenProvider;
 import kr.allcll.crawler.client.SeatClient;
@@ -45,7 +43,6 @@ public class AdminSeatService {
     private final SeatStorage seatStorage;
     private final AtomicLong lastSuccessCrawlingTime = new AtomicLong(0);
     private final BatchService batchService;
-    private final SubjectRepository subjectRepository;
     private final SeatPipelineMetrics seatPipelineMetrics;
 
     public void getAllSeatPeriodically(String userId, SeatUtilsType seatUtilsType) {
@@ -120,7 +117,7 @@ public class AdminSeatService {
 
     private void crawlPinSeatAndBuffer(CrawlerSubject pinSubject, Credential credential, SeatUtilsType seatUtilsType) {
         try {
-            CrawlerSeat crawlerSeat = sendExternalSeatRequest(pinSubject, credential, seatUtilsType);
+            CrawlerSeat crawlerSeat = sendExternalSeatRequest(pinSubject, credential, seatUtilsType, true);
             recordCrawlingSuccess();
 
             batchService.savePinSeatBatch(crawlerSeat);
@@ -135,7 +132,7 @@ public class AdminSeatService {
     private void crawlGeneralSeatAndBuffer(CrawlerSubject generalSubject, Credential credential,
         SeatUtilsType seatUtilsType) {
         try {
-            CrawlerSeat crawlerSeat = sendExternalSeatRequest(generalSubject, credential, seatUtilsType);
+            CrawlerSeat crawlerSeat = sendExternalSeatRequest(generalSubject, credential, seatUtilsType, false);
             recordCrawlingSuccess();
 
             batchService.saveGeneralSeatBatch(crawlerSeat);
@@ -150,15 +147,20 @@ public class AdminSeatService {
     private CrawlerSeat sendExternalSeatRequest(
         CrawlerSubject crawlerSubject,
         Credential credential,
-        SeatUtilsType seatUtilsType
+        SeatUtilsType seatUtilsType,
+        boolean pinSubject
     ) {
         log.info("[AdminSeatService] [학교 서버] 요청 시도 과목: {}", crawlerSubject);
         SeatPayload requestPayload = SeatPayload.from(crawlerSubject);
         SeatResponse response = seatClient.execute(credential, requestPayload);
         CrawlerSeat renewedCrawlerSeat = createSeat(response, crawlerSubject);
 
-        Subject subject = subjectRepository.findById(crawlerSubject.getId(), Semester.getCurrentSemester())
-            .orElseThrow(() -> new AllcllException(AllcllErrorCode.SUBJECT_NOT_FOUND, crawlerSubject.getId()));
+        Subject subject;
+        if (pinSubject) {
+            subject = targetSubjectStorage.getPinSubject(crawlerSubject.getId());
+        } else {
+            subject = targetSubjectStorage.getGeneralSubject(crawlerSubject.getId());
+        }
 
         seatStorage.add(
             new SeatDto(

--- a/src/main/java/kr/allcll/backend/admin/seat/AdminSeatService.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/AdminSeatService.java
@@ -35,6 +35,8 @@ import org.springframework.stereotype.Service;
 public class AdminSeatService {
 
     private static final long RECENT_CRAWLING_SUCCESS_THRESHOLD_MS = 3_000;
+    private static final boolean PIN_SUBJECT = true;
+    private static final boolean GENERAL_SUBJECT = false;
     private final SeatClient seatClient;
     private final Credentials credentials;
     private final TargetSubjectStorage targetSubjectStorage;
@@ -117,7 +119,7 @@ public class AdminSeatService {
 
     private void crawlPinSeatAndBuffer(CrawlerSubject pinSubject, Credential credential, SeatUtilsType seatUtilsType) {
         try {
-            CrawlerSeat crawlerSeat = sendExternalSeatRequest(pinSubject, credential, seatUtilsType, true);
+            CrawlerSeat crawlerSeat = sendExternalSeatRequest(pinSubject, credential, seatUtilsType, PIN_SUBJECT);
             recordCrawlingSuccess();
 
             batchService.savePinSeatBatch(crawlerSeat);
@@ -132,7 +134,7 @@ public class AdminSeatService {
     private void crawlGeneralSeatAndBuffer(CrawlerSubject generalSubject, Credential credential,
         SeatUtilsType seatUtilsType) {
         try {
-            CrawlerSeat crawlerSeat = sendExternalSeatRequest(generalSubject, credential, seatUtilsType, false);
+            CrawlerSeat crawlerSeat = sendExternalSeatRequest(generalSubject, credential, seatUtilsType, GENERAL_SUBJECT);
             recordCrawlingSuccess();
 
             batchService.saveGeneralSeatBatch(crawlerSeat);

--- a/src/main/java/kr/allcll/backend/admin/seat/TargetSubjectStorage.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/TargetSubjectStorage.java
@@ -47,8 +47,7 @@ public class TargetSubjectStorage {
 
     public void addPinSubjects(Map<CrawlerSubject, Integer> subjects) {
         String currentSemester = Semester.getCurrentSemester();
-        Map<Long, Subject> updatedPinSubjects = loadMissingPinSubjects(subjects, currentSemester);
-        pinSubjectsById = updatedPinSubjects;
+        pinSubjectsById = loadMissingPinSubjects(subjects, currentSemester);
         pinSnapshotSemester = currentSemester;
 
         firstPriorityQueue.clear();

--- a/src/main/java/kr/allcll/backend/admin/seat/TargetSubjectStorage.java
+++ b/src/main/java/kr/allcll/backend/admin/seat/TargetSubjectStorage.java
@@ -1,11 +1,19 @@
 package kr.allcll.backend.admin.seat;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import kr.allcll.backend.domain.subject.Subject;
+import kr.allcll.backend.domain.subject.SubjectRepository;
+import kr.allcll.backend.support.exception.AllcllErrorCode;
+import kr.allcll.backend.support.exception.AllcllException;
+import kr.allcll.backend.support.semester.Semester;
 import kr.allcll.crawler.subject.CrawlerSubject;
 import org.springframework.stereotype.Component;
 
@@ -16,20 +24,33 @@ public class TargetSubjectStorage {
     private final Queue<CrawlerSubject> firstPriorityQueue;
     private final Queue<CrawlerSubject> secondPriorityQueue;
     private final Queue<CrawlerSubject> thirdPriorityQueue;
+    private final SubjectRepository subjectRepository;
+    private volatile Map<Long, Subject> generalSubjectsById = Map.of();
+    private volatile Map<Long, Subject> pinSubjectsById = Map.of();
+    private volatile String generalSnapshotSemester;
+    private volatile String pinSnapshotSemester;
 
-    public TargetSubjectStorage() {
+    public TargetSubjectStorage(SubjectRepository subjectRepository) {
         this.generalSubjectsQueue = new ConcurrentLinkedQueue<>();
         this.firstPriorityQueue = new ConcurrentLinkedQueue<>();
         this.secondPriorityQueue = new ConcurrentLinkedQueue<>();
         this.thirdPriorityQueue = new ConcurrentLinkedQueue<>();
+        this.subjectRepository = subjectRepository;
     }
 
     public void addGeneralSubjects(List<CrawlerSubject> crawlerSubjects) {
         generalSubjectsQueue.clear();
         generalSubjectsQueue.addAll(crawlerSubjects);
+        generalSubjectsById = loadSubjects(crawlerSubjects);
+        generalSnapshotSemester = Semester.getCurrentSemester();
     }
 
     public void addPinSubjects(Map<CrawlerSubject, Integer> subjects) {
+        String currentSemester = Semester.getCurrentSemester();
+        Map<Long, Subject> updatedPinSubjects = loadMissingPinSubjects(subjects, currentSemester);
+        pinSubjectsById = updatedPinSubjects;
+        pinSnapshotSemester = currentSemester;
+
         firstPriorityQueue.clear();
         secondPriorityQueue.clear();
         thirdPriorityQueue.clear();
@@ -50,6 +71,14 @@ public class TargetSubjectStorage {
                     throw new IllegalArgumentException("Invalid priority: " + priority);
             }
         }
+    }
+
+    public Subject getGeneralSubject(Long subjectId) {
+        return getSubject(generalSubjectsById, generalSnapshotSemester, subjectId);
+    }
+
+    public Subject getPinSubject(Long subjectId) {
+        return getSubject(pinSubjectsById, pinSnapshotSemester, subjectId);
     }
 
     public CrawlerSubject getNextGeneralTarget() {
@@ -105,6 +134,58 @@ public class TargetSubjectStorage {
 
     public List<CrawlerSubject> getTargetGeneralSubjects() {
         return new LinkedList<>(generalSubjectsQueue);
+    }
+
+    private Map<Long, Subject> loadSubjects(List<CrawlerSubject> crawlerSubjects) {
+        String currentSemester = Semester.getCurrentSemester();
+        return loadSubjects(crawlerSubjects, currentSemester);
+    }
+
+    private Map<Long, Subject> loadMissingPinSubjects(
+        Map<CrawlerSubject, Integer> subjects,
+        String currentSemester
+    ) {
+        Map<Long, Subject> cachedSubjects = getCurrentPinSubjects(currentSemester);
+        List<CrawlerSubject> missingSubjects = subjects.keySet().stream()
+            .filter(crawlerSubject -> !cachedSubjects.containsKey(crawlerSubject.getId()))
+            .toList();
+
+        if (missingSubjects.isEmpty()) {
+            return cachedSubjects;
+        }
+
+        Map<Long, Subject> loadedSubjects = loadSubjects(missingSubjects, currentSemester);
+        Map<Long, Subject> mergedSubjects = new HashMap<>(cachedSubjects);
+        mergedSubjects.putAll(loadedSubjects);
+        return Map.copyOf(mergedSubjects);
+    }
+
+    private Map<Long, Subject> getCurrentPinSubjects(String currentSemester) {
+        if (!currentSemester.equals(pinSnapshotSemester)) {
+            return Map.of();
+        }
+        return pinSubjectsById;
+    }
+
+    private Map<Long, Subject> loadSubjects(List<CrawlerSubject> crawlerSubjects, String currentSemester) {
+        List<Long> subjectIds = crawlerSubjects.stream()
+            .map(CrawlerSubject::getId)
+            .toList();
+        return subjectRepository.findAllById(subjectIds).stream()
+            .filter(subject -> !subject.isDeleted())
+            .filter(subject -> currentSemester.equals(subject.getSemesterAt()))
+            .collect(Collectors.toUnmodifiableMap(Subject::getId, Function.identity()));
+    }
+
+    private Subject getSubject(Map<Long, Subject> subjectsById, String snapshotSemester, Long subjectId) {
+        if (!Semester.getCurrentSemester().equals(snapshotSemester)) {
+            throw new AllcllException(AllcllErrorCode.SUBJECT_NOT_FOUND, subjectId);
+        }
+        Subject subject = subjectsById.get(subjectId);
+        if (subject == null) {
+            throw new AllcllException(AllcllErrorCode.SUBJECT_NOT_FOUND, subjectId);
+        }
+        return subject;
     }
 
     private enum Priority {

--- a/src/main/java/kr/allcll/backend/client/ExternalService.java
+++ b/src/main/java/kr/allcll/backend/client/ExternalService.java
@@ -32,11 +32,16 @@ public class ExternalService {
 
     private PinSubjectUpdateRequest getPinSubjects() {
         Set<String> activeSseTokens = Set.copyOf(sseEmitterStorage.getUserTokens());
-        List<Pin> currentSemesterPins = pinRepository.findAllBySemesterAt(Semester.getCurrentSemester());
 
-        List<Pin> activePins = currentSemesterPins.stream()
-            .filter(pin -> activeSseTokens.contains(pin.getToken()))
-            .toList();
+        if (activeSseTokens.isEmpty()) {
+            return new PinSubjectUpdateRequest(List.of());
+        }
+
+        List<Pin> activePins = pinRepository.findAllByTokenInAndSemesterAt(
+            activeSseTokens,
+            Semester.getCurrentSemester()
+        );
+
         Map<Subject, Integer> pinCountBySubject = activePins.stream()
             .collect(Collectors.groupingBy(
                 Pin::getSubject,

--- a/src/test/java/kr/allcll/backend/admin/seat/TargetSubjectStorageTest.java
+++ b/src/test/java/kr/allcll/backend/admin/seat/TargetSubjectStorageTest.java
@@ -1,0 +1,81 @@
+package kr.allcll.backend.admin.seat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import kr.allcll.backend.domain.subject.Subject;
+import kr.allcll.backend.domain.subject.SubjectRepository;
+import kr.allcll.backend.support.semester.Semester;
+import kr.allcll.crawler.subject.CrawlerSubject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TargetSubjectStorageTest {
+
+    @Mock
+    private SubjectRepository subjectRepository;
+
+    @Mock
+    private CrawlerSubject crawlerSubjectA;
+
+    @Mock
+    private CrawlerSubject crawlerSubjectB;
+
+    @Mock
+    private Subject subjectA;
+
+    @Mock
+    private Subject subjectB;
+
+    private TargetSubjectStorage targetSubjectStorage;
+
+    @BeforeEach
+    void setUp() {
+        targetSubjectStorage = new TargetSubjectStorage(subjectRepository);
+
+        given(crawlerSubjectA.getId()).willReturn(1L);
+        given(crawlerSubjectB.getId()).willReturn(2L);
+        given(subjectA.getId()).willReturn(1L);
+        given(subjectB.getId()).willReturn(2L);
+        given(subjectA.isDeleted()).willReturn(false);
+        given(subjectB.isDeleted()).willReturn(false);
+        given(subjectA.getSemesterAt()).willReturn(Semester.getCurrentSemester());
+        given(subjectB.getSemesterAt()).willReturn(Semester.getCurrentSemester());
+    }
+
+    @Test
+    @DisplayName("핀 대상이 유지되면 Subject를 다시 조회하지 않고 새 대상만 조회한다.")
+    void reusePinSubjectSnapshotAndLoadOnlyNewSubjects() {
+        // given
+        given(subjectRepository.findAllById(List.of(1L))).willReturn(List.of(subjectA));
+        given(subjectRepository.findAllById(List.of(2L))).willReturn(List.of(subjectB));
+
+        // when
+        targetSubjectStorage.addPinSubjects(pinSubjects(crawlerSubjectA));
+        targetSubjectStorage.addPinSubjects(pinSubjects(crawlerSubjectA));
+        targetSubjectStorage.addPinSubjects(pinSubjects(crawlerSubjectA, crawlerSubjectB));
+
+        // then
+        verify(subjectRepository).findAllById(List.of(1L));
+        verify(subjectRepository).findAllById(List.of(2L));
+        assertThat(targetSubjectStorage.getPinSubject(1L)).isSameAs(subjectA);
+        assertThat(targetSubjectStorage.getPinSubject(2L)).isSameAs(subjectB);
+    }
+
+    private Map<CrawlerSubject, Integer> pinSubjects(CrawlerSubject... crawlerSubjects) {
+        Map<CrawlerSubject, Integer> subjects = new LinkedHashMap<>();
+        for (CrawlerSubject crawlerSubject : crawlerSubjects) {
+            subjects.put(crawlerSubject, 1);
+        }
+        return subjects;
+    }
+}

--- a/src/test/java/kr/allcll/backend/client/ExternalClientTest.java
+++ b/src/test/java/kr/allcll/backend/client/ExternalClientTest.java
@@ -8,15 +8,19 @@ import kr.allcll.backend.admin.seat.TargetSubjectStorage;
 import kr.allcll.backend.admin.seat.dto.PinSubjectUpdateRequest;
 import kr.allcll.backend.admin.seat.dto.PinSubjectUpdateRequest.PinSubject;
 import kr.allcll.backend.domain.seat.SeatStorage;
+import kr.allcll.backend.domain.seat.pin.Pin;
+import kr.allcll.backend.domain.seat.pin.PinRepository;
 import kr.allcll.backend.domain.subject.Subject;
 import kr.allcll.backend.domain.subject.SubjectRepository;
 import kr.allcll.backend.fixture.SubjectFixture;
+import kr.allcll.backend.support.sse.SseEmitterStorage;
 import kr.allcll.crawler.subject.CrawlerSubject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @SpringBootTest(classes = AllcllBackendApplication.class)
 class ExternalClientTest {
@@ -25,7 +29,13 @@ class ExternalClientTest {
     private ExternalClient externalClient;
 
     @Autowired
+    private ExternalService externalService;
+
+    @Autowired
     private SubjectRepository subjectRepository;
+
+    @Autowired
+    private PinRepository pinRepository;
 
     @Autowired
     private SeatStorage seatStorage;
@@ -33,9 +43,13 @@ class ExternalClientTest {
     @Autowired
     private TargetSubjectStorage targetSubjectStorage;
 
+    @Autowired
+    private SseEmitterStorage sseEmitterStorage;
+
     @AfterEach
     void tearDown() {
         seatStorage.clear();
+        pinRepository.deleteAllInBatch();
         subjectRepository.deleteAllInBatch();
     }
 
@@ -63,5 +77,47 @@ class ExternalClientTest {
                 subjectA.getId(),
                 subjectB.getId()
             );
+        assertThat(targetSubjectStorage.getPinSubject(subjectA.getId()).getId()).isEqualTo(subjectA.getId());
+
+        // 대상 과목이 변경되면 snapshot도 새 대상 기준으로 교체된다.
+        externalClient.sendPinSubjects(new PinSubjectUpdateRequest(List.of(new PinSubject(subjectB.getId(), 1))));
+
+        assertThat(targetSubjectStorage.getTargetSubjects())
+            .extracting(CrawlerSubject::getId)
+            .containsExactly(subjectB.getId());
+        assertThat(targetSubjectStorage.getPinSubject(subjectB.getId()).getId()).isEqualTo(subjectB.getId());
+    }
+
+    @Test
+    @DisplayName("활성 SSE token의 핀 과목만 크롤러 대상에 전달한다.")
+    void sendWantPinSubjectsToCrawler() {
+        // given
+        Subject activeSubject = subjectRepository.save(
+            SubjectFixture.createMajorSubject(null, "활성 과목", "000001", "001", "김주환")
+        );
+        Subject inactiveSubject = subjectRepository.save(
+            SubjectFixture.createMajorSubject(null, "비활성 과목", "000002", "001", "김주환")
+        );
+        String activeToken = "active-token";
+        SseEmitter emitter = new SseEmitter();
+        sseEmitterStorage.add(activeToken, emitter);
+        pinRepository.saveAll(List.of(
+            new Pin(activeToken, activeSubject),
+            new Pin("inactive-token", inactiveSubject)
+        ));
+
+        try {
+            // when
+            externalService.sendWantPinSubjectIdsToCrawler();
+
+            // then
+            assertThat(targetSubjectStorage.getTargetSubjects())
+                .extracting(CrawlerSubject::getId)
+                .containsExactly(activeSubject.getId());
+            assertThat(targetSubjectStorage.getPinSubject(activeSubject.getId()).getId())
+                .isEqualTo(activeSubject.getId());
+        } finally {
+            emitter.complete();
+        }
     }
 }


### PR DESCRIPTION
## 작업 내용

### 1. 핀 우선순위 동기화 조회 개선

[기존] 
현재 학기의 모든 Pin을 조회한 뒤 애플리케이션에서 활성 SSE token을 필터링했습니다

[개선 후]
- 활성 token과 현재 학기 조건을 DB 조회에 포함해 필요한 Pin만 조회합니다.
- 활성 token이 없으면 Pin DB 조회를 생략합니다.

### 2. 크롤링 응답의 Subject 조회 개선

[기존] 
크롤링 응답마다 `SubjectRepository.findById()`를 호출했습니다.

[개선 후]
- 대상 과목 적재 시 `Subject`를 일괄 조회해 메모리 Map에 저장합니다.
- 일반 과목은 크롤링 시작 시 생성한 snapshot을 사용합니다.
- 핀 과목은 학기 단위 cache를 사용하며, 이미 cache에 있는 과목은 재조회하지 않습니다.
- 새로 추가된 핀 과목 ID만 일괄 조회합니다.
- 이후 크롤링 응답에서는 Map에서 `Subject`를 조회합니다.

## 유지한 동작

- 핀 대상 동기화 주기
- 핀·일반 과목의 1초 주기 여석 크롤링
- 핀 우선순위 정책
- 사용자에게 전달되는 여석 결과
- 여석 저장 및 배치 처리 방식

## 후속 확인

- 운영 또는 스테이징 환경에서 변경 전후 SQL count와 실행 시간을 비교할 예정입니다.
- `TargetSubjectStorage`의 큐 관리와 Subject cache 책임 분리는 별도 리팩토링을 진행할 예정입니다.

---

## Codex Review
- `src/main/java/kr/allcll/backend/admin/seat/TargetSubjectStorage.java:51` -- "```suggestion"
- `src/main/java/kr/allcll/backend/admin/seat/AdminSeatService.java:120` -- "굳이 enum분리 보단(https://github.com/allcll/allcll-backend/pull/416#pullrequestreview-4957336260) 상수로 빼는 것 어떤가요?"

---
- [ ] `/apply-codex` 커맨드를 로컬에서 실행하기