### PR TITLE
feat: [AI] 로그인 HTTP 연결 이벤트 로깅 추가

### DIFF
--- a/src/main/java/kr/allcll/backend/client/ConnectionEventListener.java
+++ b/src/main/java/kr/allcll/backend/client/ConnectionEventListener.java
@@ -2,17 +2,28 @@ package kr.allcll.backend.client;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Call;
 import okhttp3.Connection;
 import okhttp3.EventListener;
+import okhttp3.Protocol;
 
 @Slf4j
 public class ConnectionEventListener extends EventListener {
 
+    private long connectStartNanos;
+
     @Override
     public void connectStart(Call call, InetSocketAddress inetSocketAddress, Proxy proxy) {
+        connectStartNanos = System.nanoTime();
         log.info("[CONN] new connection to {}", inetSocketAddress);
+    }
+
+    @Override
+    public void connectEnd(Call call, InetSocketAddress inetSocketAddress, Proxy proxy, Protocol protocol) {
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - connectStartNanos);
+        log.info("[CONN] connected: {}ms, host={}, protocol={}", elapsedMs, inetSocketAddress, protocol);
     }
 
     @Override

--- a/src/main/java/kr/allcll/backend/client/ConnectionEventListener.java
+++ b/src/main/java/kr/allcll/backend/client/ConnectionEventListener.java
@@ -1,0 +1,27 @@
+package kr.allcll.backend.client;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.EventListener;
+
+@Slf4j
+public class ConnectionEventListener extends EventListener {
+
+    @Override
+    public void connectStart(Call call, InetSocketAddress inetSocketAddress, Proxy proxy) {
+        log.info("[CONN] new connection to {}", inetSocketAddress);
+    }
+
+    @Override
+    public void connectionAcquired(Call call, Connection connection) {
+        log.info("[CONN] acquired: {}", connection);
+    }
+
+    @Override
+    public void connectionReleased(Call call, Connection connection) {
+        log.info("[CONN] released: {}", connection);
+    }
+}

--- a/src/main/java/kr/allcll/backend/client/ConnectionHeaderInterceptor.java
+++ b/src/main/java/kr/allcll/backend/client/ConnectionHeaderInterceptor.java
@@ -1,0 +1,20 @@
+package kr.allcll.backend.client;
+
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+@Slf4j
+public class ConnectionHeaderInterceptor implements Interceptor {
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Response response = chain.proceed(chain.request());
+        String connectionHeader = response.header("Connection");
+        if ("close".equalsIgnoreCase(connectionHeader)) {
+            log.warn("[CONN] Connection: close. url={}", chain.request().url());
+        }
+        return response;
+    }
+}

--- a/src/main/java/kr/allcll/backend/domain/user/AuthFacade.java
+++ b/src/main/java/kr/allcll/backend/domain/user/AuthFacade.java
@@ -26,9 +26,12 @@ public class AuthFacade {
 
     @Transactional
     public LoginResult login(LoginRequest loginRequest) {
+        long loginStart = System.currentTimeMillis();
         OkHttpClient client = authService.login(loginRequest);
+        long portalElapsed = System.currentTimeMillis() - loginStart;
 
         boolean toscLoginFailed = false;
+        long toscStart = System.currentTimeMillis();
         try {
             toscAuthService.loginTosc(loginRequest);
         } catch (Exception exception) {
@@ -36,6 +39,10 @@ public class AuthFacade {
             log.error("[TOSC] 로그인 실패로 TOSC 정보 업데이트를 건너뜁니다. exceptionType={}",
                 exception.getClass().getSimpleName());
         }
+        long toscElapsed = System.currentTimeMillis() - toscStart;
+        long totalElapsed = System.currentTimeMillis() - loginStart;
+        log.info("[PERF] 로그인 소요시간: portal={}ms, tosc={}ms, total={}ms",
+            portalElapsed, toscElapsed, totalElapsed);
 
         UserInfo userInfo = userFetcher.fetch(client);
         User user = userService.findOrCreate(userInfo);

--- a/src/main/java/kr/allcll/backend/domain/user/AuthService.java
+++ b/src/main/java/kr/allcll/backend/domain/user/AuthService.java
@@ -3,6 +3,8 @@ package kr.allcll.backend.domain.user;
 import java.io.IOException;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
+import kr.allcll.backend.client.ConnectionEventListener;
+import kr.allcll.backend.client.ConnectionHeaderInterceptor;
 import kr.allcll.backend.client.LoginProperties;
 import kr.allcll.backend.domain.user.dto.LoginRequest;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
@@ -33,6 +35,8 @@ public class AuthService {
 
             OkHttpClient client = new OkHttpClient().newBuilder()
                 .cookieJar(new JavaNetCookieJar(cookieManager))
+                .eventListener(new ConnectionEventListener())
+                .addNetworkInterceptor(new ConnectionHeaderInterceptor())
                 .build();
 
             RequestBody body = new FormBody.Builder()

--- a/src/main/java/kr/allcll/backend/domain/user/ToscAuthService.java
+++ b/src/main/java/kr/allcll/backend/domain/user/ToscAuthService.java
@@ -2,6 +2,8 @@ package kr.allcll.backend.domain.user;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
+import kr.allcll.backend.client.ConnectionEventListener;
+import kr.allcll.backend.client.ConnectionHeaderInterceptor;
 import kr.allcll.backend.client.LoginProperties;
 import kr.allcll.backend.domain.user.dto.LoginRequest;
 import kr.allcll.backend.support.exception.AllcllErrorCode;
@@ -23,7 +25,10 @@ public class ToscAuthService {
     private final LoginProperties properties;
 
     public void loginTosc(LoginRequest loginRequest) {
-        OkHttpClient client = new OkHttpClient();
+        OkHttpClient client = new OkHttpClient.Builder()
+            .eventListener(new ConnectionEventListener())
+            .addNetworkInterceptor(new ConnectionHeaderInterceptor())
+            .build();
 
         RequestBody body = new FormBody.Builder()
             .add("email", loginRequest.studentId())


### PR DESCRIPTION
## 작업 내용

- 로그인 HTTP 연결의 baseline 성능 측정을 위한 이벤트 로깅 추가
- `ConnectionEventListener`: 연결 수립(new connection), 획득(acquired), 해제(released) 이벤트 로깅
- `ConnectionHeaderInterceptor`: 서버가 `Connection: close` 헤더를 반환하는 경우 경고 로깅
- `AuthService`, `ToscAuthService`에 리스너/인터셉터 연결 (기존 `new OkHttpClient()` 패턴 유지)

## 고민 지점과 리뷰 포인트

- 기존 코드 동작을 변경하지 않고 로깅만 추가한 것이 맞는지 확인
- 이후 ConnectionPool 공유 적용 시 동일 로깅으로 전후 비교 예정

## 관련 이슈

- TSK-145 HTTP 연결 재사용 성능 개선의 baseline 측정 단계